### PR TITLE
Slice 2: Typed option inference + type tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 !.env.example
 .idea/
 *.tsbuildinfo
+.claude/

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "discord.js": "catalog:",
+        "expect-type": "^1.2.0",
         "typescript": "catalog:",
       },
       "peerDependencies": {
@@ -240,6 +241,8 @@
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 

--- a/examples/minimal/src/index.ts
+++ b/examples/minimal/src/index.ts
@@ -9,6 +9,18 @@ const ping = defineCommand({
 	},
 });
 
+const echo = defineCommand({
+	name: "echo",
+	description: "Echoes a message back",
+	options: {
+		message: { type: "string", description: "What to echo", required: true },
+	},
+	run: async ({ interaction, options }) => {
+		// options.message is statically typed as `string` (required)
+		await interaction.reply(options.message);
+	},
+});
+
 const token = process.env.DISCORD_TOKEN;
 if (!token) {
 	console.error("DISCORD_TOKEN environment variable is required");
@@ -19,7 +31,7 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 createCommandHandler({
 	client,
-	commands: [ping],
+	commands: [ping, echo],
 });
 
 client.once("clientReady", (c) => {

--- a/knip.json
+++ b/knip.json
@@ -1,8 +1,11 @@
 {
 	"$schema": "https://unpkg.com/knip/schema.json",
+	"ignore": [".claude/**"],
 	"workspaces": {
 		".": {},
-		"packages/core": {},
+		"packages/core": {
+			"entry": ["src/index.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"]
+		},
 		"packages/tsconfig": {},
 		"examples/minimal": {}
 	}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
 		"README.md"
 	],
 	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
+		"build": "tsc -p tsconfig.build.json",
+		"dev": "tsc -p tsconfig.build.json --watch",
 		"typecheck": "tsc --noEmit",
 		"test": "bun test"
 	},
@@ -31,6 +31,7 @@
 		"@types/bun": "catalog:",
 		"@types/node": "catalog:",
 		"discord.js": "catalog:",
+		"expect-type": "^1.2.0",
 		"typescript": "catalog:"
 	},
 	"publishConfig": {

--- a/packages/core/src/define-command.test-d.ts
+++ b/packages/core/src/define-command.test-d.ts
@@ -1,0 +1,156 @@
+import type { Attachment, GuildBasedChannel, GuildMember, Role, User } from "discord.js";
+import { expectTypeOf } from "expect-type";
+import { defineCommand } from "./define-command";
+
+// String — required: typed as string
+defineCommand({
+	name: "string-required",
+	description: "test",
+	options: { x: { type: "string", description: "x", required: true } },
+	run: ({ options }) => {
+		expectTypeOf(options.x).toEqualTypeOf<string>();
+	},
+});
+
+// String — optional: typed as string | undefined
+defineCommand({
+	name: "string-optional",
+	description: "test",
+	options: { x: { type: "string", description: "x" } },
+	run: ({ options }) => {
+		expectTypeOf(options.x).toEqualTypeOf<string | undefined>();
+	},
+});
+
+// String — with `as const` choices: narrowed to the union
+defineCommand({
+	name: "string-choices",
+	description: "test",
+	options: {
+		mode: { type: "string", description: "m", choices: ["fast", "slow"] as const, required: true },
+	},
+	run: ({ options }) => {
+		expectTypeOf(options.mode).toEqualTypeOf<"fast" | "slow">();
+	},
+});
+
+// String — choices without required: narrowed but optional
+defineCommand({
+	name: "string-choices-optional",
+	description: "test",
+	options: {
+		mode: { type: "string", description: "m", choices: ["fast", "slow"] as const },
+	},
+	run: ({ options }) => {
+		expectTypeOf(options.mode).toEqualTypeOf<"fast" | "slow" | undefined>();
+	},
+});
+
+// Integer — required and with choices
+defineCommand({
+	name: "integer-required",
+	description: "test",
+	options: { n: { type: "integer", description: "n", required: true } },
+	run: ({ options }) => {
+		expectTypeOf(options.n).toEqualTypeOf<number>();
+	},
+});
+
+defineCommand({
+	name: "integer-choices",
+	description: "test",
+	options: { n: { type: "integer", description: "n", choices: [1, 2, 3] as const, required: true } },
+	run: ({ options }) => {
+		expectTypeOf(options.n).toEqualTypeOf<1 | 2 | 3>();
+	},
+});
+
+// Number, boolean
+defineCommand({
+	name: "number-required",
+	description: "test",
+	options: { n: { type: "number", description: "n", required: true } },
+	run: ({ options }) => {
+		expectTypeOf(options.n).toEqualTypeOf<number>();
+	},
+});
+
+defineCommand({
+	name: "boolean-optional",
+	description: "test",
+	options: { b: { type: "boolean", description: "b" } },
+	run: ({ options }) => {
+		expectTypeOf(options.b).toEqualTypeOf<boolean | undefined>();
+	},
+});
+
+// User, channel, role, mentionable, attachment
+defineCommand({
+	name: "user-required",
+	description: "test",
+	options: { u: { type: "user", description: "u", required: true } },
+	run: ({ options }) => {
+		expectTypeOf(options.u).toEqualTypeOf<User>();
+	},
+});
+
+defineCommand({
+	name: "channel-optional",
+	description: "test",
+	options: { c: { type: "channel", description: "c" } },
+	run: ({ options }) => {
+		expectTypeOf(options.c).toEqualTypeOf<GuildBasedChannel | undefined>();
+	},
+});
+
+defineCommand({
+	name: "role-required",
+	description: "test",
+	options: { r: { type: "role", description: "r", required: true } },
+	run: ({ options }) => {
+		expectTypeOf(options.r).toEqualTypeOf<Role>();
+	},
+});
+
+defineCommand({
+	name: "mentionable-required",
+	description: "test",
+	options: { m: { type: "mentionable", description: "m", required: true } },
+	run: ({ options }) => {
+		expectTypeOf(options.m).toEqualTypeOf<User | GuildMember | Role>();
+	},
+});
+
+defineCommand({
+	name: "attachment-optional",
+	description: "test",
+	options: { a: { type: "attachment", description: "a" } },
+	run: ({ options }) => {
+		expectTypeOf(options.a).toEqualTypeOf<Attachment | undefined>();
+	},
+});
+
+// No options — options is an empty record
+defineCommand({
+	name: "no-options",
+	description: "test",
+	run: ({ options }) => {
+		expectTypeOf(options).toEqualTypeOf<Record<string, never>>();
+	},
+});
+
+// Multiple options — each individually typed
+defineCommand({
+	name: "multi",
+	description: "test",
+	options: {
+		who: { type: "user", description: "who", required: true },
+		why: { type: "string", description: "why" },
+		count: { type: "integer", description: "count", choices: [1, 2, 3] as const },
+	},
+	run: ({ options }) => {
+		expectTypeOf(options.who).toEqualTypeOf<User>();
+		expectTypeOf(options.why).toEqualTypeOf<string | undefined>();
+		expectTypeOf(options.count).toEqualTypeOf<1 | 2 | 3 | undefined>();
+	},
+});

--- a/packages/core/src/define-command.ts
+++ b/packages/core/src/define-command.ts
@@ -1,5 +1,6 @@
+import type { CommandOptions } from "./options";
 import type { Command } from "./types";
 
-export function defineCommand(command: Command): Command {
+export function defineCommand<S extends CommandOptions = Record<string, never>>(command: Command<S>): Command<S> {
 	return command;
 }

--- a/packages/core/src/dispatcher.test.ts
+++ b/packages/core/src/dispatcher.test.ts
@@ -2,11 +2,25 @@ import { expect, mock, test } from "bun:test";
 import type { ChatInputCommandInteraction } from "discord.js";
 import { Dispatcher } from "./dispatcher";
 
-const fakeInteraction = (commandName: string) => ({ commandName }) as unknown as ChatInputCommandInteraction;
+const fakeInteraction = (commandName: string, optionValues: Record<string, unknown> = {}) =>
+	({
+		commandName,
+		options: {
+			getString: (name: string) => optionValues[name] ?? null,
+			getInteger: (name: string) => optionValues[name] ?? null,
+			getNumber: (name: string) => optionValues[name] ?? null,
+			getBoolean: (name: string) => optionValues[name] ?? null,
+			getUser: (name: string) => optionValues[name] ?? null,
+			getChannel: (name: string) => optionValues[name] ?? null,
+			getRole: (name: string) => optionValues[name] ?? null,
+			getMentionable: (name: string) => optionValues[name] ?? null,
+			getAttachment: (name: string) => optionValues[name] ?? null,
+		},
+	}) as unknown as ChatInputCommandInteraction;
 
 test("dispatch invokes the registered command's run handler", async () => {
 	const dispatcher = new Dispatcher();
-	const run = mock(async () => {});
+	const run = mock(async (_ctx: unknown) => {});
 	dispatcher.register({ name: "ping", description: "ping", run });
 
 	await dispatcher.dispatch(fakeInteraction("ping"));
@@ -16,7 +30,7 @@ test("dispatch invokes the registered command's run handler", async () => {
 
 test("dispatch is a no-op when no command matches the interaction's commandName", async () => {
 	const dispatcher = new Dispatcher();
-	const run = mock(async () => {});
+	const run = mock(async (_ctx: unknown) => {});
 	dispatcher.register({ name: "ping", description: "ping", run });
 
 	await dispatcher.dispatch(fakeInteraction("nonexistent"));
@@ -26,8 +40,8 @@ test("dispatch is a no-op when no command matches the interaction's commandName"
 
 test("registering a command with the same name overwrites the previous one", async () => {
 	const dispatcher = new Dispatcher();
-	const first = mock(async () => {});
-	const second = mock(async () => {});
+	const first = mock(async (_ctx: unknown) => {});
+	const second = mock(async (_ctx: unknown) => {});
 	dispatcher.register({ name: "ping", description: "ping", run: first });
 	dispatcher.register({ name: "ping", description: "ping", run: second });
 
@@ -35,4 +49,51 @@ test("registering a command with the same name overwrites the previous one", asy
 
 	expect(first).toHaveBeenCalledTimes(0);
 	expect(second).toHaveBeenCalledTimes(1);
+});
+
+test("dispatch extracts options from the interaction and passes them to run", async () => {
+	const dispatcher = new Dispatcher();
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({
+		name: "echo",
+		description: "echo",
+		options: {
+			message: { type: "string", description: "msg", required: true },
+		},
+		run,
+	});
+
+	await dispatcher.dispatch(fakeInteraction("echo", { message: "hello" }));
+
+	expect(run).toHaveBeenCalledTimes(1);
+	expect(run.mock.calls[0]?.[0]).toMatchObject({ options: { message: "hello" } });
+});
+
+test("dispatch passes undefined for missing optional options", async () => {
+	const dispatcher = new Dispatcher();
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({
+		name: "echo",
+		description: "echo",
+		options: {
+			message: { type: "string", description: "msg" },
+		},
+		run,
+	});
+
+	await dispatcher.dispatch(fakeInteraction("echo"));
+
+	expect(run).toHaveBeenCalledTimes(1);
+	expect(run.mock.calls[0]?.[0]).toMatchObject({ options: { message: undefined } });
+});
+
+test("dispatch passes empty options object when the command declares no schema", async () => {
+	const dispatcher = new Dispatcher();
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({ name: "ping", description: "ping", run });
+
+	await dispatcher.dispatch(fakeInteraction("ping"));
+
+	expect(run).toHaveBeenCalledTimes(1);
+	expect(run.mock.calls[0]?.[0]).toMatchObject({ options: {} });
 });

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -1,16 +1,18 @@
 import type { ChatInputCommandInteraction } from "discord.js";
-import type { Command } from "./types";
+import { extractOptions } from "./options";
+import type { AnyCommand } from "./types";
 
 export class Dispatcher {
-	private readonly commands = new Map<string, Command>();
+	private readonly commands = new Map<string, AnyCommand>();
 
-	register(command: Command): void {
+	register(command: AnyCommand): void {
 		this.commands.set(command.name, command);
 	}
 
 	async dispatch(interaction: ChatInputCommandInteraction): Promise<void> {
 		const command = this.commands.get(interaction.commandName);
 		if (!command) return;
-		await command.run({ interaction });
+		const options = command.options ? extractOptions(interaction, command.options) : {};
+		await command.run({ interaction, options });
 	}
 }

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -1,5 +1,6 @@
-import { type Client, Events, type Interaction } from "discord.js";
+import { type ApplicationCommandDataResolvable, type Client, Events, type Interaction } from "discord.js";
 import { Dispatcher } from "./dispatcher";
+import { buildOptionsData } from "./options";
 import type { CommandHandler, CommandHandlerOptions } from "./types";
 
 export function createCommandHandler(options: CommandHandlerOptions): CommandHandler {
@@ -17,7 +18,11 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 
 	const onReady = (client: Client<true>) => {
 		if (!client.application) return;
-		const data = options.commands.map((c) => ({ name: c.name, description: c.description }));
+		const data = options.commands.map((c) => ({
+			name: c.name,
+			description: c.description,
+			options: buildOptionsData(c.options),
+		})) as unknown as ApplicationCommandDataResolvable[];
 		client.application.commands.set(data).catch((err) => {
 			console.error("[djs-commands] Failed to register application commands:", err);
 		});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,18 @@
 export { defineCommand } from "./define-command";
 export { createCommandHandler } from "./handler";
-export type { Command, CommandHandler, CommandHandlerOptions, CommandRun, CommandRunContext } from "./types";
+export type {
+	AttachmentOption,
+	BooleanOption,
+	ChannelOption,
+	CommandOption,
+	CommandOptions,
+	IntegerOption,
+	MentionableOption,
+	NumberOption,
+	ResolveOption,
+	ResolveOptions,
+	RoleOption,
+	StringOption,
+	UserOption,
+} from "./options";
+export type { AnyCommand, Command, CommandHandler, CommandHandlerOptions, CommandRun, CommandRunContext } from "./types";

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -1,0 +1,167 @@
+import { ApplicationCommandOptionType, type Attachment, type ChatInputCommandInteraction, type GuildBasedChannel, type GuildMember, type Role, type User } from "discord.js";
+
+export type StringOption = {
+	type: "string";
+	description: string;
+	required?: boolean;
+	choices?: readonly string[];
+};
+
+export type IntegerOption = {
+	type: "integer";
+	description: string;
+	required?: boolean;
+	choices?: readonly number[];
+};
+
+export type NumberOption = {
+	type: "number";
+	description: string;
+	required?: boolean;
+};
+
+export type BooleanOption = {
+	type: "boolean";
+	description: string;
+	required?: boolean;
+};
+
+export type UserOption = {
+	type: "user";
+	description: string;
+	required?: boolean;
+};
+
+export type ChannelOption = {
+	type: "channel";
+	description: string;
+	required?: boolean;
+};
+
+export type RoleOption = {
+	type: "role";
+	description: string;
+	required?: boolean;
+};
+
+export type MentionableOption = {
+	type: "mentionable";
+	description: string;
+	required?: boolean;
+};
+
+export type AttachmentOption = {
+	type: "attachment";
+	description: string;
+	required?: boolean;
+};
+
+export type CommandOption = StringOption | IntegerOption | NumberOption | BooleanOption | UserOption | ChannelOption | RoleOption | MentionableOption | AttachmentOption;
+
+export type CommandOptions = Record<string, CommandOption>;
+
+type ResolveValue<O extends CommandOption> = O extends { type: "string"; choices: readonly (infer C extends string)[] }
+	? C
+	: O extends { type: "string" }
+		? string
+		: O extends { type: "integer"; choices: readonly (infer C extends number)[] }
+			? C
+			: O extends { type: "integer" }
+				? number
+				: O extends { type: "number" }
+					? number
+					: O extends { type: "boolean" }
+						? boolean
+						: O extends { type: "user" }
+							? User
+							: O extends { type: "channel" }
+								? GuildBasedChannel
+								: O extends { type: "role" }
+									? Role
+									: O extends { type: "mentionable" }
+										? User | GuildMember | Role
+										: O extends { type: "attachment" }
+											? Attachment
+											: never;
+
+export type ResolveOption<O extends CommandOption> = O extends { required: true } ? ResolveValue<O> : ResolveValue<O> | undefined;
+
+export type ResolveOptions<S extends CommandOptions> = {
+	[K in keyof S]: ResolveOption<S[K]>;
+};
+
+const nullToUndefined = <T>(v: T | null): T | undefined => (v === null ? undefined : v);
+
+export function extractOptions<S extends CommandOptions>(interaction: ChatInputCommandInteraction, schema: S): ResolveOptions<S> {
+	const result: Record<string, unknown> = {};
+	for (const [name, opt] of Object.entries(schema)) {
+		switch (opt.type) {
+			case "string":
+				result[name] = nullToUndefined(interaction.options.getString(name));
+				break;
+			case "integer":
+				result[name] = nullToUndefined(interaction.options.getInteger(name));
+				break;
+			case "number":
+				result[name] = nullToUndefined(interaction.options.getNumber(name));
+				break;
+			case "boolean":
+				result[name] = nullToUndefined(interaction.options.getBoolean(name));
+				break;
+			case "user":
+				result[name] = nullToUndefined(interaction.options.getUser(name));
+				break;
+			case "channel":
+				result[name] = nullToUndefined(interaction.options.getChannel(name));
+				break;
+			case "role":
+				result[name] = nullToUndefined(interaction.options.getRole(name));
+				break;
+			case "mentionable":
+				result[name] = nullToUndefined(interaction.options.getMentionable(name));
+				break;
+			case "attachment":
+				result[name] = nullToUndefined(interaction.options.getAttachment(name));
+				break;
+		}
+	}
+	return result as ResolveOptions<S>;
+}
+
+const OPTION_TYPE_MAP = {
+	string: ApplicationCommandOptionType.String,
+	integer: ApplicationCommandOptionType.Integer,
+	number: ApplicationCommandOptionType.Number,
+	boolean: ApplicationCommandOptionType.Boolean,
+	user: ApplicationCommandOptionType.User,
+	channel: ApplicationCommandOptionType.Channel,
+	role: ApplicationCommandOptionType.Role,
+	mentionable: ApplicationCommandOptionType.Mentionable,
+	attachment: ApplicationCommandOptionType.Attachment,
+} as const;
+
+type DiscordOptionData = {
+	name: string;
+	type: ApplicationCommandOptionType;
+	description: string;
+	required: boolean;
+	choices?: { name: string; value: string | number }[];
+};
+
+function buildOptionData(name: string, opt: CommandOption): DiscordOptionData {
+	const base: DiscordOptionData = {
+		name,
+		type: OPTION_TYPE_MAP[opt.type],
+		description: opt.description,
+		required: opt.required ?? false,
+	};
+	if ((opt.type === "string" || opt.type === "integer") && opt.choices) {
+		base.choices = opt.choices.map((value) => ({ name: String(value), value }));
+	}
+	return base;
+}
+
+export function buildOptionsData(schema: CommandOptions | undefined): DiscordOptionData[] | undefined {
+	if (!schema) return undefined;
+	return Object.entries(schema).map(([name, opt]) => buildOptionData(name, opt));
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,20 +1,26 @@
 import type { ChatInputCommandInteraction, Client } from "discord.js";
+import type { CommandOptions, ResolveOptions } from "./options";
 
-export interface CommandRunContext {
+export interface CommandRunContext<S extends CommandOptions = Record<string, never>> {
 	interaction: ChatInputCommandInteraction;
+	options: ResolveOptions<S>;
 }
 
-export type CommandRun = (ctx: CommandRunContext) => void | Promise<void>;
+export type CommandRun<S extends CommandOptions = Record<string, never>> = (ctx: CommandRunContext<S>) => void | Promise<void>;
 
-export interface Command {
+export interface Command<S extends CommandOptions = Record<string, never>> {
 	name: string;
 	description: string;
-	run: CommandRun;
+	options?: S;
+	run: CommandRun<S>;
 }
+
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous command list erases the schema generic
+export type AnyCommand = Command<any>;
 
 export interface CommandHandlerOptions {
 	client: Client;
-	commands: Command[];
+	commands: AnyCommand[];
 }
 
 export interface CommandHandler {

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test-d.ts"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,9 +2,9 @@
 	"extends": "@djs-commands/tsconfig/library.json",
 	"compilerOptions": {
 		"rootDir": "./src",
-		"outDir": "./dist",
+		"noEmit": true,
 		"types": ["bun"]
 	},
 	"include": ["src/**/*"],
-	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test-d.ts"]
+	"exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

Adds typed option inference to `defineCommand`. Run handlers now receive a fully-typed `options` argument inferred from the option schema — no manual generics, no `interaction.options.getX(...)` boilerplate at command call sites. Resolved option values come back as their rich Discord types (`User`, `GuildBasedChannel`, `Role`, etc.). String/integer `as const` choices narrow to literal unions.

Closes #53.

## What changed

- New `@djs-commands/core` module: `src/options.ts`
  - 9 option types: `string`, `integer`, `number`, `boolean`, `user`, `channel`, `role`, `mentionable`, `attachment`
  - `required` (boolean) and `choices` (`as const` for inference) supported
  - `ResolveOption<O>` and `ResolveOptions<S>` mapped types do the inference
  - `extractOptions(interaction, schema)` runtime extractor (`null` → `undefined` for optional)
  - `buildOptionsData(schema)` translates to discord.js `ApplicationCommand` data
- `Command<S>` is now generic over its option schema; default `S = Record<string, never>`
- `Dispatcher.dispatch` extracts options before invoking `run`
- `Handler.onReady` registers slash commands with their option arrays
- 13 type-level tests in `define-command.test-d.ts` using `expect-type` (covers required/optional, choices narrowing, every option type, no-options case, and a multi-option example)
- 3 new dispatcher unit tests for option extraction (typed value passes through, optional → undefined, no schema → empty object)
- `examples/minimal` adds `/echo message:string` alongside `/ping`
- `packages/core/tsconfig.json` is now typecheck-only (includes `*.test-d.ts`); new `tsconfig.build.json` emits `dist/` and excludes test files
- `expect-type` added as a devDep

## API preview

```ts
const kick = defineCommand({
  name: "kick",
  description: "Kick a member",
  options: {
    user: { type: "user", description: "Who to kick", required: true },
    reason: { type: "string", description: "Why" },
    severity: { type: "string", description: "How bad", choices: ["low", "high"] as const },
  },
  run: async ({ interaction, options }) => {
    // options.user      → User
    // options.reason    → string | undefined
    // options.severity  → "low" | "high" | undefined
    await interaction.reply(`Kicked ${options.user.tag}`);
  },
});
```

## Local verification

```
$ bun run ci
$ biome check         ✓ 22 files
$ tsc (typecheck)     ✓ 3 packages, *.test-d.ts compile-checked
$ knip                ✓ clean
$ bun test            ✓ 6/6 pass
```

## Test plan
- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer skims the type tests in `define-command.test-d.ts` — these lock the public type contract
- [ ] Optional: clone, fill `.env`, run `bun run --cwd examples/minimal dev`, confirm `/echo` works in Discord