### PR TITLE
Slice 12: Redis cache adapter for cooldowns

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,23 @@
         "typescript": "catalog:",
       },
     },
+    "packages/adapter-redis": {
+      "name": "@djs-commands/adapter-redis",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@djs-commands/core": "workspace:*",
+        "@djs-commands/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "expect-type": "^1.2.0",
+        "ioredis": "^5.4.1",
+        "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "@djs-commands/core": "workspace:*",
+        "ioredis": "^5.0.0",
+      },
+    },
     "packages/core": {
       "name": "@djs-commands/core",
       "version": "0.0.0",
@@ -216,6 +233,8 @@
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
+    "@djs-commands/adapter-redis": ["@djs-commands/adapter-redis@workspace:packages/adapter-redis"],
+
     "@djs-commands/core": ["@djs-commands/core@workspace:packages/core"],
 
     "@djs-commands/jsx": ["@djs-commands/jsx@workspace:packages/jsx"],
@@ -291,6 +310,8 @@
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.0.5", "", { "peerDependencies": { "@tailwindcss/oxide": "^4.0.0", "tailwindcss": "^4.0.0" }, "optionalPeers": ["@tailwindcss/oxide", "tailwindcss"] }, "sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -682,6 +703,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
@@ -705,6 +728,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -858,6 +883,8 @@
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
+    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -925,6 +952,10 @@
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
     "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
 
@@ -1148,6 +1179,10 @@
 
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
@@ -1215,6 +1250,8 @@
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "srvx": ["srvx@0.11.15", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 

--- a/knip.json
+++ b/knip.json
@@ -8,6 +8,9 @@
 		"packages/jsx": {
 			"entry": ["src/index.ts", "src/jsx-runtime.ts", "src/jsx-dev-runtime.ts", "src/**/*.test.ts", "src/**/*.test-d.ts", "src/**/*.test-d.tsx"]
 		},
+		"packages/adapter-redis": {
+			"entry": ["src/index.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"]
+		},
 		"packages/tsconfig": {},
 		"examples/minimal": {},
 		"examples/components-v2-showcase": {},

--- a/packages/adapter-redis/README.md
+++ b/packages/adapter-redis/README.md
@@ -1,0 +1,82 @@
+# @djs-commands/adapter-redis
+
+Redis-backed [`CacheAdapter`](https://github.com/D3OXY/djs-commands) for
+[`@djs-commands/core`](https://github.com/D3OXY/djs-commands) cooldowns.
+
+> Distributed, TTL-native cooldown storage so sharded bots have consistent
+> cooldowns across processes. Uses `SET ... PX <ms>` for atomic
+> set-with-TTL — Redis stores the absolute expiry timestamp as the value
+> AND auto-evicts the key when the TTL elapses.
+
+## Install
+
+```bash
+bun add @djs-commands/adapter-redis @djs-commands/core ioredis
+```
+
+`ioredis` and `@djs-commands/core` are peer dependencies — install them in
+your app.
+
+## Usage
+
+Pass an `ioredis` instance (constructed however you like — connection URL,
+config object, sentinel, cluster) into `redisCacheAdapter`, then hand the
+returned adapter to your command handler.
+
+```ts
+import { Client, GatewayIntentBits } from "discord.js";
+import { createCommandHandler } from "@djs-commands/core";
+import { redisCacheAdapter } from "@djs-commands/adapter-redis";
+import Redis from "ioredis";
+
+const redis = new Redis(process.env.REDIS_URL!);
+const cache = redisCacheAdapter(redis);
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+createCommandHandler({ client, commands: [/* ... */], cache });
+
+await client.login(process.env.DISCORD_TOKEN);
+```
+
+### Multi-bot deployments: `keyPrefix`
+
+When several bots share a single Redis instance, give each one a distinct
+prefix to avoid collisions:
+
+```ts
+const cache = redisCacheAdapter(redis, { keyPrefix: "moderation-bot:" });
+```
+
+Every key the adapter reads or writes is prepended with this prefix. The
+default is `"djs-commands:"`.
+
+## How it works
+
+The adapter implements three methods from the `CacheAdapter` interface:
+
+| Method   | Redis command                              |
+| -------- | ------------------------------------------ |
+| `set`    | `SET <prefix><key> <expiresAt> PX <ttlMs>` |
+| `get`    | `GET <prefix><key>` then parse to number   |
+| `delete` | `DEL <prefix><key>`                        |
+
+`get` returns `null` for missing keys, non-numeric values, or timestamps in
+the past — defensive against clock skew.
+
+## Testing
+
+Unit tests run with a mocked `ioredis` and don't require a Redis instance.
+
+Integration tests run against a real Redis when `REDIS_URL` is set:
+
+```bash
+REDIS_URL=redis://localhost:6379 bun test
+```
+
+If `REDIS_URL` isn't set, the integration suite skips cleanly — CI without
+Redis will not fail. Locally you can spin one up with:
+
+```bash
+docker run --rm -p 6379:6379 redis:7-alpine
+```

--- a/packages/adapter-redis/package.json
+++ b/packages/adapter-redis/package.json
@@ -1,0 +1,58 @@
+{
+	"name": "@djs-commands/adapter-redis",
+	"version": "0.0.0",
+	"description": "Redis CacheAdapter for djs-commands cooldowns — distributed, TTL-native cooldown storage",
+	"author": "D3OXY <hello@deoxy.dev>",
+	"license": "MIT",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"dev": "tsc -p tsconfig.build.json --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "bun test"
+	},
+	"peerDependencies": {
+		"@djs-commands/core": "workspace:*",
+		"ioredis": "^5.0.0"
+	},
+	"devDependencies": {
+		"@djs-commands/core": "workspace:*",
+		"@djs-commands/tsconfig": "workspace:*",
+		"@types/bun": "catalog:",
+		"@types/node": "catalog:",
+		"expect-type": "^1.2.0",
+		"ioredis": "^5.4.1",
+		"typescript": "catalog:"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/D3OXY/djs-commands",
+		"directory": "packages/adapter-redis"
+	},
+	"keywords": [
+		"discord.js",
+		"discord",
+		"redis",
+		"ioredis",
+		"cache-adapter",
+		"cooldown"
+	]
+}

--- a/packages/adapter-redis/src/index.test-d.ts
+++ b/packages/adapter-redis/src/index.test-d.ts
@@ -1,0 +1,21 @@
+import type { CacheAdapter } from "@djs-commands/core";
+import { expectTypeOf } from "expect-type";
+import type { Redis } from "ioredis";
+import { type RedisCacheAdapterOptions, redisCacheAdapter } from "./redis-cache-adapter";
+
+// The factory must return a CacheAdapter exactly.
+declare const redis: Redis;
+expectTypeOf(redisCacheAdapter(redis)).toEqualTypeOf<CacheAdapter>();
+expectTypeOf(redisCacheAdapter(redis, { keyPrefix: "x:" })).toEqualTypeOf<CacheAdapter>();
+
+// Options shape.
+expectTypeOf<RedisCacheAdapterOptions>().toEqualTypeOf<{ keyPrefix?: string }>();
+
+// Method signatures.
+const adapter = redisCacheAdapter(redis);
+expectTypeOf(adapter.get).parameter(0).toEqualTypeOf<string>();
+expectTypeOf(adapter.get).returns.toEqualTypeOf<Promise<number | null>>();
+expectTypeOf(adapter.set).parameters.toEqualTypeOf<[key: string, expiresAt: number, ttlMs: number]>();
+expectTypeOf(adapter.set).returns.toEqualTypeOf<Promise<void>>();
+expectTypeOf(adapter.delete).parameter(0).toEqualTypeOf<string>();
+expectTypeOf(adapter.delete).returns.toEqualTypeOf<Promise<void>>();

--- a/packages/adapter-redis/src/index.ts
+++ b/packages/adapter-redis/src/index.ts
@@ -1,0 +1,2 @@
+export type { RedisCacheAdapterOptions } from "./redis-cache-adapter";
+export { redisCacheAdapter } from "./redis-cache-adapter";

--- a/packages/adapter-redis/src/redis-cache-adapter.test.ts
+++ b/packages/adapter-redis/src/redis-cache-adapter.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { Redis } from "ioredis";
+import { redisCacheAdapter } from "./redis-cache-adapter";
+
+// ---------------------------------------------------------------------------
+// Mock-based unit tests — always run, no Redis required.
+// Verify the adapter calls ioredis with the expected commands and arguments.
+// ---------------------------------------------------------------------------
+
+interface MockRedisCalls {
+	get: Array<[string]>;
+	set: Array<[string, string, string, number]>;
+	del: Array<[string]>;
+}
+
+function createMockRedis(initial: Record<string, string> = {}) {
+	const store = new Map<string, string>(Object.entries(initial));
+	const calls: MockRedisCalls = { get: [], set: [], del: [] };
+	const mock = {
+		get: async (key: string) => {
+			calls.get.push([key]);
+			return store.get(key) ?? null;
+		},
+		set: async (key: string, value: string, mode: string, ttl: number) => {
+			calls.set.push([key, value, mode, ttl]);
+			store.set(key, value);
+			return "OK";
+		},
+		del: async (key: string) => {
+			calls.del.push([key]);
+			const existed = store.has(key);
+			store.delete(key);
+			return existed ? 1 : 0;
+		},
+	};
+	return { mock: mock as unknown as Redis, calls, store };
+}
+
+describe("redisCacheAdapter (mocked)", () => {
+	test("set issues SET key value PX ttl with the default key prefix", async () => {
+		const { mock, calls } = createMockRedis();
+		const adapter = redisCacheAdapter(mock);
+		const expiresAt = Date.now() + 5_000;
+		await adapter.set("cd:test:user:1", expiresAt, 5_000);
+
+		expect(calls.set).toHaveLength(1);
+		expect(calls.set[0]).toEqual(["djs-commands:cd:test:user:1", expiresAt.toString(), "PX", 5_000]);
+	});
+
+	test("set with custom keyPrefix prepends the prefix", async () => {
+		const { mock, calls } = createMockRedis();
+		const adapter = redisCacheAdapter(mock, { keyPrefix: "bot-1:" });
+		const expiresAt = Date.now() + 1_000;
+		await adapter.set("cd:test:global", expiresAt, 1_000);
+
+		expect(calls.set[0]?.[0]).toBe("bot-1:cd:test:global");
+	});
+
+	test("get returns the parsed expiresAt timestamp", async () => {
+		const expiresAt = Date.now() + 10_000;
+		const { mock } = createMockRedis({
+			"djs-commands:cd:test:user:1": expiresAt.toString(),
+		});
+		const adapter = redisCacheAdapter(mock);
+
+		const result = await adapter.get("cd:test:user:1");
+		expect(result).toBe(expiresAt);
+	});
+
+	test("get returns null for missing keys", async () => {
+		const { mock } = createMockRedis();
+		const adapter = redisCacheAdapter(mock);
+
+		const result = await adapter.get("cd:missing:user:1");
+		expect(result).toBeNull();
+	});
+
+	test("get returns null when stored value is non-numeric (defensive)", async () => {
+		const { mock } = createMockRedis({
+			"djs-commands:cd:test:user:1": "not-a-number",
+		});
+		const adapter = redisCacheAdapter(mock);
+
+		const result = await adapter.get("cd:test:user:1");
+		expect(result).toBeNull();
+	});
+
+	test("get returns null when the stored expiresAt is in the past (defensive)", async () => {
+		const past = Date.now() - 1_000;
+		const { mock } = createMockRedis({
+			"djs-commands:cd:test:user:1": past.toString(),
+		});
+		const adapter = redisCacheAdapter(mock);
+
+		const result = await adapter.get("cd:test:user:1");
+		expect(result).toBeNull();
+	});
+
+	test("delete issues DEL with the prefixed key", async () => {
+		const { mock, calls } = createMockRedis({
+			"djs-commands:cd:test:user:1": (Date.now() + 1_000).toString(),
+		});
+		const adapter = redisCacheAdapter(mock);
+		await adapter.delete("cd:test:user:1");
+
+		expect(calls.del).toHaveLength(1);
+		expect(calls.del[0]).toEqual(["djs-commands:cd:test:user:1"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests against a real Redis. Skipped if no `REDIS_URL` env var
+// is set or if a connection cannot be established within ~2 seconds.
+// To run locally: `REDIS_URL=redis://localhost:6379 bun test`.
+// CI without Redis will not fail — the entire suite is `describe.skip`'d.
+// ---------------------------------------------------------------------------
+
+const REDIS_URL = process.env.REDIS_URL;
+
+async function tryConnect(url: string): Promise<Redis | null> {
+	const client = new Redis(url, {
+		lazyConnect: true,
+		connectTimeout: 2_000,
+		maxRetriesPerRequest: 1,
+		retryStrategy: () => null,
+	});
+	// Swallow background errors so an unreachable host doesn't crash the test
+	// process before our `.connect()` rejects.
+	client.on("error", () => {});
+	try {
+		await client.connect();
+		await client.ping();
+		return client;
+	} catch {
+		try {
+			client.disconnect();
+		} catch {
+			// ignore
+		}
+		return null;
+	}
+}
+
+const liveRedis = REDIS_URL ? await tryConnect(REDIS_URL) : null;
+const integration = liveRedis ? describe : describe.skip;
+
+integration("redisCacheAdapter (integration)", () => {
+	// liveRedis is non-null inside this block (describe.skip prevents callbacks
+	// from running otherwise), but TypeScript can't narrow that across closures.
+	const redis = liveRedis as Redis;
+
+	afterAll(async () => {
+		try {
+			const keys = await redis.keys("djs-commands-test:*");
+			if (keys.length > 0) await redis.del(...keys);
+			const otherKeys = await redis.keys("integration-prefix:*");
+			if (otherKeys.length > 0) await redis.del(...otherKeys);
+		} catch {
+			// ignore
+		}
+		redis.disconnect();
+	});
+
+	test("set then get returns the expiresAt value", async () => {
+		const adapter = redisCacheAdapter(redis, { keyPrefix: "djs-commands-test:" });
+		const expiresAt = Date.now() + 10_000;
+		await adapter.set("cd:set-get", expiresAt, 10_000);
+
+		const result = await adapter.get("cd:set-get");
+		expect(result).toBe(expiresAt);
+	});
+
+	test("get of a missing key returns null", async () => {
+		const adapter = redisCacheAdapter(redis, { keyPrefix: "djs-commands-test:" });
+		const result = await adapter.get("cd:does-not-exist");
+		expect(result).toBeNull();
+	});
+
+	test("set with a short TTL expires (Redis evicts the key)", async () => {
+		const adapter = redisCacheAdapter(redis, { keyPrefix: "djs-commands-test:" });
+		const expiresAt = Date.now() + 10;
+		await adapter.set("cd:short-ttl", expiresAt, 10);
+		await new Promise((r) => setTimeout(r, 60));
+		const result = await adapter.get("cd:short-ttl");
+		expect(result).toBeNull();
+	});
+
+	test("delete removes the key", async () => {
+		const adapter = redisCacheAdapter(redis, { keyPrefix: "djs-commands-test:" });
+		const expiresAt = Date.now() + 10_000;
+		await adapter.set("cd:to-delete", expiresAt, 10_000);
+		await adapter.delete("cd:to-delete");
+
+		const result = await adapter.get("cd:to-delete");
+		expect(result).toBeNull();
+	});
+
+	test("keyPrefix is prepended to keys (verified against raw GET)", async () => {
+		const adapter = redisCacheAdapter(redis, { keyPrefix: "integration-prefix:" });
+		const expiresAt = Date.now() + 10_000;
+		await adapter.set("scoped-key", expiresAt, 10_000);
+
+		const raw = await redis.get("integration-prefix:scoped-key");
+		expect(raw).toBe(expiresAt.toString());
+		// And nothing landed under the default prefix.
+		const wrong = await redis.get("djs-commands:scoped-key");
+		expect(wrong).toBeNull();
+	});
+});

--- a/packages/adapter-redis/src/redis-cache-adapter.ts
+++ b/packages/adapter-redis/src/redis-cache-adapter.ts
@@ -1,0 +1,57 @@
+import type { CacheAdapter } from "@djs-commands/core";
+import type { Redis } from "ioredis";
+
+const DEFAULT_KEY_PREFIX = "djs-commands:";
+
+export interface RedisCacheAdapterOptions {
+	/**
+	 * Prefix prepended to every Redis key written/read by this adapter.
+	 * Useful when multiple bots share a single Redis instance — give each bot
+	 * a distinct prefix to avoid key collisions.
+	 *
+	 * Defaults to `"djs-commands:"`.
+	 */
+	keyPrefix?: string;
+}
+
+/**
+ * Builds a {@link CacheAdapter} backed by Redis. Uses `SET ... PX <ms>` for
+ * atomic set-with-TTL writes — Redis stores the absolute expiry timestamp
+ * (ms) as the value AND auto-expires the key when the TTL elapses.
+ *
+ * @example
+ * ```ts
+ * import Redis from "ioredis";
+ * import { redisCacheAdapter } from "@djs-commands/adapter-redis";
+ * import { createCommandHandler } from "@djs-commands/core";
+ *
+ * const redis = new Redis(process.env.REDIS_URL!);
+ * const cache = redisCacheAdapter(redis, { keyPrefix: "my-bot:" });
+ *
+ * createCommandHandler({ client, commands, cache });
+ * ```
+ */
+export function redisCacheAdapter(redis: Redis, options: RedisCacheAdapterOptions = {}): CacheAdapter {
+	const keyPrefix = options.keyPrefix ?? DEFAULT_KEY_PREFIX;
+	const prefixed = (key: string): string => `${keyPrefix}${key}`;
+
+	return {
+		async get(key) {
+			const raw = await redis.get(prefixed(key));
+			if (raw === null) return null;
+			const expiresAt = Number(raw);
+			if (!Number.isFinite(expiresAt)) return null;
+			// Defensive: Redis should have already evicted expired keys via PX,
+			// but in the event of clock skew or race conditions, treat past
+			// timestamps as missing.
+			if (expiresAt <= Date.now()) return null;
+			return expiresAt;
+		},
+		async set(key, expiresAt, ttlMs) {
+			await redis.set(prefixed(key), expiresAt.toString(), "PX", ttlMs);
+		},
+		async delete(key) {
+			await redis.del(prefixed(key));
+		},
+	};
+}

--- a/packages/adapter-redis/tsconfig.build.json
+++ b/packages/adapter-redis/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test-d.ts"]
+}

--- a/packages/adapter-redis/tsconfig.json
+++ b/packages/adapter-redis/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@djs-commands/tsconfig/library.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"noEmit": true,
+		"types": ["bun"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds `@djs-commands/adapter-redis` — a Redis-backed implementation of the `CacheAdapter` interface that landed with slice #55 (cooldown engine). Lets sharded bots share cooldown state across processes via Redis.

Closes #63.

## Key implementation notes

- **Atomic set-with-TTL.** Uses `SET <key> <expiresAt> PX <ttlMs>` so the absolute expiry timestamp is stored as the value AND Redis auto-evicts the key when the TTL elapses. No extra `EXPIRE` round-trip, no race window between write-and-expire.
- **`keyPrefix` option (default `"djs-commands:"`).** Every key the adapter touches is prepended with this prefix so multi-bot deployments can share a Redis instance without colliding (`bot-1:cd:...`, `bot-2:cd:...`, etc.).
- **Defensive `get`.** Returns `null` if the key is missing, the stored value isn't a finite number, or the parsed `expiresAt` is in the past — guards against clock skew or a stale value sneaking through eviction.
- **Peer deps only on `@djs-commands/core` and `ioredis`.** No discord.js dependency — this package is purely a KV adapter.

## Test strategy

- **Mock-based unit tests (always run).** A small in-process fake of the `ioredis` surface (`get`/`set`/`del`) verifies the adapter emits the right Redis commands with the right args, including `PX` mode, prefix application, and defensive null returns.
- **Integration tests against a real Redis (opt-in).** Activated when `REDIS_URL` is set in the env. The suite tries to connect once at module load (with `connectTimeout: 2_000`, `maxRetriesPerRequest: 1`, and a no-op `retryStrategy`); if the connection fails, the entire `describe` block is `describe.skip`'d so CI without Redis stays green. Tests cover: round-trip `set`/`get`, missing keys, short-TTL expiration (Redis evicts), `delete`, and `keyPrefix` correctness verified with a raw `GET` against the prefixed key.
- **Type test (`src/index.test-d.ts`).** `expectTypeOf` asserts the factory returns exactly `CacheAdapter` and that each method's signature matches.

Per the slice criteria, `testcontainers` was deemed too brittle on macOS/CI runners for this small adapter — the env-var-or-skip pattern keeps CI deterministic while still enabling a one-line local run: `REDIS_URL=redis://localhost:6379 bun test`.

## Local verification

```sh
rm -rf apps/docs/.source && bun run ci
# biome check  -> clean (76 files)
# turbo typecheck -> 8/8 successful
# knip -> clean
# turbo test -> 5/5 successful, including 7 mocked unit tests + 6 integration tests skipped
```

## Test plan

- [x] `bun run ci` green from a fresh worktree
- [x] Mock-based tests cover SET (with PX), GET (with parse + defensive null), DEL, and keyPrefix application
- [x] Integration suite skips cleanly when REDIS_URL is unset
- [x] Integration suite skips cleanly when REDIS_URL points at an unreachable host (verified locally with `REDIS_URL=redis://127.0.0.1:9999`)
- [x] Type test asserts the factory returns `CacheAdapter` exactly
- [x] `knip.json` updated with the new workspace entry
- [ ] (Manual / follow-up) Run integration suite against a live Redis: `docker run --rm -p 6379:6379 redis:7-alpine` then `REDIS_URL=redis://localhost:6379 bun --filter @djs-commands/adapter-redis test`