### PR TITLE
Slice 6: Plugin runtime

### DIFF
--- a/examples/minimal/src/echo-plugin.ts
+++ b/examples/minimal/src/echo-plugin.ts
@@ -1,0 +1,37 @@
+import { defineCommand, type PluginManifest } from "@djs-commands/core";
+
+interface EchoPluginOptions {
+	/** Optional prefix prepended to every echoed message. */
+	prefix?: string;
+}
+
+/**
+ * A tiny demo plugin that contributes a `/echo` command. Demonstrates the
+ * plugin factory pattern: callers invoke `echoPlugin(opts)` and pass the
+ * resulting manifest to `createCommandHandler`.
+ */
+export function echoPlugin(options: EchoPluginOptions = {}): PluginManifest {
+	const prefix = options.prefix ?? "";
+
+	const echo = defineCommand({
+		name: "echo",
+		description: "Echoes a message back",
+		options: {
+			message: { type: "string", description: "What to echo", required: true },
+		},
+		run: async ({ interaction, options: opts }) => {
+			await interaction.reply(`${prefix}${opts.message}`);
+		},
+	});
+
+	return {
+		name: "echo-plugin",
+		commands: [echo],
+		setup: ({ client }) => {
+			console.log(`[echo-plugin] ready (prefix=${JSON.stringify(prefix)}, user=${client.user?.tag ?? "<not logged in>"})`);
+		},
+		teardown: () => {
+			console.log("[echo-plugin] shutting down");
+		},
+	};
+}

--- a/examples/minimal/src/index.ts
+++ b/examples/minimal/src/index.ts
@@ -1,23 +1,12 @@
 import { createCommandHandler, defineCommand } from "@djs-commands/core";
 import { Client, GatewayIntentBits } from "discord.js";
+import { echoPlugin } from "./echo-plugin";
 
 const ping = defineCommand({
 	name: "ping",
 	description: "Replies with pong",
 	run: async ({ interaction }) => {
 		await interaction.reply("pong");
-	},
-});
-
-const echo = defineCommand({
-	name: "echo",
-	description: "Echoes a message back",
-	options: {
-		message: { type: "string", description: "What to echo", required: true },
-	},
-	run: async ({ interaction, options }) => {
-		// options.message is statically typed as `string` (required)
-		await interaction.reply(options.message);
 	},
 });
 
@@ -42,14 +31,20 @@ if (!token) {
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-createCommandHandler({
+const handler = createCommandHandler({
 	client,
-	commands: [ping, echo, shutdown],
+	commands: [ping, shutdown],
+	plugins: [echoPlugin()],
 	// Comma-separated user IDs allowed to run owner-gated commands.
 	botOwners:
 		process.env.BOT_OWNERS?.split(",")
 			.map((id) => id.trim())
 			.filter(Boolean) ?? [],
+});
+
+handler.ready.catch((err) => {
+	console.error("Plugin boot failed:", err);
+	process.exit(1);
 });
 
 client.once("clientReady", (c) => {

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -1,15 +1,21 @@
 import { type ApplicationCommandDataResolvable, type Client, Events, type Interaction } from "discord.js";
 import { Dispatcher } from "./dispatcher";
 import { buildOptionsData } from "./options";
-import type { CommandHandler, CommandHandlerOptions } from "./types";
+import type { AnyCommand, CommandHandler, CommandHandlerOptions } from "./types";
 
 export function createCommandHandler(options: CommandHandlerOptions): CommandHandler {
+	const plugins = options.plugins ?? [];
+	const allCommands: AnyCommand[] = [...options.commands];
+	for (const plugin of plugins) {
+		if (plugin.commands) allCommands.push(...plugin.commands);
+	}
+
 	const dispatcher = new Dispatcher({
 		botOwners: options.botOwners ?? [],
 		globalValidators: options.validators ?? [],
 		canRunCommand: options.canRunCommand,
 	});
-	for (const command of options.commands) {
+	for (const command of allCommands) {
 		dispatcher.register(command);
 	}
 
@@ -22,7 +28,7 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 
 	const onReady = (client: Client<true>) => {
 		if (!client.application) return;
-		const data = options.commands.map((c) => ({
+		const data = allCommands.map((c) => ({
 			name: c.name,
 			description: c.description,
 			options: buildOptionsData(c.options),
@@ -35,10 +41,33 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 	options.client.on(Events.InteractionCreate, onInteraction);
 	options.client.once(Events.ClientReady, onReady);
 
+	const bootPromise = (async () => {
+		for (const plugin of plugins) {
+			if (!plugin.setup) continue;
+			try {
+				await plugin.setup({ client: options.client });
+			} catch (err) {
+				throw new Error(`[djs-commands] Plugin '${plugin.name}' setup failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
+			}
+		}
+	})();
+
 	return {
 		destroy: async () => {
 			options.client.off(Events.InteractionCreate, onInteraction);
 			options.client.off(Events.ClientReady, onReady);
+			// Wait for boot to settle so we don't tear down mid-setup. Boot errors
+			// are surfaced via `ready`; destroy still tears plugins down.
+			await bootPromise.catch(() => {});
+			for (const plugin of plugins) {
+				if (!plugin.teardown) continue;
+				try {
+					await plugin.teardown();
+				} catch (err) {
+					console.error(`[djs-commands] Plugin '${plugin.name}' teardown failed:`, err);
+				}
+			}
 		},
+		ready: bootPromise,
 	};
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,5 +15,6 @@ export type {
 	StringOption,
 	UserOption,
 } from "./options";
+export type { PluginManifest, PluginSetupContext } from "./plugin";
 export type { AnyCommand, Command, CommandHandler, CommandHandlerOptions, CommandRun, CommandRunContext } from "./types";
 export type { CanRunCommand, ValidationResult, Validator, ValidatorContext } from "./validators";

--- a/packages/core/src/plugin.test-d.ts
+++ b/packages/core/src/plugin.test-d.ts
@@ -1,0 +1,60 @@
+import type { Client } from "discord.js";
+import { expectTypeOf } from "expect-type";
+import { defineCommand } from "./define-command";
+import type { PluginManifest, PluginSetupContext } from "./plugin";
+import type { AnyCommand, CommandHandlerOptions } from "./types";
+
+// Plugin manifest only requires `name`; everything else is optional.
+const minimal: PluginManifest = { name: "minimal" };
+expectTypeOf(minimal.name).toEqualTypeOf<string>();
+expectTypeOf(minimal.commands).toEqualTypeOf<AnyCommand[] | undefined>();
+expectTypeOf(minimal.setup).toEqualTypeOf<((ctx: PluginSetupContext) => void | Promise<void>) | undefined>();
+expectTypeOf(minimal.teardown).toEqualTypeOf<(() => void | Promise<void>) | undefined>();
+
+// Setup context exposes `client` and nothing else mandatory.
+const setupCtx: PluginSetupContext = { client: {} as Client };
+expectTypeOf(setupCtx.client).toEqualTypeOf<Client>();
+
+// Async setup/teardown shapes are accepted.
+const asyncPlugin: PluginManifest = {
+	name: "async",
+	setup: async ({ client }) => {
+		expectTypeOf(client).toEqualTypeOf<Client>();
+	},
+	teardown: async () => {},
+};
+expectTypeOf(asyncPlugin.setup).toEqualTypeOf<((ctx: PluginSetupContext) => void | Promise<void>) | undefined>();
+
+// Sync setup/teardown shapes are also accepted.
+const syncPlugin: PluginManifest = {
+	name: "sync",
+	setup: () => {},
+	teardown: () => {},
+};
+expectTypeOf(syncPlugin).toEqualTypeOf<PluginManifest>();
+
+// Plugin commands accept commands defined via `defineCommand`.
+const ping = defineCommand({
+	name: "ping",
+	description: "ping",
+	run: () => {},
+});
+const pluginWithCommands: PluginManifest = {
+	name: "with-commands",
+	commands: [ping],
+};
+expectTypeOf(pluginWithCommands.commands).toEqualTypeOf<AnyCommand[] | undefined>();
+
+// `plugins` is an optional array on CommandHandlerOptions.
+expectTypeOf<CommandHandlerOptions["plugins"]>().toEqualTypeOf<PluginManifest[] | undefined>();
+
+// Factory pattern: a function returning a manifest is the recommended shape.
+type PluginFactory<O = void> = (options?: O) => PluginManifest;
+const factory: PluginFactory<{ greeting: string }> = (opts) => ({
+	name: "greeter",
+	setup: ({ client }) => {
+		void client;
+		void opts;
+	},
+});
+expectTypeOf(factory({ greeting: "hi" })).toEqualTypeOf<PluginManifest>();

--- a/packages/core/src/plugin.test.ts
+++ b/packages/core/src/plugin.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { ChatInputCommandInteraction, Client } from "discord.js";
+import { Events } from "discord.js";
+import { createCommandHandler } from "./handler";
+import type { PluginManifest } from "./plugin";
+import type { AnyCommand } from "./types";
+
+const fakeChatInteraction = (commandName: string, optionValues: Record<string, unknown> = {}) =>
+	({
+		isChatInputCommand: () => true,
+		commandName,
+		options: {
+			getString: (name: string) => optionValues[name] ?? null,
+			getInteger: (name: string) => optionValues[name] ?? null,
+			getNumber: (name: string) => optionValues[name] ?? null,
+			getBoolean: (name: string) => optionValues[name] ?? null,
+			getUser: (name: string) => optionValues[name] ?? null,
+			getChannel: (name: string) => optionValues[name] ?? null,
+			getRole: (name: string) => optionValues[name] ?? null,
+			getMentionable: (name: string) => optionValues[name] ?? null,
+			getAttachment: (name: string) => optionValues[name] ?? null,
+		},
+	}) as unknown as ChatInputCommandInteraction;
+
+// Minimal client stub: extends EventEmitter so on/once/off/emit work, plus a
+// stubbed `application.commands.set` so the ClientReady handler can run.
+const makeClient = () => {
+	const emitter = new EventEmitter();
+	const setMock = mock(async (_data: unknown) => {});
+	const client = emitter as unknown as Client & { application: { commands: { set: typeof setMock } } };
+	(client as unknown as { application: { commands: { set: typeof setMock } } }).application = {
+		commands: { set: setMock },
+	};
+	return { client, setMock };
+};
+
+let consoleErrorSpy: ReturnType<typeof spyOn> | undefined;
+beforeEach(() => {
+	consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+	consoleErrorSpy?.mockRestore();
+});
+
+describe("plugin runtime", () => {
+	test("setup hooks run in registration order", async () => {
+		const { client } = makeClient();
+		const order: string[] = [];
+
+		const pluginA: PluginManifest = {
+			name: "a",
+			setup: async () => {
+				order.push("a-start");
+				await Promise.resolve();
+				order.push("a-end");
+			},
+		};
+		const pluginB: PluginManifest = {
+			name: "b",
+			setup: async () => {
+				order.push("b-start");
+				await Promise.resolve();
+				order.push("b-end");
+			},
+		};
+
+		const handler = createCommandHandler({ client, commands: [], plugins: [pluginA, pluginB] });
+		await handler.ready;
+		await handler.destroy();
+
+		expect(order).toEqual(["a-start", "a-end", "b-start", "b-end"]);
+	});
+
+	test("setup hook receives a context with the client", async () => {
+		const { client } = makeClient();
+		const setup = mock(async (_ctx: { client: Client }) => {});
+		const plugin: PluginManifest = { name: "ctx", setup };
+
+		const handler = createCommandHandler({ client, commands: [], plugins: [plugin] });
+		await handler.ready;
+		await handler.destroy();
+
+		expect(setup).toHaveBeenCalledTimes(1);
+		expect(setup.mock.calls[0]?.[0]?.client).toBe(client);
+	});
+
+	test("setup failure aborts boot and re-throws with the plugin name", async () => {
+		const { client } = makeClient();
+		const failing: PluginManifest = {
+			name: "broken",
+			setup: () => {
+				throw new Error("kaboom");
+			},
+		};
+		const after = mock(async () => {});
+		const afterPlugin: PluginManifest = { name: "after", setup: after };
+
+		const handler = createCommandHandler({ client, commands: [], plugins: [failing, afterPlugin] });
+
+		await expect(handler.ready).rejects.toThrow(/Plugin 'broken' setup failed: kaboom/);
+		expect(after).toHaveBeenCalledTimes(0);
+
+		await handler.destroy();
+	});
+
+	test("teardown errors are logged but do not block other teardowns", async () => {
+		const { client } = makeClient();
+		const teardownA = mock(async () => {});
+		const teardownC = mock(async () => {});
+		const plugins: PluginManifest[] = [
+			{ name: "a", teardown: teardownA },
+			{
+				name: "b-fails",
+				teardown: () => {
+					throw new Error("boom");
+				},
+			},
+			{ name: "c", teardown: teardownC },
+		];
+
+		const handler = createCommandHandler({ client, commands: [], plugins });
+		await handler.ready;
+		await handler.destroy();
+
+		expect(teardownA).toHaveBeenCalledTimes(1);
+		expect(teardownC).toHaveBeenCalledTimes(1);
+		expect(consoleErrorSpy).toHaveBeenCalledWith("[djs-commands] Plugin 'b-fails' teardown failed:", expect.any(Error));
+	});
+
+	test("teardown runs in registration order", async () => {
+		const { client } = makeClient();
+		const order: string[] = [];
+		const plugins: PluginManifest[] = [
+			{
+				name: "a",
+				teardown: async () => {
+					order.push("a");
+				},
+			},
+			{
+				name: "b",
+				teardown: async () => {
+					order.push("b");
+				},
+			},
+		];
+
+		const handler = createCommandHandler({ client, commands: [], plugins });
+		await handler.ready;
+		await handler.destroy();
+
+		expect(order).toEqual(["a", "b"]);
+	});
+
+	test("plugin commands dispatch correctly", async () => {
+		const { client } = makeClient();
+		const run = mock(async (_ctx: unknown) => {});
+		const pluginCommand: AnyCommand = {
+			name: "from-plugin",
+			description: "test",
+			run,
+		};
+		const plugin: PluginManifest = { name: "demo", commands: [pluginCommand] };
+
+		const handler = createCommandHandler({ client, commands: [], plugins: [plugin] });
+		await handler.ready;
+
+		client.emit(Events.InteractionCreate, fakeChatInteraction("from-plugin"));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(run).toHaveBeenCalledTimes(1);
+
+		await handler.destroy();
+	});
+
+	test("plugin commands are included in slash command registration on ClientReady", async () => {
+		const { client, setMock } = makeClient();
+		const pluginCommand: AnyCommand = {
+			name: "from-plugin",
+			description: "registered",
+			run: () => {},
+		};
+		const baseCommand: AnyCommand = {
+			name: "from-base",
+			description: "base",
+			run: () => {},
+		};
+
+		const handler = createCommandHandler({
+			client,
+			commands: [baseCommand],
+			plugins: [{ name: "demo", commands: [pluginCommand] }],
+		});
+		await handler.ready;
+
+		client.emit(Events.ClientReady, client as unknown as Client<true>);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(setMock).toHaveBeenCalledTimes(1);
+		const data = setMock.mock.calls[0]?.[0] as { name: string }[];
+		expect(data.map((c) => c.name)).toEqual(["from-base", "from-plugin"]);
+
+		await handler.destroy();
+	});
+
+	test("handler with no plugins still works", async () => {
+		const { client } = makeClient();
+		const handler = createCommandHandler({ client, commands: [] });
+		await handler.ready;
+		await handler.destroy();
+	});
+});

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,0 +1,28 @@
+import type { Client } from "discord.js";
+import type { AnyCommand } from "./types";
+
+/**
+ * Context passed to a plugin's `setup` hook. Kept intentionally small —
+ * plugins that need richer state should attach it to `client` or close
+ * over their own values.
+ */
+export interface PluginSetupContext {
+	client: Client;
+}
+
+/**
+ * Manifest returned by a plugin factory. Registered on `createCommandHandler`
+ * via the `plugins` option.
+ */
+export interface PluginManifest {
+	/** Human-readable identifier; used in error messages and lifecycle ordering. */
+	name: string;
+	/** Commands merged into the handler's dispatcher at boot. */
+	commands?: AnyCommand[];
+	/** Awaited at boot in registration order. Throwing aborts handler boot. */
+	setup?: (ctx: PluginSetupContext) => void | Promise<void>;
+	/** Awaited on `handler.destroy()`. Errors are logged but do not block other teardowns. */
+	teardown?: () => void | Promise<void>;
+	// validators?: Validator[]; // pending #54
+	// events?: EventHandler[]; // pending future event-handler slice
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
 import type { ChatInputCommandInteraction, Client, PermissionsString } from "discord.js";
 import type { CommandOptions, ResolveOptions } from "./options";
+import type { PluginManifest } from "./plugin";
 import type { CanRunCommand, Validator } from "./validators";
 
 export interface CommandRunContext<S extends CommandOptions = Record<string, never>> {
@@ -31,8 +32,11 @@ export interface CommandHandlerOptions {
 	botOwners?: readonly string[];
 	validators?: readonly Validator[];
 	canRunCommand?: CanRunCommand;
+	plugins?: PluginManifest[];
 }
 
 export interface CommandHandler {
+	/** Resolves once all plugin `setup` hooks have completed; rejects if any plugin's setup throws. */
+	ready: Promise<void>;
 	destroy: () => Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Adds a `PluginManifest` type and wires plugin lifecycle into `createCommandHandler`. Plugins are factory functions returning a manifest with `name`, optional `commands`, `setup`, and `teardown` hooks; users register them via `plugins: [pluginA(opts), pluginB()]`.
- At boot, plugin commands are merged into the dispatcher and into the `ClientReady` slash registration; `setup` hooks are awaited in registration order via the new `handler.ready` promise, and a failure aborts boot with the offending plugin's name in the error message.
- At destroy, `teardown` hooks run in registration order; errors are caught and logged via `console.error("[djs-commands] Plugin '<name>' teardown failed:", err)` so one bad teardown can't block others.
- Demo plugin lives at `examples/minimal/src/echo-plugin.ts`; `examples/minimal/src/index.ts` now consumes it via `plugins: [echoPlugin()]` while keeping `/ping` as a top-level command — `/echo` demonstrates the plugin pattern.

`validators` and `events` are intentionally not on the manifest yet — code comments in `plugin.ts` mark the extension points pending #54 and the future event-handler slice.

## Acceptance criteria

- [x] `PluginManifest` type exported from `@djs-commands/core`
- [x] `createCommandHandler` accepts `plugins?: PluginManifest[]`
- [x] At boot: plugin commands merged into the dispatcher's registry alongside `options.commands`
- [x] At boot: `setup` hooks awaited in registration order; throwing aborts boot via `handler.ready` (re-thrown with the plugin name in the message)
- [x] At destroy: `teardown` hooks awaited in registration order; errors are logged but do not block other teardowns
- [x] Slash command registration on `ClientReady` includes plugin commands
- [x] Type tests in `packages/core/src/plugin.test-d.ts` lock the manifest shape and lifecycle hook signatures
- [x] Unit tests in `packages/core/src/plugin.test.ts` cover setup ordering, setup failure aborts boot, teardown errors don't block other teardowns, plugin commands dispatch correctly
- [x] Demo `echoPlugin` in `examples/minimal` consumed via `plugins: [echoPlugin()]`; `/ping` still works
- [x] `bun run ci` green locally after wiping `apps/docs/.source`

## Local verification

```
$ rm -rf apps/docs/.source && bun run ci
... biome check (46 files clean)
... turbo typecheck (4/4 successful, includes plugin.test-d.ts)
... knip (no unused exports)
... turbo test
  src/dispatcher.test.ts: 6 pass
  src/plugin.test.ts:     8 pass
  14 pass / 0 fail / 22 expect() calls
```

## Notes / API additions

- New public types: `PluginManifest`, `PluginSetupContext`.
- `CommandHandler` now exposes a `ready: Promise<void>` so callers can `await handler.ready` (and surface boot failures) before `client.login()`.
- `dispatcher.ts` was not refactored; plugin commands flow through the existing `register(command)` path so slice #54's validator chain has a clean lane to land in.

## Test plan

- [ ] Land on top of `main` and confirm `bun run ci` is still green from a fresh clone.
- [ ] Smoke test: run `examples/minimal` against a real bot token; verify `/ping` and `/echo` register, `/echo` replies, and the `[echo-plugin] ready` log fires once.
- [ ] Manually break `echoPlugin` setup (throw inside `setup`) and confirm the example exits with `Plugin 'echo-plugin' setup failed: …`.
- [ ] Confirm `handler.destroy()` from a SIGINT handler runs `[echo-plugin] shutting down`.