### PR TITLE
Slice 3: Validator chain + canRunCommand hook

### DIFF
--- a/examples/minimal/.env.example
+++ b/examples/minimal/.env.example
@@ -1,1 +1,3 @@
 DISCORD_TOKEN=your-bot-token-here
+# Optional: comma-separated Discord user IDs that can run ownerOnly commands
+BOT_OWNERS=

--- a/examples/minimal/src/index.ts
+++ b/examples/minimal/src/index.ts
@@ -21,6 +21,19 @@ const echo = defineCommand({
 	},
 });
 
+// Demonstrates validators: gated by ownerOnly + guildOnly.
+// The framework auto-replies ephemerally with the failure reason if
+// validation fails, so the run handler only sees authorized invocations.
+const shutdown = defineCommand({
+	name: "shutdown",
+	description: "Owner-only command (demo)",
+	ownerOnly: true,
+	guildOnly: true,
+	run: async ({ interaction }) => {
+		await interaction.reply("Pretending to shut down…");
+	},
+});
+
 const token = process.env.DISCORD_TOKEN;
 if (!token) {
 	console.error("DISCORD_TOKEN environment variable is required");
@@ -31,7 +44,12 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 createCommandHandler({
 	client,
-	commands: [ping, echo],
+	commands: [ping, echo, shutdown],
+	// Comma-separated user IDs allowed to run owner-gated commands.
+	botOwners:
+		process.env.BOT_OWNERS?.split(",")
+			.map((id) => id.trim())
+			.filter(Boolean) ?? [],
 });
 
 client.once("clientReady", (c) => {

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://unpkg.com/knip/schema.json",
-	"ignore": [".claude/**"],
 	"workspaces": {
 		".": {},
 		"packages/core": {

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -1,9 +1,25 @@
-import type { ChatInputCommandInteraction } from "discord.js";
+import { type ChatInputCommandInteraction, MessageFlags } from "discord.js";
 import { extractOptions } from "./options";
 import type { AnyCommand } from "./types";
+import { type CanRunCommand, runValidatorChain, type Validator } from "./validators";
+
+interface DispatcherConfig {
+	botOwners: readonly string[];
+	globalValidators: readonly Validator[];
+	canRunCommand?: CanRunCommand;
+}
 
 export class Dispatcher {
 	private readonly commands = new Map<string, AnyCommand>();
+	private readonly config: DispatcherConfig;
+
+	constructor(config: Partial<DispatcherConfig> = {}) {
+		this.config = {
+			botOwners: config.botOwners ?? [],
+			globalValidators: config.globalValidators ?? [],
+			canRunCommand: config.canRunCommand,
+		};
+	}
 
 	register(command: AnyCommand): void {
 		this.commands.set(command.name, command);
@@ -12,6 +28,18 @@ export class Dispatcher {
 	async dispatch(interaction: ChatInputCommandInteraction): Promise<void> {
 		const command = this.commands.get(interaction.commandName);
 		if (!command) return;
+
+		const validation = await runValidatorChain(
+			{ interaction, command, botOwners: this.config.botOwners },
+			{ globalValidators: this.config.globalValidators, canRunCommand: this.config.canRunCommand }
+		);
+
+		if (!validation.ok) {
+			if (interaction.replied || interaction.deferred) return;
+			await interaction.reply({ content: validation.reason, flags: MessageFlags.Ephemeral });
+			return;
+		}
+
 		const options = command.options ? extractOptions(interaction, command.options) : {};
 		await command.run({ interaction, options });
 	}

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -4,7 +4,11 @@ import { buildOptionsData } from "./options";
 import type { CommandHandler, CommandHandlerOptions } from "./types";
 
 export function createCommandHandler(options: CommandHandlerOptions): CommandHandler {
-	const dispatcher = new Dispatcher();
+	const dispatcher = new Dispatcher({
+		botOwners: options.botOwners ?? [],
+		globalValidators: options.validators ?? [],
+		canRunCommand: options.canRunCommand,
+	});
 	for (const command of options.commands) {
 		dispatcher.register(command);
 	}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,4 @@ export type {
 	UserOption,
 } from "./options";
 export type { AnyCommand, Command, CommandHandler, CommandHandlerOptions, CommandRun, CommandRunContext } from "./types";
+export type { CanRunCommand, ValidationResult, Validator, ValidatorContext } from "./validators";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
-import type { ChatInputCommandInteraction, Client } from "discord.js";
+import type { ChatInputCommandInteraction, Client, PermissionsString } from "discord.js";
 import type { CommandOptions, ResolveOptions } from "./options";
+import type { CanRunCommand, Validator } from "./validators";
 
 export interface CommandRunContext<S extends CommandOptions = Record<string, never>> {
 	interaction: ChatInputCommandInteraction;
@@ -13,6 +14,12 @@ export interface Command<S extends CommandOptions = Record<string, never>> {
 	description: string;
 	options?: S;
 	run: CommandRun<S>;
+	ownerOnly?: boolean;
+	guildOnly?: boolean;
+	channels?: readonly string[];
+	permissions?: readonly PermissionsString[];
+	roles?: readonly string[];
+	validators?: readonly Validator[];
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous command list erases the schema generic
@@ -21,6 +28,9 @@ export type AnyCommand = Command<any>;
 export interface CommandHandlerOptions {
 	client: Client;
 	commands: AnyCommand[];
+	botOwners?: readonly string[];
+	validators?: readonly Validator[];
+	canRunCommand?: CanRunCommand;
 }
 
 export interface CommandHandler {

--- a/packages/core/src/validators.test.ts
+++ b/packages/core/src/validators.test.ts
@@ -1,0 +1,284 @@
+import { expect, test } from "bun:test";
+import type { ChatInputCommandInteraction, GuildMember } from "discord.js";
+import type { AnyCommand } from "./types";
+import { runValidatorChain, type Validator } from "./validators";
+
+const fakeMember = (perms: string[] = [], roleIds: string[] = []) =>
+	({
+		permissions: {
+			has: (p: string) => perms.includes(p),
+		},
+		roles: {
+			cache: {
+				has: (id: string) => roleIds.includes(id),
+			},
+		},
+	}) as unknown as GuildMember;
+
+const fakeInteraction = (
+	overrides: Partial<{
+		commandName: string;
+		channelId: string;
+		user: { id: string };
+		guild: object | null;
+		member: GuildMember | null;
+	}> = {}
+) =>
+	({
+		commandName: "test",
+		channelId: "channel-1",
+		user: { id: "user-1" },
+		guild: null,
+		member: null,
+		...overrides,
+	}) as unknown as ChatInputCommandInteraction;
+
+const baseCommand = (overrides: Partial<AnyCommand> = {}): AnyCommand => ({
+	name: "test",
+	description: "test",
+	run: async () => {},
+	...overrides,
+});
+
+// ─── ownerOnly ──────────────────────────────────────────────────────────────
+
+test("ownerOnly: blocks non-owners", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({ user: { id: "regular" } }),
+		command: baseCommand({ ownerOnly: true }),
+		botOwners: ["owner-1"],
+	});
+	expect(result.ok).toBe(false);
+});
+
+test("ownerOnly: passes for owners", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({ user: { id: "owner-1" } }),
+		command: baseCommand({ ownerOnly: true }),
+		botOwners: ["owner-1"],
+	});
+	expect(result.ok).toBe(true);
+});
+
+test("ownerOnly: is a no-op when not set on the command", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction(),
+		command: baseCommand(),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(true);
+});
+
+// ─── guildOnly ──────────────────────────────────────────────────────────────
+
+test("guildOnly: blocks DMs", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({ guild: null }),
+		command: baseCommand({ guildOnly: true }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(false);
+});
+
+test("guildOnly: passes inside a guild", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({ guild: { id: "g1" } }),
+		command: baseCommand({ guildOnly: true }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(true);
+});
+
+// ─── channelOnly ────────────────────────────────────────────────────────────
+
+test("channelOnly: blocks disallowed channel", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({ channelId: "channel-99" }),
+		command: baseCommand({ channels: ["channel-1", "channel-2"] }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(false);
+});
+
+test("channelOnly: passes for allowed channel", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({ channelId: "channel-1" }),
+		command: baseCommand({ channels: ["channel-1"] }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(true);
+});
+
+// ─── permissions ────────────────────────────────────────────────────────────
+
+test("permissions: blocks when missing one of the required perms", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({
+			guild: { id: "g1" },
+			member: fakeMember(["KickMembers"]),
+		}),
+		command: baseCommand({ permissions: ["KickMembers", "BanMembers"] }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(false);
+});
+
+test("permissions: passes when all required perms are present", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({
+			guild: { id: "g1" },
+			member: fakeMember(["KickMembers", "BanMembers"]),
+		}),
+		command: baseCommand({ permissions: ["KickMembers", "BanMembers"] }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(true);
+});
+
+test("permissions: blocks in DM context", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({ guild: null }),
+		command: baseCommand({ permissions: ["KickMembers"] }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(false);
+});
+
+// ─── roles ──────────────────────────────────────────────────────────────────
+
+test("roles: blocks when missing one of the required roles", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({
+			guild: { id: "g1" },
+			member: fakeMember([], ["role-1"]),
+		}),
+		command: baseCommand({ roles: ["role-1", "role-2"] }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(false);
+});
+
+test("roles: passes when all required roles are present", async () => {
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({
+			guild: { id: "g1" },
+			member: fakeMember([], ["role-1", "role-2"]),
+		}),
+		command: baseCommand({ roles: ["role-1", "role-2"] }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(true);
+});
+
+// ─── ordering / short-circuit ───────────────────────────────────────────────
+
+test("chain short-circuits on first failure: built-in failure skips later validators", async () => {
+	let secondCalled = false;
+	const second: Validator = () => {
+		secondCalled = true;
+		return { ok: true };
+	};
+	const result = await runValidatorChain({
+		interaction: fakeInteraction({ guild: null }),
+		command: baseCommand({ guildOnly: true, validators: [second] }),
+		botOwners: [],
+	});
+	expect(result.ok).toBe(false);
+	expect(secondCalled).toBe(false);
+});
+
+// ─── custom validators ──────────────────────────────────────────────────────
+
+test("global validators run after built-ins", async () => {
+	const order: string[] = [];
+	const globalV: Validator = () => {
+		order.push("global");
+		return { ok: true };
+	};
+	const cmdV: Validator = () => {
+		order.push("cmd");
+		return { ok: true };
+	};
+	const result = await runValidatorChain(
+		{
+			interaction: fakeInteraction({ guild: { id: "g1" } }),
+			command: baseCommand({ guildOnly: true, validators: [cmdV] }),
+			botOwners: [],
+		},
+		{ globalValidators: [globalV] }
+	);
+	expect(result.ok).toBe(true);
+	expect(order).toEqual(["global", "cmd"]);
+});
+
+test("a failing custom validator returns its reason", async () => {
+	const failing: Validator = () => ({ ok: false, reason: "custom failure" });
+	const result = await runValidatorChain(
+		{
+			interaction: fakeInteraction(),
+			command: baseCommand(),
+			botOwners: [],
+		},
+		{ globalValidators: [failing] }
+	);
+	expect(result.ok).toBe(false);
+	if (!result.ok) expect(result.reason).toBe("custom failure");
+});
+
+// ─── canRunCommand hook ────────────────────────────────────────────────────
+
+test("canRunCommand: returning false fails with default reason", async () => {
+	const result = await runValidatorChain(
+		{
+			interaction: fakeInteraction(),
+			command: baseCommand(),
+			botOwners: [],
+		},
+		{ canRunCommand: () => false }
+	);
+	expect(result.ok).toBe(false);
+});
+
+test("canRunCommand: returning a string uses it as the reason", async () => {
+	const result = await runValidatorChain(
+		{
+			interaction: fakeInteraction(),
+			command: baseCommand(),
+			botOwners: [],
+		},
+		{ canRunCommand: () => "rate limited" }
+	);
+	expect(result.ok).toBe(false);
+	if (!result.ok) expect(result.reason).toBe("rate limited");
+});
+
+test("canRunCommand: returning true passes", async () => {
+	const result = await runValidatorChain(
+		{
+			interaction: fakeInteraction(),
+			command: baseCommand(),
+			botOwners: [],
+		},
+		{ canRunCommand: () => true }
+	);
+	expect(result.ok).toBe(true);
+});
+
+test("canRunCommand: runs after all other validators", async () => {
+	let hookCalled = false;
+	const result = await runValidatorChain(
+		{
+			interaction: fakeInteraction({ guild: null }),
+			command: baseCommand({ guildOnly: true }),
+			botOwners: [],
+		},
+		{
+			canRunCommand: () => {
+				hookCalled = true;
+				return true;
+			},
+		}
+	);
+	expect(result.ok).toBe(false);
+	expect(hookCalled).toBe(false);
+});

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -1,0 +1,94 @@
+import type { ChatInputCommandInteraction, GuildMember } from "discord.js";
+import type { AnyCommand } from "./types";
+
+export type ValidationResult = { ok: true } | { ok: false; reason: string };
+
+export interface ValidatorContext {
+	interaction: ChatInputCommandInteraction;
+	command: AnyCommand;
+	botOwners: readonly string[];
+}
+
+export type Validator = (ctx: ValidatorContext) => ValidationResult | Promise<ValidationResult>;
+
+export type CanRunCommand = (interaction: ChatInputCommandInteraction) => boolean | string | Promise<boolean | string>;
+
+const ownerOnly: Validator = ({ command, interaction, botOwners }) => {
+	if (!command.ownerOnly) return { ok: true };
+	if (botOwners.includes(interaction.user.id)) return { ok: true };
+	return { ok: false, reason: "This command is restricted to bot owners." };
+};
+
+const guildOnly: Validator = ({ command, interaction }) => {
+	if (!command.guildOnly) return { ok: true };
+	if (interaction.guild) return { ok: true };
+	return { ok: false, reason: "This command can only be used in a server." };
+};
+
+const channelOnly: Validator = ({ command, interaction }) => {
+	const allowed = command.channels;
+	if (!allowed?.length) return { ok: true };
+	if (allowed.includes(interaction.channelId)) return { ok: true };
+	return { ok: false, reason: "This command isn't allowed in this channel." };
+};
+
+const permissions: Validator = ({ command, interaction }) => {
+	const required = command.permissions;
+	if (!required?.length) return { ok: true };
+	if (!interaction.guild) {
+		return { ok: false, reason: "Permission checks require a server context." };
+	}
+	const member = interaction.member as GuildMember | null;
+	if (!member?.permissions || typeof member.permissions === "string") {
+		return { ok: false, reason: "Could not determine your permissions." };
+	}
+	for (const perm of required) {
+		if (!member.permissions.has(perm)) {
+			return { ok: false, reason: `Missing permission: ${perm}` };
+		}
+	}
+	return { ok: true };
+};
+
+const roles: Validator = ({ command, interaction }) => {
+	const required = command.roles;
+	if (!required?.length) return { ok: true };
+	if (!interaction.guild) {
+		return { ok: false, reason: "Role checks require a server context." };
+	}
+	const member = interaction.member as GuildMember | null;
+	if (!member?.roles || !("cache" in member.roles)) {
+		return { ok: false, reason: "Could not determine your roles." };
+	}
+	for (const roleId of required) {
+		if (!member.roles.cache.has(roleId)) {
+			return { ok: false, reason: "You don't have the required role for this command." };
+		}
+	}
+	return { ok: true };
+};
+
+const BUILTIN_VALIDATORS: readonly Validator[] = [ownerOnly, guildOnly, channelOnly, permissions, roles];
+
+interface ValidatorChainOptions {
+	globalValidators?: readonly Validator[];
+	canRunCommand?: CanRunCommand;
+}
+
+export async function runValidatorChain(ctx: ValidatorContext, options: ValidatorChainOptions = {}): Promise<ValidationResult> {
+	const commandValidators = ctx.command.validators ?? [];
+	const allValidators = [...BUILTIN_VALIDATORS, ...(options.globalValidators ?? []), ...commandValidators];
+
+	for (const v of allValidators) {
+		const result = await v(ctx);
+		if (!result.ok) return result;
+	}
+
+	if (options.canRunCommand) {
+		const r = await options.canRunCommand(ctx.interaction);
+		if (r === false) return { ok: false, reason: "You can't run this command right now." };
+		if (typeof r === "string") return { ok: false, reason: r };
+	}
+
+	return { ok: true };
+}


### PR DESCRIPTION
## Summary

A deterministic validator chain that runs before each command's `run` handler. Built-in validators (`ownerOnly`, `guildOnly`, `channelOnly`, `permissions`, `roles`) declared as properties on `defineCommand`. Custom validators registerable globally and per-command. Top-level `canRunCommand` hook for dynamic data-driven gating.

Validation failures auto-reply ephemerally with the reason; the run handler only sees authorized invocations.

Closes #54.

## What changed

- `packages/core/src/validators.ts` — new module
  - 5 built-ins in deterministic order: `ownerOnly` → `guildOnly` → `channelOnly` → `permissions` → `roles`
  - Then global validators → command validators → `canRunCommand` hook
  - Short-circuits on first failure with typed `ValidationResult`
- `Command<S>` extended with: `ownerOnly?`, `guildOnly?`, `channels?`, `permissions?`, `roles?`, `validators?`
- `CommandHandlerOptions` extended with: `botOwners?`, `validators?`, `canRunCommand?`
- `Dispatcher` runs the chain pre-`run`; on failure, `interaction.reply({ flags: MessageFlags.Ephemeral })` with the reason
- `createCommandHandler` wires the validation config into `Dispatcher`
- 19 unit tests covering each built-in (pass + fail paths), DM-context errors, short-circuit semantics, custom validator ordering, and `canRunCommand` boolean/string return shapes
- `examples/minimal` adds `/shutdown` (`ownerOnly` + `guildOnly`); `.env.example` documents `BOT_OWNERS`

## API preview

```ts
const ban = defineCommand({
  name: "ban",
  description: "Ban a user",
  guildOnly: true,
  permissions: ["BanMembers"],
  options: { user: { type: "user", description: "Who", required: true } },
  run: async ({ interaction, options }) => {
    await interaction.guild!.members.ban(options.user);
  },
});

createCommandHandler({
  client,
  commands: [ban],
  botOwners: ["123…"],
  canRunCommand: async (i) => {
    const limited = await rateLimiter.check(i.user.id);
    return limited ? "You are rate-limited." : true;
  },
});
```

## Local verification

```
$ bun run ci
$ biome check                  ✓ 44 files
$ tsc (typecheck)              ✓ 4 packages
$ knip                         ✓ clean
$ bun test                     ✓ 25/25 (6 dispatcher + 19 validators)
```

## Test plan
- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer skims validator order/short-circuit semantics — these define when failure messages are surfaced to users
- [ ] Optional: clone, fill `BOT_OWNERS` in `examples/minimal/.env`, run `bun run --cwd examples/minimal dev`, confirm `/shutdown` rejects non-owners with the ephemeral reason and runs for owners