### PR TITLE
Slice 13: @djs-commands/jsx — Components V2

### DIFF
--- a/apps/docs/content/pages/components-v2/index.mdx
+++ b/apps/docs/content/pages/components-v2/index.mdx
@@ -1,19 +1,208 @@
 ---
 title: Components V2
-description: JSX-first builders and a function-call fallback for Discord's new component model.
+description: JSX runtime and a function-call fallback for Discord's new component model.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
-<Callout type="warn">
-**Coming with [Slice #61 — Components V2](https://github.com/D3OXY/djs-commands/issues/61).** This section is currently a placeholder.
+Discord's [Components V2](https://discord.com/developers/docs/components/reference) message format replaces the
+old "embed + button rows" pattern with composable layout primitives — Containers, Sections, Text Displays,
+Media Galleries, Separators, Files, and Action Rows of Buttons.
+
+`djs-commands` ships **two ways** to build them. Pick whichever fits your project:
+
+- **`@djs-commands/jsx`** — write components as JSX, like React. Best DX if your toolchain (TS, Bun, ESBuild,
+  SWC) already supports JSX.
+- **Function fallback from `@djs-commands/core`** — the same builders, exposed as plain functions. No JSX
+  pragma, no extra dependency.
+
+Both produce real `discord.js` builder objects, so you can mix the two freely.
+
+## Quick start (JSX)
+
+```bash
+bun add @djs-commands/jsx
+```
+
+Configure TypeScript to use the runtime:
+
+```json title="tsconfig.json"
+{
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "jsxImportSource": "@djs-commands/jsx"
+    }
+}
+```
+
+That's it — no Babel, no SWC. Bun's transpiler and TypeScript both honor `jsxImportSource` directly.
+
+```tsx title="src/welcome.tsx"
+import { defineCommand } from "@djs-commands/core";
+import { Button, Container, Section, TextDisplay, render } from "@djs-commands/jsx";
+import { MessageFlags } from "discord.js";
+
+export const welcome = defineCommand({
+    name: "welcome",
+    description: "Show a Components V2 welcome card",
+    run: async ({ interaction }) => {
+        await interaction.reply({
+            flags: MessageFlags.IsComponentsV2,
+            components: render(
+                <Container accentColor={0x5865f2}>
+                    <TextDisplay># Welcome</TextDisplay>
+                    <Section accessory={<Button style="primary" customId="welcome:next" label="Next" />}>
+                        Components V2 lets you compose rich messages from layout primitives.
+                    </Section>
+                </Container>
+            ),
+        });
+    },
+});
+```
+
+## Quick start (function fallback)
+
+If you can't (or won't) enable JSX, every component has a function-form sibling re-exported from
+`@djs-commands/core`. They return the same `discord.js` builders.
+
+```ts title="src/welcome.ts"
+import { button, container, defineCommand, section, textDisplay } from "@djs-commands/core";
+import { MessageFlags } from "discord.js";
+
+export const welcome = defineCommand({
+    name: "welcome",
+    description: "Show a Components V2 welcome card",
+    run: async ({ interaction }) => {
+        await interaction.reply({
+            flags: MessageFlags.IsComponentsV2,
+            components: [
+                container({
+                    accentColor: 0x5865f2,
+                    children: [
+                        textDisplay("# Welcome"),
+                        section({
+                            accessory: button({ style: "primary", customId: "welcome:next", label: "Next" }),
+                            text: "Components V2 lets you compose rich messages from layout primitives.",
+                        }),
+                    ],
+                }),
+            ],
+        });
+    },
+});
+```
+
+## Side-by-side: same output
+
+The two APIs are isomorphic. Here's the identical message expressed both ways:
+
+<Tabs items={["JSX", "Functions"]}>
+<Tab value="JSX">
+
+```tsx
+render(
+    <Container accentColor={0xff6b35}>
+        <TextDisplay># Bug report</TextDisplay>
+        <Section accessory={<Button style="link" url="https://github.com/owner/repo" label="Repo" />}>
+            File an issue if something looks off.
+        </Section>
+        <Separator divider={true} />
+        <ActionRow>
+            <Button style="primary" customId="bug:reopen" label="Reopen" />
+            <Button style="danger" customId="bug:close" label="Close" />
+        </ActionRow>
+    </Container>
+);
+```
+
+</Tab>
+<Tab value="Functions">
+
+```ts
+container({
+    accentColor: 0xff6b35,
+    children: [
+        textDisplay("# Bug report"),
+        section({
+            accessory: button({ style: "link", url: "https://github.com/owner/repo", label: "Repo" }),
+            text: "File an issue if something looks off.",
+        }),
+        separator({ divider: true }),
+        actionRow({
+            children: [button({ style: "primary", customId: "bug:reopen", label: "Reopen" }), button({ style: "danger", customId: "bug:close", label: "Close" })],
+        }),
+    ],
+});
+```
+
+</Tab>
+</Tabs>
+
+## Modals
+
+Both runtimes can build modals. The JSX form mirrors the message API:
+
+<Tabs items={["JSX", "Functions"]}>
+<Tab value="JSX">
+
+```tsx
+import { Modal, TextInput, renderModal } from "@djs-commands/jsx";
+
+await interaction.showModal(
+    renderModal(
+        <Modal title="Send Feedback" customId="feedback-modal">
+            <TextInput customId="subject" label="Subject" style="short" required={true} />
+            <TextInput customId="body" label="What's on your mind?" style="paragraph" />
+        </Modal>
+    )
+);
+```
+
+</Tab>
+<Tab value="Functions">
+
+```ts
+import { modal, textInput } from "@djs-commands/core";
+
+await interaction.showModal(
+    modal({
+        title: "Send Feedback",
+        customId: "feedback-modal",
+        fields: [textInput({ customId: "subject", label: "Subject", style: "short", required: true }), textInput({ customId: "body", label: "What's on your mind?", style: "paragraph" })],
+    })
+);
+```
+
+</Tab>
+</Tabs>
+
+`<RadioGroup>` and `<CheckboxGroup>` are also available for modal forms; the function-form equivalents are
+`radioGroup()` and `checkboxGroup()`.
+
+## What you can build
+
+The full component set covers everything Discord exposes today:
+
+| Layout         | Form           |
+| -------------- | -------------- |
+| `Container`    | `ActionRow`    |
+| `Section`      | `Button`       |
+| `TextDisplay`  | `Modal`        |
+| `MediaGallery` | `TextInput`    |
+| `Separator`    | `RadioGroup`   |
+| `File`         | `CheckboxGroup`|
+| `Thumbnail`    |                |
+
+## Full example
+
+For a runnable bot covering every primitive — slash command, container, section, gallery, separator,
+action row, and a modal — see
+[`examples/components-v2-showcase`](https://github.com/D3OXY/djs-commands/tree/main/examples/components-v2-showcase).
+
+<Callout type="info">
+Interaction routing (a click in `<Button customId="..." />` reaching a typed handler) is the next slice's
+focus. Today, you wire button/modal interactions on `client.on(Events.InteractionCreate, ...)` as in the
+showcase example.
 </Callout>
-
-Components V2 is the headline feature of djs-commands v2. The plan:
-
-- **JSX builders** for projects with a JSX-capable toolchain (TS, ESBuild, SWC, Bun). Write Discord components like React.
-- **Function-call fallback** with the same primitives, for plain-JS projects that can't compile JSX.
-- **Type-safe interaction routing** so a button click in one command can be handled by a function with the right argument types.
-- **Layout primitives** (Action Row, Container, Section) wired into the component tree.
-
-Track issue [#61](https://github.com/D3OXY/djs-commands/issues/61) for the API design and rollout. The dedicated [Components V2 concept page](/concepts/components-v2) will explain how the runtime fits into the rest of the framework.

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,21 @@
         "typescript": "catalog:",
       },
     },
+    "examples/components-v2-showcase": {
+      "name": "components-v2-showcase",
+      "version": "0.0.0",
+      "dependencies": {
+        "@djs-commands/core": "workspace:*",
+        "@djs-commands/jsx": "workspace:*",
+        "discord.js": "catalog:",
+      },
+      "devDependencies": {
+        "@djs-commands/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "examples/minimal": {
       "name": "minimal",
       "version": "0.0.0",
@@ -53,6 +68,21 @@
     },
     "packages/core": {
       "name": "@djs-commands/core",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@djs-commands/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "discord.js": "catalog:",
+        "expect-type": "^1.2.0",
+        "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "discord.js": "^14.26.0",
+      },
+    },
+    "packages/jsx": {
+      "name": "@djs-commands/jsx",
       "version": "0.0.0",
       "devDependencies": {
         "@djs-commands/tsconfig": "workspace:*",
@@ -187,6 +217,8 @@
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
     "@djs-commands/core": ["@djs-commands/core@workspace:packages/core"],
+
+    "@djs-commands/jsx": ["@djs-commands/jsx@workspace:packages/jsx"],
 
     "@djs-commands/tsconfig": ["@djs-commands/tsconfig@workspace:packages/tsconfig"],
 
@@ -653,6 +685,8 @@
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "components-v2-showcase": ["components-v2-showcase@workspace:examples/components-v2-showcase"],
 
     "compute-scroll-into-view": ["compute-scroll-into-view@3.1.1", "", {}, "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="],
 

--- a/examples/components-v2-showcase/.env.example
+++ b/examples/components-v2-showcase/.env.example
@@ -1,0 +1,1 @@
+DISCORD_TOKEN=your-bot-token-here

--- a/examples/components-v2-showcase/README.md
+++ b/examples/components-v2-showcase/README.md
@@ -1,0 +1,13 @@
+# components-v2-showcase
+
+Example bot demonstrating `@djs-commands/jsx`. Replies to `/welcome` with a
+Container holding a heading, a Section with a Button accessory, a media
+gallery, a separator, and an action row. The button opens a modal collecting
+free-form feedback.
+
+## Run
+
+```bash
+cp .env.example .env  # paste your DISCORD_TOKEN
+bun run dev
+```

--- a/examples/components-v2-showcase/package.json
+++ b/examples/components-v2-showcase/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "components-v2-showcase",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"description": "djs-commands example showing Components V2 via JSX",
+	"scripts": {
+		"dev": "bun run --watch src/index.tsx",
+		"start": "bun run src/index.tsx",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@djs-commands/core": "workspace:*",
+		"@djs-commands/jsx": "workspace:*",
+		"discord.js": "catalog:"
+	},
+	"devDependencies": {
+		"@djs-commands/tsconfig": "workspace:*",
+		"@types/bun": "catalog:",
+		"@types/node": "catalog:",
+		"typescript": "catalog:"
+	}
+}

--- a/examples/components-v2-showcase/src/index.tsx
+++ b/examples/components-v2-showcase/src/index.tsx
@@ -1,0 +1,83 @@
+import { createCommandHandler, defineCommand } from "@djs-commands/core";
+import { ActionRow, Button, Container, MediaGallery, Modal, render, renderModal, Section, Separator, TextDisplay, TextInput } from "@djs-commands/jsx";
+import { Client, Events, GatewayIntentBits, MessageFlags } from "discord.js";
+
+/**
+ * `/welcome` — replies with a Components V2 message that exercises the most
+ * common layout primitives: a Container with a heading, a Section that pairs
+ * text with a Button accessory, a media gallery, a separator, and an action
+ * row. Clicking the "Send Feedback" button opens a modal.
+ */
+const welcome = defineCommand({
+	name: "welcome",
+	description: "Show off Components V2 (JSX runtime)",
+	run: async ({ interaction }) => {
+		await interaction.reply({
+			flags: MessageFlags.IsComponentsV2,
+			components: render(
+				<Container accentColor={0x5865f2}>
+					<TextDisplay># Welcome to djs-commands v2</TextDisplay>
+					<Section accessory={<Button style="primary" customId="welcome:open-feedback" label="Send Feedback" />}>
+						Components V2 lets you compose rich messages from layout primitives. Click the button to open a feedback modal.
+					</Section>
+					<MediaGallery
+						items={[
+							{ media: { url: "https://cdn.discordapp.com/embed/avatars/0.png" }, description: "default avatar 0" },
+							{ media: { url: "https://cdn.discordapp.com/embed/avatars/1.png" }, description: "default avatar 1" },
+						]}
+					/>
+					<Separator divider={true} spacing={1} />
+					<TextDisplay>Built with `@djs-commands/jsx`. Mix and match with the function-API fallback from `@djs-commands/core`.</TextDisplay>
+					<ActionRow>
+						<Button style="secondary" customId="welcome:dismiss" label="Dismiss" />
+						<Button style="link" url="https://github.com/D3OXY/djs-commands" label="GitHub" />
+					</ActionRow>
+				</Container>
+			),
+		});
+	},
+});
+
+const token = process.env.DISCORD_TOKEN;
+if (!token) {
+	console.error("DISCORD_TOKEN environment variable is required");
+	process.exit(1);
+}
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+const handler = createCommandHandler({
+	client,
+	commands: [welcome],
+});
+
+handler.ready.catch((err) => {
+	console.error("Plugin boot failed:", err);
+	process.exit(1);
+});
+
+// Show the feedback modal when the user clicks the button. Lives outside the
+// command handler since this is a button interaction rather than a slash
+// command — Components V2 routing is the next slice's concern.
+client.on(Events.InteractionCreate, (interaction) => {
+	if (interaction.isButton() && interaction.customId === "welcome:open-feedback") {
+		interaction
+			.showModal(
+				renderModal(
+					<Modal title="Send Feedback" customId="welcome:feedback-modal">
+						<TextInput customId="subject" label="Subject" style="short" required={true} />
+						<TextInput customId="body" label="What's on your mind?" style="paragraph" />
+					</Modal>
+				)
+			)
+			.catch((err) => {
+				console.error("Failed to show modal:", err);
+			});
+	}
+});
+
+client.once(Events.ClientReady, (c) => {
+	console.log(`Logged in as ${c.user.tag}`);
+});
+
+await client.login(token);

--- a/examples/components-v2-showcase/tsconfig.json
+++ b/examples/components-v2-showcase/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "@djs-commands/tsconfig/base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"esModuleInterop": true,
+		"isolatedModules": true,
+		"resolveJsonModule": true,
+		"jsx": "react-jsx",
+		"jsxImportSource": "@djs-commands/jsx",
+		"types": ["bun"]
+	},
+	"include": ["src/**/*"]
+}

--- a/knip.json
+++ b/knip.json
@@ -5,8 +5,12 @@
 		"packages/core": {
 			"entry": ["src/index.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"]
 		},
+		"packages/jsx": {
+			"entry": ["src/index.ts", "src/jsx-runtime.ts", "src/jsx-dev-runtime.ts", "src/**/*.test.ts", "src/**/*.test-d.ts", "src/**/*.test-d.tsx"]
+		},
 		"packages/tsconfig": {},
 		"examples/minimal": {},
+		"examples/components-v2-showcase": {},
 		"apps/docs": {
 			"entry": ["src/client.tsx", "src/ssr.tsx", "src/router.tsx", "src/start.ts", "src/routes/**/*.{ts,tsx}", "source.config.ts"]
 		}

--- a/packages/core/src/components.test.ts
+++ b/packages/core/src/components.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import { ButtonStyle, ComponentType, ContainerBuilder, ModalBuilder, TextInputStyle } from "discord.js";
+import { actionRow, button, checkboxGroup, container, file, mediaGallery, modal, radioGroup, section, separator, textDisplay, textInput, thumbnail } from "./components";
+
+describe("function-API fallback — Components V2", () => {
+	test("container() produces the same shape as the JSX runtime", () => {
+		const built = container({
+			accentColor: 0x5865f2,
+			id: 1,
+			children: [
+				textDisplay("# Heading", { id: 10 }),
+				section({
+					id: 11,
+					accessory: button({ style: "primary", customId: "go", label: "Go" }),
+					text: "body text",
+				}),
+				mediaGallery({ items: [{ media: { url: "https://example.com/a.png" } }] }),
+				separator({ divider: true, spacing: 1 }),
+				file({ url: "attachment://file.txt" }),
+				actionRow({ children: [button({ style: "secondary", customId: "x", label: "X" })] }),
+			],
+		});
+
+		expect(built).toBeInstanceOf(ContainerBuilder);
+		expect(built.toJSON()).toMatchObject({
+			type: ComponentType.Container,
+			id: 1,
+			accent_color: 0x5865f2,
+			components: [
+				{ type: ComponentType.TextDisplay, content: "# Heading", id: 10 },
+				{
+					type: ComponentType.Section,
+					id: 11,
+					accessory: { type: ComponentType.Button, style: ButtonStyle.Primary, custom_id: "go", label: "Go" },
+					components: [{ type: ComponentType.TextDisplay, content: "body text" }],
+				},
+				{ type: ComponentType.MediaGallery, items: [{ media: { url: "https://example.com/a.png" } }] },
+				{ type: ComponentType.Separator, divider: true, spacing: 1 },
+				{ type: ComponentType.File, file: { url: "attachment://file.txt" } },
+				{
+					type: ComponentType.ActionRow,
+					components: [{ type: ComponentType.Button, style: ButtonStyle.Secondary, custom_id: "x", label: "X" }],
+				},
+			],
+		});
+	});
+
+	test("section() supports a thumbnail accessory", () => {
+		const built = section({
+			accessory: thumbnail({ url: "https://example.com/t.png", description: "alt" }),
+			text: ["line one", "line two"],
+		});
+		expect(built.toJSON()).toMatchObject({
+			type: ComponentType.Section,
+			accessory: { type: ComponentType.Thumbnail, media: { url: "https://example.com/t.png" }, description: "alt" },
+			components: [
+				{ type: ComponentType.TextDisplay, content: "line one" },
+				{ type: ComponentType.TextDisplay, content: "line two" },
+			],
+		});
+	});
+
+	test("modal() wraps text inputs in labels using each input's own label text", () => {
+		const built = modal({
+			title: "Feedback",
+			customId: "feedback",
+			fields: [textInput({ customId: "subject", label: "Subject", style: "short", required: true }), textInput({ customId: "body", label: "Body", style: "paragraph" })],
+		});
+		expect(built).toBeInstanceOf(ModalBuilder);
+		expect(built.toJSON()).toMatchObject({
+			title: "Feedback",
+			custom_id: "feedback",
+			components: [
+				{
+					type: ComponentType.Label,
+					label: "Subject",
+					component: { type: ComponentType.TextInput, custom_id: "subject", style: TextInputStyle.Short, required: true },
+				},
+				{
+					type: ComponentType.Label,
+					label: "Body",
+					component: { type: ComponentType.TextInput, custom_id: "body", style: TextInputStyle.Paragraph },
+				},
+			],
+		});
+	});
+
+	test("radioGroup() and checkboxGroup() return prebuilt LabelBuilders", () => {
+		const built = modal({
+			title: "Survey",
+			customId: "survey",
+			fields: [
+				radioGroup({
+					customId: "color",
+					label: "Pick a color",
+					options: [
+						{ value: "r", label: "Red" },
+						{ value: "b", label: "Blue" },
+					],
+				}),
+				checkboxGroup({
+					customId: "topics",
+					label: "Topics of interest",
+					options: [
+						{ value: "ts", label: "TS" },
+						{ value: "js", label: "JS" },
+					],
+					minValues: 1,
+					maxValues: 2,
+				}),
+			],
+		});
+		const json = built.toJSON();
+		expect(json.components).toEqual([
+			expect.objectContaining({
+				type: ComponentType.Label,
+				label: "Pick a color",
+				component: expect.objectContaining({
+					type: ComponentType.RadioGroup,
+					custom_id: "color",
+					options: [
+						{ value: "r", label: "Red" },
+						{ value: "b", label: "Blue" },
+					],
+				}),
+			}),
+			expect.objectContaining({
+				type: ComponentType.Label,
+				label: "Topics of interest",
+				component: expect.objectContaining({
+					type: ComponentType.CheckboxGroup,
+					custom_id: "topics",
+					options: [
+						{ value: "ts", label: "TS" },
+						{ value: "js", label: "JS" },
+					],
+					min_values: 1,
+					max_values: 2,
+				}),
+			}),
+		]);
+	});
+
+	test("button() handles link and premium variants", () => {
+		const link = button({ style: "link", url: "https://example.com", label: "Open" }).toJSON();
+		expect(link).toMatchObject({
+			type: ComponentType.Button,
+			style: ButtonStyle.Link,
+			url: "https://example.com",
+			label: "Open",
+		});
+
+		const premium = button({ style: "premium", skuId: "1234" }).toJSON();
+		expect(premium).toMatchObject({
+			type: ComponentType.Button,
+			style: ButtonStyle.Premium,
+			sku_id: "1234",
+		});
+	});
+});

--- a/packages/core/src/components.ts
+++ b/packages/core/src/components.ts
@@ -1,0 +1,373 @@
+/**
+ * Function-API fallback for Components V2.
+ *
+ * This module ships from `@djs-commands/core` so consumers who can't (or won't)
+ * enable a JSX pragma still get a typed surface for building V2 messages. It
+ * produces the same `discord.js` builder objects as `@djs-commands/jsx`'s
+ * renderer, so users may freely mix the two without worrying about parity.
+ *
+ * Important: core does NOT depend on `@djs-commands/jsx`. The functions here
+ * are independent factories — there's no shared runtime.
+ */
+
+import {
+	ActionRowBuilder,
+	type APIButtonComponent,
+	type APICheckboxGroupOption,
+	type APIMediaGalleryItem,
+	type APIRadioGroupOption,
+	ButtonBuilder,
+	ButtonStyle,
+	ComponentType,
+	ContainerBuilder,
+	FileBuilder,
+	LabelBuilder,
+	MediaGalleryBuilder,
+	type MessageActionRowComponentBuilder,
+	ModalBuilder,
+	SectionBuilder,
+	SeparatorBuilder,
+	type SeparatorSpacingSize,
+	TextDisplayBuilder,
+	TextInputBuilder,
+	TextInputStyle,
+	ThumbnailBuilder,
+} from "discord.js";
+
+// --- Display components ------------------------------------------------------
+
+export interface ContainerOptions {
+	accentColor?: number | readonly [number, number, number];
+	spoiler?: boolean;
+	id?: number;
+	children?: readonly ContainerChild[];
+}
+
+/**
+ * Children accepted by `container()`. These are the discord.js builders that
+ * Components V2 allows as direct children of a container.
+ */
+export type ContainerChild = TextDisplayBuilder | SectionBuilder | MediaGalleryBuilder | SeparatorBuilder | FileBuilder | ActionRowBuilder<MessageActionRowComponentBuilder>;
+
+export function container(options: ContainerOptions = {}): ContainerBuilder {
+	const builder = new ContainerBuilder({
+		type: ComponentType.Container,
+		...(options.id !== undefined && { id: options.id }),
+		...(options.spoiler !== undefined && { spoiler: options.spoiler }),
+	});
+	if (options.accentColor !== undefined) {
+		const color = Array.isArray(options.accentColor) ? (options.accentColor as unknown as [number, number, number]) : (options.accentColor as number);
+		builder.setAccentColor(color);
+	}
+	for (const child of options.children ?? []) appendContainerChild(builder, child);
+	return builder;
+}
+
+function appendContainerChild(builder: ContainerBuilder, child: ContainerChild): void {
+	if (child instanceof TextDisplayBuilder) {
+		builder.addTextDisplayComponents(child);
+	} else if (child instanceof SectionBuilder) {
+		builder.addSectionComponents(child);
+	} else if (child instanceof MediaGalleryBuilder) {
+		builder.addMediaGalleryComponents(child);
+	} else if (child instanceof SeparatorBuilder) {
+		builder.addSeparatorComponents(child);
+	} else if (child instanceof FileBuilder) {
+		builder.addFileComponents(child);
+	} else if (child instanceof ActionRowBuilder) {
+		builder.addActionRowComponents(child);
+	} else {
+		throw new Error("[djs-commands] container(): unsupported child builder");
+	}
+}
+
+export interface SectionOptions {
+	accessory: ButtonBuilder | ThumbnailBuilder;
+	id?: number;
+	text: string | readonly string[];
+}
+
+export function section(options: SectionOptions): SectionBuilder {
+	const builder = new SectionBuilder({
+		type: ComponentType.Section,
+		...(options.id !== undefined && { id: options.id }),
+	});
+	const lines = Array.isArray(options.text) ? options.text : [options.text as string];
+	for (const line of lines) {
+		builder.addTextDisplayComponents(
+			new TextDisplayBuilder({
+				type: ComponentType.TextDisplay,
+				content: line,
+			})
+		);
+	}
+	if (options.accessory instanceof ThumbnailBuilder) {
+		builder.setThumbnailAccessory(options.accessory);
+	} else {
+		builder.setButtonAccessory(options.accessory);
+	}
+	return builder;
+}
+
+export function textDisplay(content: string, options: { id?: number } = {}): TextDisplayBuilder {
+	return new TextDisplayBuilder({
+		type: ComponentType.TextDisplay,
+		content,
+		...(options.id !== undefined && { id: options.id }),
+	});
+}
+
+export interface MediaGalleryOptions {
+	items: readonly APIMediaGalleryItem[];
+	id?: number;
+}
+
+export function mediaGallery(options: MediaGalleryOptions): MediaGalleryBuilder {
+	return new MediaGalleryBuilder({
+		type: ComponentType.MediaGallery,
+		items: options.items.map((item) => ({ ...item })),
+		...(options.id !== undefined && { id: options.id }),
+	});
+}
+
+export interface SeparatorOptions {
+	id?: number;
+	divider?: boolean;
+	spacing?: SeparatorSpacingSize;
+}
+
+export function separator(options: SeparatorOptions = {}): SeparatorBuilder {
+	return new SeparatorBuilder({
+		type: ComponentType.Separator,
+		...(options.id !== undefined && { id: options.id }),
+		...(options.divider !== undefined && { divider: options.divider }),
+		...(options.spacing !== undefined && { spacing: options.spacing }),
+	});
+}
+
+export interface FileOptions {
+	url: string;
+	id?: number;
+	spoiler?: boolean;
+}
+
+export function file(options: FileOptions): FileBuilder {
+	return new FileBuilder({
+		type: ComponentType.File,
+		file: { url: options.url },
+		...(options.id !== undefined && { id: options.id }),
+		...(options.spoiler !== undefined && { spoiler: options.spoiler }),
+	});
+}
+
+export interface ThumbnailOptions {
+	url: string;
+	description?: string;
+	spoiler?: boolean;
+}
+
+export function thumbnail(options: ThumbnailOptions): ThumbnailBuilder {
+	return new ThumbnailBuilder({
+		type: ComponentType.Thumbnail,
+		media: { url: options.url },
+		...(options.description !== undefined && { description: options.description }),
+		...(options.spoiler !== undefined && { spoiler: options.spoiler }),
+	});
+}
+
+// --- Form components --------------------------------------------------------
+
+export type ButtonStyleName = "primary" | "secondary" | "success" | "danger" | "link" | "premium";
+
+const buttonStyleMap: Record<ButtonStyleName, ButtonStyle> = {
+	primary: ButtonStyle.Primary,
+	secondary: ButtonStyle.Secondary,
+	success: ButtonStyle.Success,
+	danger: ButtonStyle.Danger,
+	link: ButtonStyle.Link,
+	premium: ButtonStyle.Premium,
+};
+
+interface ButtonBaseOptions {
+	id?: number;
+	label?: string;
+	emoji?: { id?: string; name?: string; animated?: boolean };
+	disabled?: boolean;
+}
+
+interface InteractiveButtonOptions extends ButtonBaseOptions {
+	style: "primary" | "secondary" | "success" | "danger" | ButtonStyle.Primary | ButtonStyle.Secondary | ButtonStyle.Success | ButtonStyle.Danger;
+	customId: string;
+}
+
+interface LinkButtonOptions extends ButtonBaseOptions {
+	style: "link" | ButtonStyle.Link;
+	url: string;
+}
+
+interface PremiumButtonOptions extends ButtonBaseOptions {
+	style: "premium" | ButtonStyle.Premium;
+	skuId: string;
+}
+
+export type ButtonOptions = InteractiveButtonOptions | LinkButtonOptions | PremiumButtonOptions;
+
+function resolveButtonStyle(style: ButtonStyle | ButtonStyleName): ButtonStyle {
+	return typeof style === "string" ? buttonStyleMap[style] : style;
+}
+
+export function button(options: ButtonOptions): ButtonBuilder {
+	const style = resolveButtonStyle(options.style);
+	let data: APIButtonComponent;
+	if (style === ButtonStyle.Link) {
+		const link = options as LinkButtonOptions;
+		data = {
+			type: ComponentType.Button,
+			style: ButtonStyle.Link,
+			url: link.url,
+			...(link.id !== undefined && { id: link.id }),
+			...(link.label !== undefined && { label: link.label }),
+			...(link.emoji !== undefined && { emoji: link.emoji }),
+			...(link.disabled !== undefined && { disabled: link.disabled }),
+		};
+	} else if (style === ButtonStyle.Premium) {
+		const premium = options as PremiumButtonOptions;
+		data = {
+			type: ComponentType.Button,
+			style: ButtonStyle.Premium,
+			sku_id: premium.skuId,
+			...(premium.id !== undefined && { id: premium.id }),
+			...(premium.disabled !== undefined && { disabled: premium.disabled }),
+		};
+	} else {
+		const interactive = options as InteractiveButtonOptions;
+		data = {
+			type: ComponentType.Button,
+			style,
+			custom_id: interactive.customId,
+			...(interactive.id !== undefined && { id: interactive.id }),
+			...(interactive.label !== undefined && { label: interactive.label }),
+			...(interactive.emoji !== undefined && { emoji: interactive.emoji }),
+			...(interactive.disabled !== undefined && { disabled: interactive.disabled }),
+		};
+	}
+	return new ButtonBuilder(data as ConstructorParameters<typeof ButtonBuilder>[0]);
+}
+
+export interface ActionRowOptions {
+	id?: number;
+	children: readonly ButtonBuilder[];
+}
+
+export function actionRow(options: ActionRowOptions): ActionRowBuilder<MessageActionRowComponentBuilder> {
+	const row = new ActionRowBuilder<MessageActionRowComponentBuilder>();
+	if (options.id !== undefined) (row.data as { id?: number }).id = options.id;
+	for (const child of options.children) row.addComponents(child);
+	return row;
+}
+
+export type TextInputStyleName = "short" | "paragraph";
+
+const textInputStyleMap: Record<TextInputStyleName, TextInputStyle> = {
+	short: TextInputStyle.Short,
+	paragraph: TextInputStyle.Paragraph,
+};
+
+export interface TextInputOptions {
+	customId: string;
+	label?: string;
+	style?: TextInputStyle | TextInputStyleName;
+	placeholder?: string;
+	value?: string;
+	minLength?: number;
+	maxLength?: number;
+	required?: boolean;
+	id?: number;
+}
+
+export function textInput(options: TextInputOptions): TextInputBuilder {
+	const rawStyle = options.style ?? "short";
+	const style = typeof rawStyle === "string" ? textInputStyleMap[rawStyle] : rawStyle;
+	return new TextInputBuilder({
+		type: ComponentType.TextInput,
+		style,
+		custom_id: options.customId,
+		...(options.id !== undefined && { id: options.id }),
+		...(options.label !== undefined && { label: options.label }),
+		...(options.placeholder !== undefined && { placeholder: options.placeholder }),
+		...(options.value !== undefined && { value: options.value }),
+		...(options.minLength !== undefined && { min_length: options.minLength }),
+		...(options.maxLength !== undefined && { max_length: options.maxLength }),
+		...(options.required !== undefined && { required: options.required }),
+	});
+}
+
+export interface RadioGroupOptions {
+	customId: string;
+	label: string;
+	description?: string;
+	options: readonly APIRadioGroupOption[];
+	required?: boolean;
+}
+
+export function radioGroup(opts: RadioGroupOptions): LabelBuilder {
+	const builder = new LabelBuilder().setLabel(opts.label);
+	if (opts.description !== undefined) builder.setDescription(opts.description);
+	builder.setRadioGroupComponent({
+		type: ComponentType.RadioGroup,
+		custom_id: opts.customId,
+		options: [...opts.options],
+		...(opts.required !== undefined && { required: opts.required }),
+	});
+	return builder;
+}
+
+export interface CheckboxGroupOptions {
+	customId: string;
+	label: string;
+	description?: string;
+	options: readonly APICheckboxGroupOption[];
+	minValues?: number;
+	maxValues?: number;
+	required?: boolean;
+}
+
+export function checkboxGroup(opts: CheckboxGroupOptions): LabelBuilder {
+	const builder = new LabelBuilder().setLabel(opts.label);
+	if (opts.description !== undefined) builder.setDescription(opts.description);
+	builder.setCheckboxGroupComponent({
+		type: ComponentType.CheckboxGroup,
+		custom_id: opts.customId,
+		options: [...opts.options],
+		...(opts.minValues !== undefined && { min_values: opts.minValues }),
+		...(opts.maxValues !== undefined && { max_values: opts.maxValues }),
+		...(opts.required !== undefined && { required: opts.required }),
+	});
+	return builder;
+}
+
+export interface ModalOptions {
+	title: string;
+	customId: string;
+	/**
+	 * Either a `LabelBuilder` (preferred — wraps a single interactive
+	 * component) or a `TextInputBuilder` (which we'll wrap in a label using
+	 * the input's own label text).
+	 */
+	fields: readonly (LabelBuilder | TextInputBuilder)[];
+}
+
+export function modal(options: ModalOptions): ModalBuilder {
+	const builder = new ModalBuilder().setCustomId(options.customId).setTitle(options.title);
+	const labels: LabelBuilder[] = [];
+	for (const field of options.fields) {
+		if (field instanceof LabelBuilder) {
+			labels.push(field);
+		} else {
+			const inputJSON = field.toJSON();
+			labels.push(new LabelBuilder().setLabel(inputJSON.label ?? "").setTextInputComponent(field));
+		}
+	}
+	if (labels.length > 0) builder.addLabelComponents(...labels);
+	return builder;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,35 @@
+export type {
+	ActionRowOptions,
+	ButtonOptions,
+	ButtonStyleName,
+	CheckboxGroupOptions,
+	ContainerChild,
+	ContainerOptions,
+	FileOptions,
+	MediaGalleryOptions,
+	ModalOptions,
+	RadioGroupOptions,
+	SectionOptions,
+	SeparatorOptions,
+	TextInputOptions,
+	TextInputStyleName,
+	ThumbnailOptions,
+} from "./components";
+export {
+	actionRow,
+	button,
+	checkboxGroup,
+	container,
+	file,
+	mediaGallery,
+	modal,
+	radioGroup,
+	section,
+	separator,
+	textDisplay,
+	textInput,
+	thumbnail,
+} from "./components";
 export type { CacheAdapter, CooldownConfig, CooldownType } from "./cooldowns";
 export { defineCommand } from "./define-command";
 export { createCommandHandler } from "./handler";

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -1,0 +1,50 @@
+# @djs-commands/jsx
+
+JSX runtime + Components V2 components for [`@djs-commands/core`](https://github.com/D3OXY/djs-commands).
+
+Write Discord Components V2 messages as JSX:
+
+```tsx
+import { Container, Section, TextDisplay, Button, render } from "@djs-commands/jsx";
+import { MessageFlags } from "discord.js";
+
+await interaction.reply({
+    flags: MessageFlags.IsComponentsV2,
+    components: render(
+        <Container accentColor={0x5865f2}>
+            <TextDisplay># Welcome</TextDisplay>
+            <Section accessory={<Button style="primary" customId="ok" label="OK" />}>
+                Click the button to continue.
+            </Section>
+        </Container>
+    ),
+});
+```
+
+## Setup
+
+In your `tsconfig.json`:
+
+```json
+{
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "jsxImportSource": "@djs-commands/jsx"
+    }
+}
+```
+
+That's it — no Babel, no SWC. The TypeScript compiler (and Bun's transpiler) emits `import { jsx } from "@djs-commands/jsx/jsx-runtime"` automatically.
+
+## Components
+
+Display: `<Container>`, `<Section>`, `<TextDisplay>`, `<MediaGallery>`, `<Separator>`, `<File>`, `<Thumbnail>`.
+
+Forms: `<ActionRow>`, `<Button>`, `<Modal>`, `<TextInput>`, `<RadioGroup>`, `<CheckboxGroup>`.
+
+## No JSX? Use the function fallback
+
+If you can't enable JSX in your project, every component has a function-form
+sibling re-exported from `@djs-commands/core` (e.g. `container`, `section`,
+`textDisplay`, `button`). They return the same discord.js builders, so you can
+mix the two freely.

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,0 +1,63 @@
+{
+	"name": "@djs-commands/jsx",
+	"version": "0.0.0",
+	"description": "JSX runtime + components for djs-commands — Components V2 expressed as JSX",
+	"author": "D3OXY <hello@deoxy.dev>",
+	"license": "MIT",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./jsx-runtime": {
+			"types": "./dist/jsx-runtime.d.ts",
+			"import": "./dist/jsx-runtime.js"
+		},
+		"./jsx-dev-runtime": {
+			"types": "./dist/jsx-dev-runtime.d.ts",
+			"import": "./dist/jsx-dev-runtime.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"dev": "tsc -p tsconfig.build.json --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "bun test"
+	},
+	"peerDependencies": {
+		"discord.js": "^14.26.0"
+	},
+	"devDependencies": {
+		"@djs-commands/tsconfig": "workspace:*",
+		"@types/bun": "catalog:",
+		"@types/node": "catalog:",
+		"discord.js": "catalog:",
+		"expect-type": "^1.2.0",
+		"typescript": "catalog:"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/D3OXY/djs-commands",
+		"directory": "packages/jsx"
+	},
+	"keywords": [
+		"discord.js",
+		"discord",
+		"components-v2",
+		"jsx",
+		"jsx-runtime"
+	]
+}

--- a/packages/jsx/src/components.test-d.ts
+++ b/packages/jsx/src/components.test-d.ts
@@ -1,0 +1,122 @@
+/**
+ * Type-level tests for component prop shapes.
+ *
+ * These don't run at test time — `bun test` ignores `*.test-d.ts` files. They
+ * are picked up by `tsconfig.json` (which includes them) but excluded by
+ * `tsconfig.build.json`, so a failure here surfaces in `bun run typecheck`.
+ */
+
+import { type APIButtonComponent, ButtonStyle, type ComponentType } from "discord.js";
+import { expectTypeOf } from "expect-type";
+import { Container, Section, TextDisplay, Thumbnail } from "./components/display";
+import { ActionRow, Button, CheckboxGroup, Modal, RadioGroup, TextInput } from "./components/forms";
+import type { ButtonNode, ContainerNode, DjsxNode, ModalNode, SectionNode, TextDisplayNode, TextInputNode } from "./types";
+
+// --- Container ---------------------------------------------------------------
+
+// Required `accentColor` shape: number or RGB tuple, both accepted.
+const c1 = Container({ accentColor: 0x123456, children: TextDisplay({ children: "x" }) });
+expectTypeOf(c1).toEqualTypeOf<ContainerNode>();
+
+const c2 = Container({ accentColor: [10, 20, 30] as const, children: [] });
+expectTypeOf(c2).toEqualTypeOf<ContainerNode>();
+
+// Children can be a single node or an array, and accept all V2 layout types.
+Container({
+	children: [
+		TextDisplay({ children: "heading" }),
+		Section({
+			accessory: Button({ style: "primary", customId: "x", label: "X" }),
+			children: ["body"],
+		}),
+		ActionRow({ children: [Button({ style: "primary", customId: "x", label: "X" })] }),
+	],
+});
+
+// --- Section -----------------------------------------------------------------
+
+const s1 = Section({
+	accessory: Button({ style: "secondary", customId: "y", label: "Y" }),
+	children: ["body"],
+});
+expectTypeOf(s1).toEqualTypeOf<SectionNode>();
+
+// Thumbnail also accepted as accessory.
+Section({ accessory: Thumbnail({ url: "https://example.com/x.png" }), children: [TextDisplay({ children: "row" })] });
+
+// @ts-expect-error — bare strings are not valid accessories.
+Section({ accessory: "not allowed", children: [] });
+
+// @ts-expect-error — accessory is required.
+Section({ children: [TextDisplay({ children: "x" })] });
+
+// --- TextDisplay -------------------------------------------------------------
+
+const t1 = TextDisplay({ children: "static text" });
+expectTypeOf(t1).toEqualTypeOf<TextDisplayNode>();
+TextDisplay({ children: ["a", "b"] });
+TextDisplay({ children: 42 }); // numbers stringify
+TextDisplay({}); // children optional → empty content
+
+// @ts-expect-error — TextDisplay rejects nested nodes (they aren't text).
+TextDisplay({ children: TextDisplay({ children: "x" }) });
+
+// --- Button ------------------------------------------------------------------
+
+const b1 = Button({ style: "primary", customId: "ok", label: "OK" });
+expectTypeOf(b1).toEqualTypeOf<ButtonNode>();
+expectTypeOf(b1.data).toMatchTypeOf<APIButtonComponent>();
+
+// Link buttons require `url`, not `customId`.
+Button({ style: "link", url: "https://example.com" });
+
+// Premium buttons require `skuId`.
+Button({ style: "premium", skuId: "100" });
+
+// Enum-style style values are also accepted.
+Button({ style: ButtonStyle.Primary, customId: "ok" });
+
+// @ts-expect-error — link buttons can't have a customId.
+Button({ style: "link", customId: "nope" });
+
+// @ts-expect-error — interactive buttons require a customId.
+Button({ style: "primary", label: "no id" });
+
+// --- Modal -------------------------------------------------------------------
+
+const m1 = Modal({
+	title: "Survey",
+	customId: "survey-modal",
+	children: [TextInput({ customId: "name", label: "Name" })],
+});
+expectTypeOf(m1).toEqualTypeOf<ModalNode>();
+
+Modal({
+	title: "Survey",
+	customId: "survey-modal",
+	children: [
+		TextInput({ customId: "name", label: "Name" }),
+		RadioGroup({ customId: "c", label: "Pick", options: [{ value: "a", label: "A" }] }),
+		CheckboxGroup({ customId: "k", label: "Topics", options: [{ value: "a", label: "A" }] }),
+	],
+});
+
+// Modal children are typed as `DjsxNode` (the union) so JSX expressions can
+// be passed without casting; the runtime asserts the kind is one of TextInput,
+// RadioGroup, or CheckboxGroup. If we tightened the type here, you'd need to
+// cast `<TextInput />` since JSX expressions are typed as the wide union.
+
+// --- TextInput ---------------------------------------------------------------
+
+const ti = TextInput({ customId: "name", label: "Name", style: "short", required: true });
+expectTypeOf(ti).toEqualTypeOf<TextInputNode>();
+expectTypeOf(ti.data.type).toEqualTypeOf<ComponentType.TextInput>();
+
+// --- DjsxNode union sanity ---------------------------------------------------
+
+// Every component returns a member of the DjsxNode union.
+expectTypeOf<TextDisplayNode>().toMatchTypeOf<DjsxNode>();
+expectTypeOf<ContainerNode>().toMatchTypeOf<DjsxNode>();
+expectTypeOf<SectionNode>().toMatchTypeOf<DjsxNode>();
+expectTypeOf<ButtonNode>().toMatchTypeOf<DjsxNode>();
+expectTypeOf<ModalNode>().toMatchTypeOf<DjsxNode>();

--- a/packages/jsx/src/components/display.ts
+++ b/packages/jsx/src/components/display.ts
@@ -1,0 +1,144 @@
+/**
+ * Display components — the top-level layout primitives that go in messages.
+ *
+ * These map 1:1 onto Components V2 layout types: Container, Section,
+ * TextDisplay, MediaGallery, Separator, File. Each component is a pure
+ * function returning a tagged node; the actual builder construction happens
+ * in `../render.ts`.
+ */
+
+import type { APIMediaGalleryItem } from "discord.js";
+import { flattenChildren } from "../internal";
+import type { ButtonNode, Children, ContainerNode, DjsxNode, FileNode, MediaGalleryNode, SectionNode, SeparatorNode, Spacing, TextDisplayNode, ThumbnailNode } from "../types";
+
+export interface ContainerProps {
+	/** Optional 0xRRGGBB number or RGB triple for the accent bar. */
+	accentColor?: number | readonly [number, number, number];
+	/** Whether the container should be blurred behind a spoiler veil. */
+	spoiler?: boolean;
+	/** Stable component id — useful for referencing within an interaction response. */
+	id?: number;
+	children?: Children<DjsxNode>;
+}
+
+export function Container(props: ContainerProps): ContainerNode {
+	return {
+		$$kind: "container",
+		accentColor: props.accentColor,
+		spoiler: props.spoiler,
+		id: props.id,
+		children: flattenChildren(props.children),
+	};
+}
+
+export interface SectionProps {
+	/**
+	 * The accessory rendered to the right of the text. Discord currently
+	 * accepts a Button or a Thumbnail; we widen the type to `DjsxNode` so
+	 * that JSX expressions (typed as the union) compose without casting,
+	 * and assert at the runtime layer in `render.ts`.
+	 */
+	accessory: DjsxNode;
+	id?: number;
+	children?: Children<TextDisplayNode | string>;
+}
+
+export function Section(props: SectionProps): SectionNode {
+	const accessory = props.accessory;
+	if (accessory.$$kind !== "button" && accessory.$$kind !== "thumbnail") {
+		throw new Error(`[djs-commands/jsx] <Section accessory={...}> must be a <Button> or <Thumbnail>; got ${accessory.$$kind}`);
+	}
+	return {
+		$$kind: "section",
+		id: props.id,
+		accessory: accessory as ButtonNode | ThumbnailNode,
+		children: flattenChildren(props.children),
+	};
+}
+
+type TextLiteral = string | number | boolean;
+
+export interface TextDisplayProps {
+	id?: number;
+	/**
+	 * Markdown content. JSX children are concatenated into a single string,
+	 * so `<TextDisplay>Hello, {name}!</TextDisplay>` works as expected.
+	 */
+	children?: TextLiteral | readonly TextLiteral[];
+}
+
+export function TextDisplay(props: TextDisplayProps): TextDisplayNode {
+	const raw = props.children;
+	const arr = raw === undefined ? [] : Array.isArray(raw) ? (raw as readonly TextLiteral[]) : [raw as TextLiteral];
+	return {
+		$$kind: "textDisplay",
+		id: props.id,
+		content: arr.map((c) => String(c)).join(""),
+	};
+}
+
+export interface MediaGalleryProps {
+	id?: number;
+	/**
+	 * 1-10 media items. Each item is the raw `APIMediaGalleryItem` shape
+	 * (`{ media: { url }, description?, spoiler? }`). We accept the raw shape
+	 * directly so users can spread upload metadata returned by the bot.
+	 */
+	items: readonly APIMediaGalleryItem[];
+}
+
+export function MediaGallery(props: MediaGalleryProps): MediaGalleryNode {
+	return {
+		$$kind: "mediaGallery",
+		id: props.id,
+		items: props.items,
+	};
+}
+
+export interface SeparatorProps {
+	id?: number;
+	/** Whether to render a visible divider line. Defaults to `true` in Discord. */
+	divider?: boolean;
+	/** Padding size — `1` = small, `2` = large. */
+	spacing?: Spacing;
+}
+
+export function Separator(props: SeparatorProps = {}): SeparatorNode {
+	return {
+		$$kind: "separator",
+		id: props.id,
+		divider: props.divider,
+		spacing: props.spacing,
+	};
+}
+
+export interface FileProps {
+	id?: number;
+	/** Must be an `attachment://<filename>` reference per the Discord API. */
+	url: string;
+	spoiler?: boolean;
+}
+
+export function File(props: FileProps): FileNode {
+	return {
+		$$kind: "file",
+		id: props.id,
+		url: props.url,
+		spoiler: props.spoiler,
+	};
+}
+
+export interface ThumbnailProps {
+	url: string;
+	description?: string;
+	spoiler?: boolean;
+}
+
+export function Thumbnail(props: ThumbnailProps): ThumbnailNode {
+	return {
+		$$kind: "thumbnail",
+		media: { url: props.url },
+		description: props.description,
+		spoiler: props.spoiler,
+	};
+}

--- a/packages/jsx/src/components/forms.ts
+++ b/packages/jsx/src/components/forms.ts
@@ -1,0 +1,231 @@
+/**
+ * Form components — interactive inputs that appear inside ActionRows or
+ * Modals: Button, ActionRow, TextInput, RadioGroup, CheckboxGroup, Modal.
+ */
+
+import { type APICheckboxGroupOption, type APIRadioGroupOption, ButtonStyle, ComponentType, TextInputStyle } from "discord.js";
+import { flattenChildren } from "../internal";
+import type { ActionRowNode, ButtonNode, CheckboxGroupNode, Children, DjsxNode, ModalNode, RadioGroupNode, TextInputNode } from "../types";
+
+/**
+ * Style names exposed via JSX. We accept the discord-api-types enum values
+ * as well as friendlier string aliases for parity with the rest of the
+ * ecosystem.
+ */
+export type ButtonStyleName = "primary" | "secondary" | "success" | "danger" | "link" | "premium";
+
+const buttonStyleMap: Record<ButtonStyleName, ButtonStyle> = {
+	primary: ButtonStyle.Primary,
+	secondary: ButtonStyle.Secondary,
+	success: ButtonStyle.Success,
+	danger: ButtonStyle.Danger,
+	link: ButtonStyle.Link,
+	premium: ButtonStyle.Premium,
+};
+
+interface ButtonBaseProps {
+	id?: number;
+	label?: string;
+	emoji?: { id?: string; name?: string; animated?: boolean };
+	disabled?: boolean;
+}
+
+interface InteractiveButtonProps extends ButtonBaseProps {
+	style: "primary" | "secondary" | "success" | "danger" | ButtonStyle.Primary | ButtonStyle.Secondary | ButtonStyle.Success | ButtonStyle.Danger;
+	customId: string;
+}
+
+interface LinkButtonProps extends ButtonBaseProps {
+	style: "link" | ButtonStyle.Link;
+	url: string;
+}
+
+interface PremiumButtonProps extends ButtonBaseProps {
+	style: "premium" | ButtonStyle.Premium;
+	skuId: string;
+}
+
+export type ButtonProps = InteractiveButtonProps | LinkButtonProps | PremiumButtonProps;
+
+function resolveButtonStyle(style: ButtonStyle | ButtonStyleName): ButtonStyle {
+	return typeof style === "string" ? buttonStyleMap[style] : style;
+}
+
+export function Button(props: ButtonProps): ButtonNode {
+	const style = resolveButtonStyle(props.style);
+	if (style === ButtonStyle.Link) {
+		const link = props as LinkButtonProps;
+		return {
+			$$kind: "button",
+			data: {
+				type: ComponentType.Button,
+				style: ButtonStyle.Link,
+				url: link.url,
+				...(link.id !== undefined && { id: link.id }),
+				...(link.label !== undefined && { label: link.label }),
+				...(link.emoji !== undefined && { emoji: link.emoji }),
+				...(link.disabled !== undefined && { disabled: link.disabled }),
+			},
+		};
+	}
+	if (style === ButtonStyle.Premium) {
+		const premium = props as PremiumButtonProps;
+		return {
+			$$kind: "button",
+			data: {
+				type: ComponentType.Button,
+				style: ButtonStyle.Premium,
+				sku_id: premium.skuId,
+				...(premium.id !== undefined && { id: premium.id }),
+				...(premium.disabled !== undefined && { disabled: premium.disabled }),
+			},
+		};
+	}
+	const interactive = props as InteractiveButtonProps;
+	return {
+		$$kind: "button",
+		data: {
+			type: ComponentType.Button,
+			style,
+			custom_id: interactive.customId,
+			...(interactive.id !== undefined && { id: interactive.id }),
+			...(interactive.label !== undefined && { label: interactive.label }),
+			...(interactive.emoji !== undefined && { emoji: interactive.emoji }),
+			...(interactive.disabled !== undefined && { disabled: interactive.disabled }),
+		},
+	};
+}
+
+export interface ActionRowProps {
+	id?: number;
+	/**
+	 * Accepts only `<Button>` children at runtime. Typed as `DjsxNode` so JSX
+	 * expressions (which all carry that union type) compose without casts;
+	 * we assert at runtime in this constructor and let the renderer surface
+	 * a clear error if the assertion is bypassed.
+	 */
+	children?: Children<DjsxNode>;
+}
+
+export function ActionRow(props: ActionRowProps): ActionRowNode {
+	const children = flattenChildren(props.children);
+	for (const child of children) {
+		if (child.$$kind !== "button") {
+			throw new Error(`[djs-commands/jsx] <ActionRow> children must be <Button> nodes; got ${child.$$kind}`);
+		}
+	}
+	return {
+		$$kind: "actionRow",
+		id: props.id,
+		children: children as readonly ButtonNode[],
+	};
+}
+
+export type TextInputStyleName = "short" | "paragraph";
+
+const textInputStyleMap: Record<TextInputStyleName, TextInputStyle> = {
+	short: TextInputStyle.Short,
+	paragraph: TextInputStyle.Paragraph,
+};
+
+export interface TextInputProps {
+	customId: string;
+	label?: string;
+	style?: TextInputStyle | TextInputStyleName;
+	placeholder?: string;
+	value?: string;
+	minLength?: number;
+	maxLength?: number;
+	required?: boolean;
+	id?: number;
+}
+
+export function TextInput(props: TextInputProps): TextInputNode {
+	const rawStyle = props.style ?? "short";
+	const style = typeof rawStyle === "string" ? textInputStyleMap[rawStyle] : rawStyle;
+	return {
+		$$kind: "textInput",
+		data: {
+			type: ComponentType.TextInput,
+			style,
+			custom_id: props.customId,
+			...(props.id !== undefined && { id: props.id }),
+			...(props.label !== undefined && { label: props.label }),
+			...(props.placeholder !== undefined && { placeholder: props.placeholder }),
+			...(props.value !== undefined && { value: props.value }),
+			...(props.minLength !== undefined && { min_length: props.minLength }),
+			...(props.maxLength !== undefined && { max_length: props.maxLength }),
+			...(props.required !== undefined && { required: props.required }),
+		},
+	};
+}
+
+export interface RadioGroupProps {
+	customId: string;
+	/** Label text shown above the group inside a modal — required by Discord. */
+	label: string;
+	description?: string;
+	options: readonly APIRadioGroupOption[];
+	required?: boolean;
+}
+
+export function RadioGroup(props: RadioGroupProps): RadioGroupNode {
+	return {
+		$$kind: "radioGroup",
+		customId: props.customId,
+		label: props.label,
+		...(props.description !== undefined && { description: props.description }),
+		options: props.options,
+		...(props.required !== undefined && { required: props.required }),
+	};
+}
+
+export interface CheckboxGroupProps {
+	customId: string;
+	/** Label text shown above the group inside a modal — required by Discord. */
+	label: string;
+	description?: string;
+	options: readonly APICheckboxGroupOption[];
+	minValues?: number;
+	maxValues?: number;
+	required?: boolean;
+}
+
+export function CheckboxGroup(props: CheckboxGroupProps): CheckboxGroupNode {
+	return {
+		$$kind: "checkboxGroup",
+		customId: props.customId,
+		label: props.label,
+		...(props.description !== undefined && { description: props.description }),
+		options: props.options,
+		...(props.minValues !== undefined && { minValues: props.minValues }),
+		...(props.maxValues !== undefined && { maxValues: props.maxValues }),
+		...(props.required !== undefined && { required: props.required }),
+	};
+}
+
+export interface ModalProps {
+	title: string;
+	customId: string;
+	/**
+	 * Accepts only `<TextInput>`, `<RadioGroup>`, and `<CheckboxGroup>`
+	 * children at runtime. Typed as `DjsxNode` to play nicely with the JSX
+	 * automatic transform — see the comment on `ActionRowProps.children`.
+	 */
+	children?: Children<DjsxNode>;
+}
+
+export function Modal(props: ModalProps): ModalNode {
+	const children = flattenChildren(props.children);
+	for (const child of children) {
+		if (child.$$kind !== "textInput" && child.$$kind !== "radioGroup" && child.$$kind !== "checkboxGroup") {
+			throw new Error(`[djs-commands/jsx] <Modal> children must be <TextInput>, <RadioGroup>, or <CheckboxGroup>; got ${child.$$kind}`);
+		}
+	}
+	return {
+		$$kind: "modal",
+		title: props.title,
+		customId: props.customId,
+		children: children as readonly (TextInputNode | RadioGroupNode | CheckboxGroupNode)[],
+	};
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Public entry for `@djs-commands/jsx`.
+ *
+ * The JSX runtime lives in `./jsx-runtime.ts` (and `./jsx-dev-runtime.ts`).
+ * This entry exposes the components and the renderer for non-JSX usage and
+ * for JSX-using code that wants a single import surface.
+ */
+
+export type { ContainerProps, FileProps, MediaGalleryProps, SectionProps, SeparatorProps, TextDisplayProps, ThumbnailProps } from "./components/display";
+export { Container, File, MediaGallery, Section, Separator, TextDisplay, Thumbnail } from "./components/display";
+export type {
+	ActionRowProps,
+	ButtonProps,
+	ButtonStyleName,
+	CheckboxGroupProps,
+	ModalProps,
+	RadioGroupProps,
+	TextInputProps,
+	TextInputStyleName,
+} from "./components/forms";
+export { ActionRow, Button, CheckboxGroup, Modal, RadioGroup, TextInput } from "./components/forms";
+export { Fragment } from "./jsx-runtime";
+export type { ComponentBuilderArray } from "./render";
+export { render, renderModal } from "./render";
+export type { DjsxNode } from "./types";

--- a/packages/jsx/src/internal.ts
+++ b/packages/jsx/src/internal.ts
@@ -1,0 +1,28 @@
+/**
+ * Small, internal helpers shared across the runtime and components. Not
+ * exported from the package entry — keeping these private lets us evolve them
+ * without breaking consumers.
+ */
+
+import type { Children, DjsxNode, FragmentNode } from "./types";
+
+/**
+ * Normalize a children prop into a flat readonly array. JSX collapses a
+ * single child into a non-array value, so most components receive a union.
+ *
+ * Fragments encountered at any depth are flattened — this is the only kind
+ * of structural transparency the runtime offers.
+ */
+export function flattenChildren<T extends DjsxNode | string>(input: Children<T> | undefined): readonly T[] {
+	if (input === undefined) return [];
+	const arr = Array.isArray(input) ? (input as readonly T[]) : [input as T];
+	const out: T[] = [];
+	for (const item of arr) {
+		if (item && typeof item === "object" && "$$kind" in item && (item as DjsxNode).$$kind === "fragment") {
+			out.push(...(flattenChildren((item as FragmentNode).children as Children<T>) as T[]));
+			continue;
+		}
+		out.push(item);
+	}
+	return out;
+}

--- a/packages/jsx/src/jsx-dev-runtime.ts
+++ b/packages/jsx/src/jsx-dev-runtime.ts
@@ -1,0 +1,24 @@
+/**
+ * Dev variant of the JSX runtime.
+ *
+ * TypeScript's `react-jsxdev` transform imports `jsxDEV` from this entry. Our
+ * runtime has no dev-only behavior, so we re-export `jsx-runtime` and provide
+ * a `jsxDEV` shim that drops the extra source-position arguments.
+ */
+
+import { jsx } from "./jsx-runtime";
+import type { DjsxNode } from "./types";
+
+type AnyProps = Record<string, unknown>;
+
+export type { JSX } from "./jsx-runtime";
+export { Fragment, jsx, jsx as jsxs } from "./jsx-runtime";
+
+/**
+ * `jsxDEV(type, props, key, isStaticChildren, source, self)` — the dev
+ * transform's signature. We only care about the first two args; the rest
+ * carry source-map metadata that's irrelevant to our renderer.
+ */
+export function jsxDEV<P extends AnyProps>(type: (props: P) => DjsxNode, props: P): DjsxNode {
+	return jsx(type, props);
+}

--- a/packages/jsx/src/jsx-runtime.ts
+++ b/packages/jsx/src/jsx-runtime.ts
@@ -1,0 +1,65 @@
+/**
+ * Custom JSX runtime for `@djs-commands/jsx`.
+ *
+ * Set in `tsconfig.json`:
+ *   "jsx": "react-jsx",
+ *   "jsxImportSource": "@djs-commands/jsx"
+ *
+ * Components V2 elements are represented as plain "node" objects (see
+ * `./types.ts`). Each component function takes its props and returns a node
+ * directly — `jsx()` and `jsxs()` simply forward the call. This avoids React's
+ * lazy {type, props} representation entirely, since we have no reconciliation
+ * to perform.
+ */
+
+import type { DjsxNode, FragmentNode } from "./types";
+
+type AnyProps = Record<string, unknown>;
+
+type ComponentFn<P extends AnyProps = AnyProps, R extends DjsxNode = DjsxNode> = (props: P) => R;
+
+/**
+ * The intrinsic Fragment marker. Children are flattened by `render()`. We
+ * model it as a function so it's a valid `jsx()` `type` argument.
+ */
+export function Fragment(props: { children?: DjsxNode | readonly DjsxNode[] }): FragmentNode {
+	const raw = props.children;
+	const children = raw === undefined ? [] : Array.isArray(raw) ? (raw as readonly DjsxNode[]) : [raw as DjsxNode];
+	return { $$kind: "fragment", children };
+}
+
+/**
+ * `jsx(type, props)` — TS calls this for elements with 0 or 1 children.
+ *
+ * Components are plain functions: invoke them with their resolved props. We
+ * accept either a function component or the `Fragment` symbol.
+ */
+export function jsx<P extends AnyProps>(type: ComponentFn<P>, props: P): DjsxNode {
+	return type(props);
+}
+
+/**
+ * `jsxs(type, props)` — TS calls this when the element has multiple static
+ * children. Functionally identical to `jsx` for our runtime.
+ */
+export function jsxs<P extends AnyProps>(type: ComponentFn<P>, props: P): DjsxNode {
+	return type(props);
+}
+
+/**
+ * The TS automatic JSX transform looks up `JSX.Element`, `JSX.IntrinsicElements`
+ * and `JSX.ElementChildrenAttribute` from the `jsxImportSource` package.
+ *
+ * - `Element` is what JSX expressions evaluate to. We type it as `DjsxNode`.
+ * - `IntrinsicElements` is empty — there are no lower-cased HTML tags.
+ * - `ElementChildrenAttribute` tells TS our children prop is `children` (the
+ *   default), but exposing it makes intent explicit.
+ */
+export namespace JSX {
+	export type Element = DjsxNode;
+	export type ElementType = ComponentFn<never, DjsxNode>;
+	export type IntrinsicElements = Record<never, never>;
+	export interface ElementChildrenAttribute {
+		children: object;
+	}
+}

--- a/packages/jsx/src/jsx-smoke.test-d.tsx
+++ b/packages/jsx/src/jsx-smoke.test-d.tsx
@@ -1,0 +1,45 @@
+/**
+ * Smoke test for the JSX automatic transform.
+ *
+ * If this file fails to compile, the JSX runtime export shape (or the
+ * `jsxImportSource` resolution in tsconfig) is broken. We don't run anything
+ * here at runtime — `bun test` ignores `*.test-d.tsx` because it's not a
+ * Bun-native test file extension we register, and `tsconfig.build.json`
+ * excludes it.
+ */
+
+import { Container, Section, TextDisplay } from "./components/display";
+import { ActionRow, Button, Modal, TextInput } from "./components/forms";
+import type { ComponentBuilderArray } from "./render";
+import { render, renderModal } from "./render";
+
+// Top-level message render
+const tree = (
+	<Container accentColor={0x5865f2}>
+		<TextDisplay># Hello</TextDisplay>
+		<Section accessory={<Button style="primary" customId="ok" label="OK" />}>Click below</Section>
+		<ActionRow>
+			<Button style="secondary" customId="x" label="X" />
+		</ActionRow>
+	</Container>
+);
+
+const built: ComponentBuilderArray = render(tree);
+void built;
+
+// Modal render
+const modalTree = (
+	<Modal title="Form" customId="form-modal">
+		<TextInput customId="name" label="Name" />
+	</Modal>
+);
+
+renderModal(modalTree);
+
+// Fragments work too.
+render(
+	<>
+		<TextDisplay>a</TextDisplay>
+		<TextDisplay>b</TextDisplay>
+	</>
+);

--- a/packages/jsx/src/render.test.ts
+++ b/packages/jsx/src/render.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { ButtonStyle, ComponentType, ContainerBuilder, ModalBuilder, TextDisplayBuilder, TextInputStyle } from "discord.js";
+import { Container, File, MediaGallery, Section, Separator, TextDisplay, Thumbnail } from "./components/display";
+import { ActionRow, Button, CheckboxGroup, Modal, RadioGroup, TextInput } from "./components/forms";
+import { Fragment } from "./jsx-runtime";
+import { render, renderModal } from "./render";
+
+describe("render() — top-level builders", () => {
+	test("returns a TextDisplayBuilder for a top-level <TextDisplay>", () => {
+		const out = render(TextDisplay({ children: "hello" }));
+		expect(out).toHaveLength(1);
+		const first = out[0];
+		expect(first).toBeInstanceOf(TextDisplayBuilder);
+		expect(first?.toJSON()).toEqual({ type: ComponentType.TextDisplay, content: "hello" });
+	});
+
+	test("flattens fragments at the top level", () => {
+		const out = render(
+			Fragment({
+				children: [TextDisplay({ children: "a" }), TextDisplay({ children: "b" })],
+			})
+		);
+		expect(out).toHaveLength(2);
+		expect(out[0]?.toJSON()).toMatchObject({ content: "a" });
+		expect(out[1]?.toJSON()).toMatchObject({ content: "b" });
+	});
+
+	test("accepts an array of nodes", () => {
+		const out = render([TextDisplay({ children: "a" }), Separator()]);
+		expect(out).toHaveLength(2);
+	});
+});
+
+describe("render() — Container shape", () => {
+	test("renders a full container with all V2 child types", () => {
+		const tree = Container({
+			accentColor: 0x5865f2,
+			id: 1,
+			children: [
+				TextDisplay({ id: 10, children: "# Heading" }),
+				Section({
+					id: 11,
+					accessory: Button({ style: "primary", customId: "go", label: "Go" }),
+					children: ["body text"],
+				}),
+				MediaGallery({ items: [{ media: { url: "https://example.com/a.png" } }] }),
+				Separator({ divider: true, spacing: 1 }),
+				File({ url: "attachment://file.txt" }),
+				ActionRow({ children: [Button({ style: "secondary", customId: "x", label: "X" })] }),
+			],
+		});
+		const out = render(tree);
+		expect(out).toHaveLength(1);
+		const first = out[0];
+		expect(first).toBeInstanceOf(ContainerBuilder);
+		const json = first?.toJSON();
+		expect(json).toMatchObject({
+			type: ComponentType.Container,
+			id: 1,
+			accent_color: 0x5865f2,
+			components: [
+				{ type: ComponentType.TextDisplay, content: "# Heading", id: 10 },
+				{
+					type: ComponentType.Section,
+					id: 11,
+					accessory: { type: ComponentType.Button, style: ButtonStyle.Primary, custom_id: "go", label: "Go" },
+					components: [{ type: ComponentType.TextDisplay, content: "body text" }],
+				},
+				{ type: ComponentType.MediaGallery, items: [{ media: { url: "https://example.com/a.png" } }] },
+				{ type: ComponentType.Separator, divider: true, spacing: 1 },
+				{ type: ComponentType.File, file: { url: "attachment://file.txt" } },
+				{
+					type: ComponentType.ActionRow,
+					components: [{ type: ComponentType.Button, style: ButtonStyle.Secondary, custom_id: "x", label: "X" }],
+				},
+			],
+		});
+	});
+
+	test("supports a thumbnail accessory in <Section>", () => {
+		const tree = Container({
+			children: [
+				Section({
+					accessory: Thumbnail({ url: "https://example.com/thumb.png", description: "alt" }),
+					children: ["text"],
+				}),
+			],
+		});
+		const json = render(tree)[0]?.toJSON();
+		expect(json).toMatchObject({
+			components: [
+				{
+					type: ComponentType.Section,
+					accessory: { type: ComponentType.Thumbnail, media: { url: "https://example.com/thumb.png" }, description: "alt" },
+				},
+			],
+		});
+	});
+});
+
+describe("Button — link and premium variants", () => {
+	test("link button serializes with url instead of custom_id", () => {
+		const tree = ActionRow({ children: [Button({ style: "link", url: "https://example.com", label: "Open" })] });
+		const json = render(tree)[0]?.toJSON();
+		expect(json).toMatchObject({
+			type: ComponentType.ActionRow,
+			components: [{ type: ComponentType.Button, style: ButtonStyle.Link, url: "https://example.com", label: "Open" }],
+		});
+	});
+
+	test("premium button serializes with sku_id", () => {
+		const tree = ActionRow({ children: [Button({ style: "premium", skuId: "1234" })] });
+		const json = render(tree)[0]?.toJSON();
+		expect(json).toMatchObject({
+			components: [{ type: ComponentType.Button, style: ButtonStyle.Premium, sku_id: "1234" }],
+		});
+	});
+});
+
+describe("renderModal()", () => {
+	test("renders text input fields wrapped in labels", () => {
+		const tree = Modal({
+			title: "Feedback",
+			customId: "feedback-modal",
+			children: [TextInput({ customId: "subject", label: "Subject", style: "short", required: true }), TextInput({ customId: "body", label: "Body", style: "paragraph" })],
+		});
+		const builder = renderModal(tree);
+		expect(builder).toBeInstanceOf(ModalBuilder);
+		const json = builder.toJSON();
+		expect(json).toMatchObject({
+			title: "Feedback",
+			custom_id: "feedback-modal",
+			components: [
+				{
+					type: ComponentType.Label,
+					label: "Subject",
+					component: { type: ComponentType.TextInput, custom_id: "subject", style: TextInputStyle.Short, required: true },
+				},
+				{
+					type: ComponentType.Label,
+					label: "Body",
+					component: { type: ComponentType.TextInput, custom_id: "body", style: TextInputStyle.Paragraph },
+				},
+			],
+		});
+	});
+
+	test("renders radio + checkbox groups via setRadioGroupComponent / setCheckboxGroupComponent", () => {
+		const tree = Modal({
+			title: "Survey",
+			customId: "survey",
+			children: [
+				RadioGroup({
+					customId: "color",
+					label: "Pick a color",
+					options: [
+						{ value: "r", label: "Red" },
+						{ value: "b", label: "Blue" },
+					],
+				}),
+				CheckboxGroup({
+					customId: "topics",
+					label: "Topics of interest",
+					options: [
+						{ value: "ts", label: "TS" },
+						{ value: "js", label: "JS" },
+					],
+					minValues: 1,
+					maxValues: 2,
+				}),
+			],
+		});
+		const json = renderModal(tree).toJSON();
+		expect(json.components).toEqual([
+			expect.objectContaining({
+				type: ComponentType.Label,
+				component: expect.objectContaining({
+					type: ComponentType.RadioGroup,
+					custom_id: "color",
+					options: [
+						{ value: "r", label: "Red" },
+						{ value: "b", label: "Blue" },
+					],
+				}),
+			}),
+			expect.objectContaining({
+				type: ComponentType.Label,
+				component: expect.objectContaining({
+					type: ComponentType.CheckboxGroup,
+					custom_id: "topics",
+					options: [
+						{ value: "ts", label: "TS" },
+						{ value: "js", label: "JS" },
+					],
+					min_values: 1,
+					max_values: 2,
+				}),
+			}),
+		]);
+	});
+});
+
+describe("error paths", () => {
+	test("render() throws on a node that isn't a valid top-level component", () => {
+		// Hand-craft a node that the runtime would never produce normally.
+		// biome-ignore lint/suspicious/noExplicitAny: forcing an invalid shape for the negative test
+		const invalid = { $$kind: "thumbnail", media: { url: "x" } } as any;
+		expect(() => render(invalid)).toThrow(/invalid top-level node/);
+	});
+});

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -1,0 +1,286 @@
+/**
+ * Render walker — turns a JSX node tree into a flat array of discord.js
+ * builders ready for `interaction.reply({ flags: MessageFlags.IsComponentsV2,
+ * components: render(<Container>...</Container>) })`.
+ *
+ * The walker only sees nodes produced by our component functions (or fragments
+ * from the JSX runtime). Each node maps to a deterministic builder shape; we
+ * always return real discord.js builders so consumers can keep chaining
+ * `.set...` calls if they need to.
+ */
+
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ComponentType,
+	ContainerBuilder,
+	FileBuilder,
+	LabelBuilder,
+	MediaGalleryBuilder,
+	type MessageActionRowComponentBuilder,
+	ModalBuilder,
+	SectionBuilder,
+	SeparatorBuilder,
+	TextDisplayBuilder,
+	TextInputBuilder,
+	ThumbnailBuilder,
+} from "discord.js";
+import type {
+	ActionRowNode,
+	ButtonNode,
+	ContainerNode,
+	DjsxNode,
+	FileNode,
+	MediaGalleryNode,
+	ModalNode,
+	SectionNode,
+	SeparatorNode,
+	TextDisplayNode,
+	ThumbnailNode,
+	TopLevelNode,
+} from "./types";
+
+/**
+ * Top-level builder union returned by `render()`. Discord.js types
+ * `interaction.reply({ components })` to accept a wider set; we narrow to
+ * what's valid in a Components V2 message.
+ */
+export type ComponentBuilderArray = (
+	| ContainerBuilder
+	| TextDisplayBuilder
+	| SectionBuilder
+	| MediaGalleryBuilder
+	| SeparatorBuilder
+	| FileBuilder
+	| ActionRowBuilder<MessageActionRowComponentBuilder>
+)[];
+
+function buildButton(node: ButtonNode): ButtonBuilder {
+	return new ButtonBuilder(node.data as ConstructorParameters<typeof ButtonBuilder>[0]);
+}
+
+function buildThumbnail(node: ThumbnailNode): ThumbnailBuilder {
+	return new ThumbnailBuilder({
+		type: ComponentType.Thumbnail,
+		media: node.media,
+		...(node.description !== undefined && { description: node.description }),
+		...(node.spoiler !== undefined && { spoiler: node.spoiler }),
+	});
+}
+
+function buildTextDisplay(node: TextDisplayNode): TextDisplayBuilder {
+	return new TextDisplayBuilder({
+		type: ComponentType.TextDisplay,
+		content: node.content,
+		...(node.id !== undefined && { id: node.id }),
+	});
+}
+
+function buildSeparator(node: SeparatorNode): SeparatorBuilder {
+	return new SeparatorBuilder({
+		type: ComponentType.Separator,
+		...(node.id !== undefined && { id: node.id }),
+		...(node.divider !== undefined && { divider: node.divider }),
+		...(node.spacing !== undefined && { spacing: node.spacing }),
+	});
+}
+
+function buildFile(node: FileNode): FileBuilder {
+	return new FileBuilder({
+		type: ComponentType.File,
+		file: { url: node.url },
+		...(node.id !== undefined && { id: node.id }),
+		...(node.spoiler !== undefined && { spoiler: node.spoiler }),
+	});
+}
+
+function buildMediaGallery(node: MediaGalleryNode): MediaGalleryBuilder {
+	return new MediaGalleryBuilder({
+		type: ComponentType.MediaGallery,
+		items: node.items.map((item) => ({ ...item })),
+		...(node.id !== undefined && { id: node.id }),
+	});
+}
+
+function buildSection(node: SectionNode): SectionBuilder {
+	const builder = new SectionBuilder({
+		type: ComponentType.Section,
+		...(node.id !== undefined && { id: node.id }),
+	});
+	for (const child of node.children) {
+		const content = typeof child === "string" ? child : child.content;
+		const childId = typeof child === "string" ? undefined : child.id;
+		builder.addTextDisplayComponents(
+			new TextDisplayBuilder({
+				type: ComponentType.TextDisplay,
+				content,
+				...(childId !== undefined && { id: childId }),
+			})
+		);
+	}
+	const accessoryNode = node.accessory;
+	if (accessoryNode.$$kind === "thumbnail") {
+		builder.setThumbnailAccessory(buildThumbnail(accessoryNode));
+	} else {
+		builder.setButtonAccessory(buildButton(accessoryNode));
+	}
+	return builder;
+}
+
+function buildActionRow(node: ActionRowNode): ActionRowBuilder<MessageActionRowComponentBuilder> {
+	const row = new ActionRowBuilder<MessageActionRowComponentBuilder>();
+	if (node.id !== undefined) {
+		// Action row builders don't expose a setId method; the data field is
+		// writable for component identity purposes.
+		(row.data as { id?: number }).id = node.id;
+	}
+	for (const child of node.children) row.addComponents(buildButton(child));
+	return row;
+}
+
+function buildContainer(node: ContainerNode): ContainerBuilder {
+	const container = new ContainerBuilder({
+		type: ComponentType.Container,
+		...(node.id !== undefined && { id: node.id }),
+		...(node.spoiler !== undefined && { spoiler: node.spoiler }),
+	});
+	if (node.accentColor !== undefined) {
+		const color = Array.isArray(node.accentColor) ? (node.accentColor as unknown as [number, number, number]) : (node.accentColor as number);
+		container.setAccentColor(color);
+	}
+	for (const child of node.children) appendChildToContainer(container, child);
+	return container;
+}
+
+function appendChildToContainer(container: ContainerBuilder, child: DjsxNode): void {
+	switch (child.$$kind) {
+		case "fragment":
+			for (const inner of child.children) appendChildToContainer(container, inner);
+			return;
+		case "textDisplay":
+			container.addTextDisplayComponents(buildTextDisplay(child));
+			return;
+		case "section":
+			container.addSectionComponents(buildSection(child));
+			return;
+		case "mediaGallery":
+			container.addMediaGalleryComponents(buildMediaGallery(child));
+			return;
+		case "separator":
+			container.addSeparatorComponents(buildSeparator(child));
+			return;
+		case "file":
+			container.addFileComponents(buildFile(child));
+			return;
+		case "actionRow":
+			container.addActionRowComponents(buildActionRow(child));
+			return;
+		default:
+			throw new Error(`[djs-commands/jsx] <Container> received an unsupported child kind: ${(child as DjsxNode).$$kind}`);
+	}
+}
+
+/**
+ * Render a top-level JSX tree into a discord.js component array. Pass the
+ * result straight to `interaction.reply({ flags: MessageFlags.IsComponentsV2,
+ * components: render(tree) })`.
+ *
+ * Modals use `renderModal()` because their shape is different.
+ */
+export function render(tree: TopLevelNode | DjsxNode | readonly DjsxNode[]): ComponentBuilderArray {
+	const nodes = Array.isArray(tree) ? (tree as readonly DjsxNode[]) : [tree as DjsxNode];
+	const out: ComponentBuilderArray = [];
+	for (const node of nodes) appendTopLevel(out, node);
+	return out;
+}
+
+function appendTopLevel(out: ComponentBuilderArray, node: DjsxNode): void {
+	switch (node.$$kind) {
+		case "fragment":
+			for (const child of node.children) appendTopLevel(out, child);
+			return;
+		case "container":
+			out.push(buildContainer(node));
+			return;
+		case "textDisplay":
+			out.push(buildTextDisplay(node));
+			return;
+		case "section":
+			out.push(buildSection(node));
+			return;
+		case "mediaGallery":
+			out.push(buildMediaGallery(node));
+			return;
+		case "separator":
+			out.push(buildSeparator(node));
+			return;
+		case "file":
+			out.push(buildFile(node));
+			return;
+		case "actionRow":
+			out.push(buildActionRow(node));
+			return;
+		default:
+			throw new Error(`[djs-commands/jsx] render() received an invalid top-level node: ${(node as DjsxNode).$$kind}`);
+	}
+}
+
+/**
+ * Render a `<Modal>` JSX tree into a `ModalBuilder`. Pass the result to
+ * `interaction.showModal(...)` directly — discord.js accepts the builder.
+ *
+ * Modal children become `LabelBuilder`s wrapping the actual interactive
+ * component (TextInput, RadioGroup, CheckboxGroup). Action rows in modals
+ * are deprecated by Discord, so we always emit Labels.
+ *
+ * Accepts `DjsxNode` for symmetry with `render()` — but only `ModalNode` is
+ * meaningful, so anything else throws.
+ */
+export function renderModal(modal: ModalNode | DjsxNode): ModalBuilder {
+	if (modal.$$kind !== "modal") {
+		throw new Error(`[djs-commands/jsx] renderModal() expected a <Modal> root; got ${modal.$$kind}`);
+	}
+	const builder = new ModalBuilder().setCustomId(modal.customId).setTitle(modal.title);
+	const labels = modal.children.map(buildModalLabel);
+	if (labels.length > 0) builder.addLabelComponents(...labels);
+	return builder;
+}
+
+function buildModalLabel(child: ModalNode["children"][number]): LabelBuilder {
+	switch (child.$$kind) {
+		case "textInput": {
+			// `<TextInput label="...">` flows through as `data.label` per the
+			// Components V2 shape — Discord wraps the input in a Label
+			// internally, so we mirror that with a LabelBuilder here.
+			const labelText = child.data.label ?? "";
+			const builder = new LabelBuilder().setLabel(labelText).setTextInputComponent(new TextInputBuilder(child.data));
+			return builder;
+		}
+		case "radioGroup": {
+			const builder = new LabelBuilder().setLabel(child.label);
+			if (child.description !== undefined) builder.setDescription(child.description);
+			builder.setRadioGroupComponent({
+				type: ComponentType.RadioGroup,
+				custom_id: child.customId,
+				options: [...child.options],
+				...(child.required !== undefined && { required: child.required }),
+			});
+			return builder;
+		}
+		case "checkboxGroup": {
+			const builder = new LabelBuilder().setLabel(child.label);
+			if (child.description !== undefined) builder.setDescription(child.description);
+			builder.setCheckboxGroupComponent({
+				type: ComponentType.CheckboxGroup,
+				custom_id: child.customId,
+				options: [...child.options],
+				...(child.minValues !== undefined && { min_values: child.minValues }),
+				...(child.maxValues !== undefined && { max_values: child.maxValues }),
+				...(child.required !== undefined && { required: child.required }),
+			});
+			return builder;
+		}
+		default:
+			throw new Error(`[djs-commands/jsx] <Modal> received an unsupported child kind: ${(child as DjsxNode).$$kind}`);
+	}
+}

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1,0 +1,149 @@
+/**
+ * Shared types for the @djs-commands/jsx runtime.
+ *
+ * Components V2 elements are represented as tagged plain objects ("nodes").
+ * `render()` walks the tree and produces actual discord.js builders.
+ *
+ * Why not lazy {type, props} like React? We don't need reconciliation, so
+ * components are just plain functions that return a normalized node. This
+ * keeps the runtime trivial (no scheduler, no fiber tree) and lets users
+ * mix JSX and the function-API fallback freely.
+ */
+
+import type {
+	APIButtonComponent,
+	APICheckboxGroupOption,
+	APIMediaGalleryItem,
+	APIRadioGroupOption,
+	APISeparatorComponent,
+	APITextInputComponent,
+	APIUnfurledMediaItem,
+} from "discord.js";
+
+export type Spacing = APISeparatorComponent["spacing"];
+
+export interface FragmentNode {
+	readonly $$kind: "fragment";
+	readonly children: readonly DjsxNode[];
+}
+
+export interface ContainerNode {
+	readonly $$kind: "container";
+	readonly accentColor?: number | readonly [number, number, number];
+	readonly spoiler?: boolean;
+	readonly id?: number;
+	readonly children: readonly DjsxNode[];
+}
+
+export interface SectionNode {
+	readonly $$kind: "section";
+	readonly id?: number;
+	readonly accessory: ButtonNode | ThumbnailNode;
+	readonly children: readonly (TextDisplayNode | string)[];
+}
+
+export interface TextDisplayNode {
+	readonly $$kind: "textDisplay";
+	readonly id?: number;
+	readonly content: string;
+}
+
+export interface MediaGalleryNode {
+	readonly $$kind: "mediaGallery";
+	readonly id?: number;
+	readonly items: readonly APIMediaGalleryItem[];
+}
+
+export interface SeparatorNode {
+	readonly $$kind: "separator";
+	readonly id?: number;
+	readonly divider?: boolean;
+	readonly spacing?: Spacing;
+}
+
+export interface FileNode {
+	readonly $$kind: "file";
+	readonly id?: number;
+	readonly url: string;
+	readonly spoiler?: boolean;
+}
+
+export interface ThumbnailNode {
+	readonly $$kind: "thumbnail";
+	readonly media: APIUnfurledMediaItem;
+	readonly description?: string;
+	readonly spoiler?: boolean;
+}
+
+export interface ActionRowNode {
+	readonly $$kind: "actionRow";
+	readonly id?: number;
+	readonly children: readonly ButtonNode[];
+}
+
+export interface ButtonNode {
+	readonly $$kind: "button";
+	readonly data: APIButtonComponent;
+}
+
+export interface TextInputNode {
+	readonly $$kind: "textInput";
+	readonly data: APITextInputComponent;
+}
+
+export interface RadioGroupNode {
+	readonly $$kind: "radioGroup";
+	readonly customId: string;
+	readonly label: string;
+	readonly description?: string;
+	readonly options: readonly APIRadioGroupOption[];
+	readonly required?: boolean;
+}
+
+export interface CheckboxGroupNode {
+	readonly $$kind: "checkboxGroup";
+	readonly customId: string;
+	readonly label: string;
+	readonly description?: string;
+	readonly options: readonly APICheckboxGroupOption[];
+	readonly minValues?: number;
+	readonly maxValues?: number;
+	readonly required?: boolean;
+}
+
+export interface ModalNode {
+	readonly $$kind: "modal";
+	readonly title: string;
+	readonly customId: string;
+	readonly children: readonly (TextInputNode | RadioGroupNode | CheckboxGroupNode)[];
+}
+
+/**
+ * Any node the JSX runtime may produce. Strings are accepted in a few specific
+ * places (e.g. as `<TextDisplay>` children) and are treated as the `content`
+ * field there.
+ */
+export type DjsxNode =
+	| FragmentNode
+	| ContainerNode
+	| SectionNode
+	| TextDisplayNode
+	| MediaGalleryNode
+	| SeparatorNode
+	| FileNode
+	| ThumbnailNode
+	| ActionRowNode
+	| ButtonNode
+	| TextInputNode
+	| RadioGroupNode
+	| CheckboxGroupNode
+	| ModalNode;
+
+/**
+ * The set of nodes that can sit at the top level of a `<Container>` or be
+ * passed directly to `render()`.
+ */
+export type TopLevelNode = ContainerNode | SectionNode | TextDisplayNode | MediaGalleryNode | SeparatorNode | FileNode | ActionRowNode | FragmentNode;
+
+/** Children helpers — JSX runtime collapses single-child to a non-array. */
+export type Children<T> = T | readonly T[];

--- a/packages/jsx/tsconfig.build.json
+++ b/packages/jsx/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.test-d.ts", "**/*.test-d.tsx"]
+}

--- a/packages/jsx/tsconfig.json
+++ b/packages/jsx/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "@djs-commands/tsconfig/library.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"noEmit": true,
+		"jsx": "react-jsx",
+		"jsxImportSource": "@djs-commands/jsx",
+		"types": ["bun"],
+		"paths": {
+			"@djs-commands/jsx/jsx-runtime": ["./src/jsx-runtime.ts"],
+			"@djs-commands/jsx/jsx-dev-runtime": ["./src/jsx-dev-runtime.ts"]
+		}
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

- New workspace package `@djs-commands/jsx`: custom JSX runtime (`jsx`, `jsxs`, `Fragment`) + Components V2 components (Container, Section, TextDisplay, MediaGallery, Separator, File, Thumbnail, ActionRow, Button, Modal, TextInput, RadioGroup, CheckboxGroup). `render()` and `renderModal()` produce real discord.js builders.
- Function-API fallback re-exported from `@djs-commands/core` (`container()`, `section()`, `button()`, `modal()`, …) for projects that can't enable a JSX pragma. Both APIs return the same discord.js builders, so users can mix and match.
- New `examples/components-v2-showcase` workspace exercising every layout primitive plus a follow-up modal.
- Replaced the Components V2 docs page with real content + side-by-side JSX-vs-functions examples.

Closes #64.

## API tradeoff: JSX vs function fallback

`@djs-commands/jsx` opts you into the automatic JSX transform via `jsxImportSource`. Pros: declarative composition, JSX-native conditionals/maps, IDE auto-import works on tag names. Cons: needs a JSX-capable toolchain (TS, Bun, ESBuild, SWC — all support it natively).

`@djs-commands/core`'s function fallback (`container()`, `section()`, …) is plain TypeScript with the same prop shapes and same builder output. Pros: zero pragma config, works in any TS/JS project. Cons: slightly noisier.

Both produce identical `discord.js` builder objects, so a function-built `container()` can be passed into the same `interaction.reply({ flags: MessageFlags.IsComponentsV2, components })` array as a JSX-rendered tree.

## In scope

- All Components V2 layout components (Container, Section, TextDisplay, MediaGallery, Separator, File, Thumbnail).
- All form components: ActionRow, Button (Primary/Secondary/Success/Danger/Link/Premium), Modal, TextInput, RadioGroup, CheckboxGroup. discord.js 14.26 already exposes `RadioGroupBuilder` and `CheckboxGroupBuilder` via `@discordjs/builders` 1.14, so we use the real builders rather than emitting raw JSON.
- `Fragment` flattening at any tree depth.
- Type tests for prop shapes + a JSX smoke test (`*.test-d.tsx`) confirming the runtime resolution works end-to-end.

## Deferred

- Interaction routing for `<Button customId="..." />` (typed handlers wired into the dispatcher) — that's the next slice.
- A `Checkbox` component (singular, not the group) — Discord exposes `APICheckboxComponent` but it's only meaningful inside a `Label`, which isn't useful until interaction routing is in place. Easy to add later.

## Acceptance criteria

- [x] `@djs-commands/jsx` package installs from the workspace and exports a JSX runtime
- [x] Display components: `<Container>`, `<Section>`, `<TextDisplay>`, `<MediaGallery>`, `<Separator>`, `<File>`
- [x] Form components: `<ActionRow>`, `<Button>`, `<Modal>`, `<TextInput>`, `<RadioGroup>`, `<CheckboxGroup>`
- [x] `render(tree)` returns a builder array compatible with `interaction.reply({ flags: MessageFlags.IsComponentsV2, components })`
- [x] Function-API fallback exported from `@djs-commands/core` covering the same set
- [x] Type tests in `packages/jsx/src/components.test-d.ts` lock prop shapes for Container/Section/TextDisplay/Button/Modal/TextInput
- [x] 10 unit tests in `packages/jsx/src/render.test.ts` + 5 in `packages/core/src/components.test.ts` verifying builder shape via `.toJSON()`
- [x] `examples/components-v2-showcase` builds and typechecks
- [x] `apps/docs` `components-v2/index.mdx` updated with real content + side-by-side examples
- [x] `bun run ci` green from a fresh state (biome + 5-package typecheck + knip + tests)
- [x] Root `knip.json` adds entries for `packages/jsx`

## Local verification

```
rm -rf apps/docs/.source && bun run ci
```

Output: 67 files biome-checked, 7 typecheck tasks pass, knip clean, 38 core tests + 10 jsx tests pass.

## Test plan

- [ ] Reviewer confirms the JSX prop shapes match the Discord Components V2 documentation
- [ ] Reviewer evaluates the JSX vs function-API DX tradeoff (especially around modal forms)
- [ ] Reviewer confirms interaction routing is okay to defer to the next slice
- [ ] Reviewer verifies that mixing JSX-rendered and function-built components in a single `components` array works in their local bot