### PR TITLE
Slice 4: Cooldown engine

### DIFF
--- a/examples/minimal/src/index.ts
+++ b/examples/minimal/src/index.ts
@@ -5,6 +5,7 @@ import { echoPlugin } from "./echo-plugin";
 const ping = defineCommand({
 	name: "ping",
 	description: "Replies with pong",
+	cooldown: { type: "perUser", duration: 5_000 },
 	run: async ({ interaction }) => {
 		await interaction.reply("pong");
 	},

--- a/packages/core/src/cooldowns.test.ts
+++ b/packages/core/src/cooldowns.test.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "bun:test";
+import type { ChatInputCommandInteraction } from "discord.js";
+import { type CacheAdapter, CooldownEngine } from "./cooldowns";
+import type { AnyCommand } from "./types";
+
+const fakeInteraction = (userId = "user-1", guildId: string | null = "guild-1") =>
+	({
+		user: { id: userId },
+		guildId,
+	}) as unknown as ChatInputCommandInteraction;
+
+const cmd = (overrides: Partial<AnyCommand> = {}): AnyCommand => ({
+	name: "test",
+	description: "test",
+	run: async () => {},
+	...overrides,
+});
+
+test("check returns null when the command has no cooldown configured", async () => {
+	const engine = new CooldownEngine();
+	const result = await engine.check(cmd(), fakeInteraction());
+	expect(result).toBeNull();
+});
+
+test("check returns null before start is called", async () => {
+	const engine = new CooldownEngine();
+	const c = cmd({ cooldown: { type: "perUser", duration: 1000 } });
+	const result = await engine.check(c, fakeInteraction());
+	expect(result).toBeNull();
+});
+
+test("check returns the remaining ms while inside the cooldown window", async () => {
+	const engine = new CooldownEngine();
+	const c = cmd({ cooldown: { type: "perUser", duration: 5_000 } });
+	await engine.start(c, fakeInteraction());
+	const result = await engine.check(c, fakeInteraction());
+	expect(result).not.toBeNull();
+	expect(result).toBeGreaterThan(0);
+	expect(result).toBeLessThanOrEqual(5_000);
+});
+
+test("check returns null after the cooldown expires", async () => {
+	const engine = new CooldownEngine();
+	const c = cmd({ cooldown: { type: "perUser", duration: 1 } });
+	await engine.start(c, fakeInteraction());
+	await new Promise((r) => setTimeout(r, 5));
+	const result = await engine.check(c, fakeInteraction());
+	expect(result).toBeNull();
+});
+
+test("perUser: starting cooldown for one user does not block another user", async () => {
+	const engine = new CooldownEngine();
+	const c = cmd({ cooldown: { type: "perUser", duration: 5_000 } });
+	await engine.start(c, fakeInteraction("alice"));
+	const aliceBlocked = await engine.check(c, fakeInteraction("alice"));
+	const bobBlocked = await engine.check(c, fakeInteraction("bob"));
+	expect(aliceBlocked).not.toBeNull();
+	expect(bobBlocked).toBeNull();
+});
+
+test("perGuild: blocks every user in the same guild", async () => {
+	const engine = new CooldownEngine();
+	const c = cmd({ cooldown: { type: "perGuild", duration: 5_000 } });
+	await engine.start(c, fakeInteraction("alice", "guild-A"));
+	const sameGuildOther = await engine.check(c, fakeInteraction("bob", "guild-A"));
+	const otherGuild = await engine.check(c, fakeInteraction("alice", "guild-B"));
+	expect(sameGuildOther).not.toBeNull();
+	expect(otherGuild).toBeNull();
+});
+
+test("perUserPerGuild: blocks user X in guild A but not user X in guild B", async () => {
+	const engine = new CooldownEngine();
+	const c = cmd({ cooldown: { type: "perUserPerGuild", duration: 5_000 } });
+	await engine.start(c, fakeInteraction("alice", "guild-A"));
+	const sameUserSameGuild = await engine.check(c, fakeInteraction("alice", "guild-A"));
+	const sameUserOtherGuild = await engine.check(c, fakeInteraction("alice", "guild-B"));
+	const otherUserSameGuild = await engine.check(c, fakeInteraction("bob", "guild-A"));
+	expect(sameUserSameGuild).not.toBeNull();
+	expect(sameUserOtherGuild).toBeNull();
+	expect(otherUserSameGuild).toBeNull();
+});
+
+test("global: blocks every user across all guilds", async () => {
+	const engine = new CooldownEngine();
+	const c = cmd({ cooldown: { type: "global", duration: 5_000 } });
+	await engine.start(c, fakeInteraction("alice", "guild-A"));
+	const sameUserSameGuild = await engine.check(c, fakeInteraction("alice", "guild-A"));
+	const otherUserOtherGuild = await engine.check(c, fakeInteraction("bob", "guild-B"));
+	expect(sameUserSameGuild).not.toBeNull();
+	expect(otherUserOtherGuild).not.toBeNull();
+});
+
+test("CacheAdapter: when provided, in-memory map is bypassed", async () => {
+	const store = new Map<string, number>();
+	let getCalls = 0;
+	let setCalls = 0;
+	const adapter: CacheAdapter = {
+		get: async (k) => {
+			getCalls++;
+			return store.get(k) ?? null;
+		},
+		set: async (k, expiresAt) => {
+			setCalls++;
+			store.set(k, expiresAt);
+		},
+		delete: async (k) => {
+			store.delete(k);
+		},
+	};
+
+	const engine = new CooldownEngine(adapter);
+	const c = cmd({ cooldown: { type: "perUser", duration: 5_000 } });
+	await engine.start(c, fakeInteraction());
+	const remaining = await engine.check(c, fakeInteraction());
+
+	expect(setCalls).toBe(1);
+	expect(getCalls).toBe(1);
+	expect(remaining).not.toBeNull();
+});
+
+test("start is a no-op when the command has no cooldown configured", async () => {
+	const engine = new CooldownEngine();
+	await engine.start(cmd(), fakeInteraction());
+	const result = await engine.check(cmd(), fakeInteraction());
+	expect(result).toBeNull();
+});

--- a/packages/core/src/cooldowns.ts
+++ b/packages/core/src/cooldowns.ts
@@ -1,0 +1,92 @@
+import type { ChatInputCommandInteraction } from "discord.js";
+import type { AnyCommand } from "./types";
+
+export type CooldownType = "perUser" | "perGuild" | "perUserPerGuild" | "global";
+
+export interface CooldownConfig {
+	type: CooldownType;
+	/** Duration in milliseconds */
+	duration: number;
+}
+
+/**
+ * TTL-native cache contract for distributed cooldowns. Implement against any
+ * KV store (Redis, Memcached) — `expiresAt` is a millisecond UNIX timestamp,
+ * `ttlMs` is the hint for stores that take TTL directly (e.g. Redis SETEX).
+ */
+export interface CacheAdapter {
+	/** Returns the absolute expiry timestamp (ms), or null if missing/expired. */
+	get(key: string): Promise<number | null>;
+	set(key: string, expiresAt: number, ttlMs: number): Promise<void>;
+	delete(key: string): Promise<void>;
+}
+
+export class CooldownEngine {
+	private readonly memory = new Map<string, number>();
+	private readonly cache?: CacheAdapter;
+
+	constructor(cache?: CacheAdapter) {
+		this.cache = cache;
+	}
+
+	/**
+	 * Returns the remaining cooldown in ms if the command is on cooldown for this
+	 * interaction's actor; null otherwise (no cooldown configured, never started,
+	 * or already expired).
+	 */
+	async check(command: AnyCommand, interaction: ChatInputCommandInteraction): Promise<number | null> {
+		if (!command.cooldown) return null;
+		const key = makeKey(command, interaction);
+		const expiresAt = await this.read(key);
+		if (expiresAt === null) return null;
+		const now = Date.now();
+		if (expiresAt > now) return expiresAt - now;
+		await this.deleteKey(key);
+		return null;
+	}
+
+	async start(command: AnyCommand, interaction: ChatInputCommandInteraction): Promise<void> {
+		if (!command.cooldown) return;
+		const key = makeKey(command, interaction);
+		const expiresAt = Date.now() + command.cooldown.duration;
+		await this.write(key, expiresAt, command.cooldown.duration);
+	}
+
+	private async read(key: string): Promise<number | null> {
+		if (this.cache) return this.cache.get(key);
+		return this.memory.get(key) ?? null;
+	}
+
+	private async write(key: string, expiresAt: number, ttlMs: number): Promise<void> {
+		if (this.cache) {
+			await this.cache.set(key, expiresAt, ttlMs);
+			return;
+		}
+		this.memory.set(key, expiresAt);
+	}
+
+	private async deleteKey(key: string): Promise<void> {
+		if (this.cache) {
+			await this.cache.delete(key);
+			return;
+		}
+		this.memory.delete(key);
+	}
+}
+
+function makeKey(command: AnyCommand, interaction: ChatInputCommandInteraction): string {
+	const cooldown = command.cooldown;
+	if (!cooldown) throw new Error("makeKey called on a command without a cooldown");
+	const userId = interaction.user.id;
+	const guildId = interaction.guildId ?? "dm";
+	switch (cooldown.type) {
+		case "perUser":
+			return `cd:${command.name}:user:${userId}`;
+		case "perGuild":
+			return `cd:${command.name}:guild:${guildId}`;
+		case "perUserPerGuild":
+			return `cd:${command.name}:user:${userId}:guild:${guildId}`;
+		case "global":
+			return `cd:${command.name}:global`;
+	}
+}

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -1,4 +1,5 @@
 import { type ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { type CacheAdapter, CooldownEngine } from "./cooldowns";
 import { extractOptions } from "./options";
 import type { AnyCommand } from "./types";
 import { type CanRunCommand, runValidatorChain, type Validator } from "./validators";
@@ -7,18 +8,22 @@ interface DispatcherConfig {
 	botOwners: readonly string[];
 	globalValidators: readonly Validator[];
 	canRunCommand?: CanRunCommand;
+	cacheAdapter?: CacheAdapter;
 }
 
 export class Dispatcher {
 	private readonly commands = new Map<string, AnyCommand>();
 	private readonly config: DispatcherConfig;
+	private readonly cooldowns: CooldownEngine;
 
 	constructor(config: Partial<DispatcherConfig> = {}) {
 		this.config = {
 			botOwners: config.botOwners ?? [],
 			globalValidators: config.globalValidators ?? [],
 			canRunCommand: config.canRunCommand,
+			cacheAdapter: config.cacheAdapter,
 		};
+		this.cooldowns = new CooldownEngine(this.config.cacheAdapter);
 	}
 
 	register(command: AnyCommand): void {
@@ -39,6 +44,18 @@ export class Dispatcher {
 			await interaction.reply({ content: validation.reason, flags: MessageFlags.Ephemeral });
 			return;
 		}
+
+		const remaining = await this.cooldowns.check(command, interaction);
+		if (remaining !== null) {
+			if (interaction.replied || interaction.deferred) return;
+			await interaction.reply({
+				content: `On cooldown — try again in ${(remaining / 1000).toFixed(1)}s.`,
+				flags: MessageFlags.Ephemeral,
+			});
+			return;
+		}
+
+		await this.cooldowns.start(command, interaction);
 
 		const options = command.options ? extractOptions(interaction, command.options) : {};
 		await command.run({ interaction, options });

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -14,6 +14,7 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		botOwners: options.botOwners ?? [],
 		globalValidators: options.validators ?? [],
 		canRunCommand: options.canRunCommand,
+		cacheAdapter: options.cacheAdapter,
 	});
 	for (const command of allCommands) {
 		dispatcher.register(command);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export type { CacheAdapter, CooldownConfig, CooldownType } from "./cooldowns";
 export { defineCommand } from "./define-command";
 export { createCommandHandler } from "./handler";
 export type {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,5 @@
 import type { ChatInputCommandInteraction, Client, PermissionsString } from "discord.js";
+import type { CacheAdapter, CooldownConfig } from "./cooldowns";
 import type { CommandOptions, ResolveOptions } from "./options";
 import type { PluginManifest } from "./plugin";
 import type { CanRunCommand, Validator } from "./validators";
@@ -21,6 +22,7 @@ export interface Command<S extends CommandOptions = Record<string, never>> {
 	permissions?: readonly PermissionsString[];
 	roles?: readonly string[];
 	validators?: readonly Validator[];
+	cooldown?: CooldownConfig;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous command list erases the schema generic
@@ -33,6 +35,7 @@ export interface CommandHandlerOptions {
 	validators?: readonly Validator[];
 	canRunCommand?: CanRunCommand;
 	plugins?: PluginManifest[];
+	cacheAdapter?: CacheAdapter;
 }
 
 export interface CommandHandler {


### PR DESCRIPTION
## Summary

Per-command cooldowns with 4 types (`perUser`, `perGuild`, `perUserPerGuild`, `global`) declared as one property on `defineCommand`. Default backend is an in-memory Map — zero config. For sharded bots, callers pass a `CacheAdapter` (TTL-native `get`/`set`/`delete`) and the engine delegates to it. `@djs-commands/adapter-redis` (#63) will be the first official implementation.

Closes #55.

## What changed

- **`packages/core/src/cooldowns.ts`** — new module
  - `CooldownEngine.check()` returns remaining ms or `null`
  - `CooldownEngine.start()` arms the cooldown
  - `CacheAdapter` interface with TTL-native semantics
  - 4 cooldown types with deterministic key shapes
- **`Command<S>`** extended with `cooldown?: { type, duration }` (duration in ms)
- **`CommandHandlerOptions`** extended with `cacheAdapter?: CacheAdapter`
- **`Dispatcher`** flow: validators → cooldown check → arm cooldown → run
  - Cooldown is armed **before** run, so a failing handler still incurs cooldown (intentional — prevents rapid-retry spam on flaky commands)
  - Cooldown failure replies ephemerally with remaining time formatted as `s.s seconds`
- **10 unit tests**: each type's key isolation, expiry, `CacheAdapter` delegation (verifies memory map is bypassed), no-cooldown no-op
- **`examples/minimal`**: `/ping` demos a 5s `perUser` cooldown

## API preview

```ts
const ban = defineCommand({
  name: "ban",
  description: "Ban a user",
  cooldown: { type: "perUser", duration: 30_000 },
  // ...
});

createCommandHandler({
  client,
  commands: [ban],
  cacheAdapter: redisCacheAdapter(redis), // optional, falls back to in-memory
});
```

## Local verification

```
$ bun run ci
$ biome check                  ✓ 50 files
$ tsc (typecheck)              ✓ 4 packages
$ knip                         ✓ clean
$ bun test                     ✓ 43/43 (6 dispatcher + 19 validators + 8 plugins + 10 cooldowns)
```

## Test plan
- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer skims the cooldown-armed-before-run decision — locks behavior for failed runs
- [ ] Optional: clone, run `bun run --cwd examples/minimal dev`, run `/ping` twice within 5s, confirm second invocation is rejected ephemerally

## Future
- `@djs-commands/adapter-redis` lands in #63 — implements `CacheAdapter` against ioredis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command cooldown system supporting multiple scoping options (per-user, per-guild, per-user-per-guild, and global).
  * Cooldowns now automatically check during command dispatch and reply with remaining time if active.
  * Optional distributed cache support for cooldown persistence across instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->