### PR TITLE
Slice 7: Legacy prefix mode + Context Normalizer

### DIFF
--- a/examples/components-v2-showcase/src/index.tsx
+++ b/examples/components-v2-showcase/src/index.tsx
@@ -11,8 +11,11 @@ import { Client, Events, GatewayIntentBits, MessageFlags } from "discord.js";
 const welcome = defineCommand({
 	name: "welcome",
 	description: "Show off Components V2 (JSX runtime)",
-	run: async ({ interaction }) => {
-		await interaction.reply({
+	run: async (ctx) => {
+		// Components V2 messages require the interaction-level `flags` field,
+		// which only the slash dispatch path can deliver. Narrow on ctx.type.
+		if (ctx.type !== "slash") return;
+		await ctx.interaction.reply({
 			flags: MessageFlags.IsComponentsV2,
 			components: render(
 				<Container accentColor={0x5865f2}>

--- a/examples/minimal/src/echo-plugin.ts
+++ b/examples/minimal/src/echo-plugin.ts
@@ -19,8 +19,8 @@ export function echoPlugin(options: EchoPluginOptions = {}): PluginManifest {
 		options: {
 			message: { type: "string", description: "What to echo", required: true },
 		},
-		run: async ({ interaction, options: opts }) => {
-			await interaction.reply(`${prefix}${opts.message}`);
+		run: async (ctx) => {
+			await ctx.reply(`${prefix}${ctx.options.message}`);
 		},
 	});
 

--- a/examples/minimal/src/index.ts
+++ b/examples/minimal/src/index.ts
@@ -2,12 +2,16 @@ import { createCommandHandler, defineCommand } from "@djs-commands/core";
 import { Client, GatewayIntentBits } from "discord.js";
 import { echoPlugin } from "./echo-plugin";
 
+// One definition, two invocation styles: `/ping` (slash) and `!ping` (legacy).
+// `ctx.reply` works for both. Use `ctx.type` to narrow if you need raw access
+// to ctx.interaction or ctx.message.
 const ping = defineCommand({
 	name: "ping",
 	description: "Replies with pong",
 	cooldown: { type: "perUser", duration: 5_000 },
-	run: async ({ interaction }) => {
-		await interaction.reply("pong");
+	legacy: { enabled: true, aliases: ["p"] },
+	run: async (ctx) => {
+		await ctx.reply("pong");
 	},
 });
 
@@ -19,8 +23,8 @@ const shutdown = defineCommand({
 	description: "Owner-only command (demo)",
 	ownerOnly: true,
 	guildOnly: true,
-	run: async ({ interaction }) => {
-		await interaction.reply("Pretending to shut down…");
+	run: async (ctx) => {
+		await ctx.reply("Pretending to shut down…");
 	},
 });
 
@@ -30,7 +34,9 @@ if (!token) {
 	process.exit(1);
 }
 
-const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+const client = new Client({
+	intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
+});
 
 const handler = createCommandHandler({
 	client,
@@ -41,6 +47,7 @@ const handler = createCommandHandler({
 		process.env.BOT_OWNERS?.split(",")
 			.map((id) => id.trim())
 			.filter(Boolean) ?? [],
+	legacy: { enabled: true, defaultPrefix: "!" },
 });
 
 handler.ready.catch((err) => {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,0 +1,33 @@
+import type { ChatInputCommandInteraction, GuildMember, Message } from "discord.js";
+import type { CommandOptions, ResolveOptions } from "./options";
+import type { LegacyRunContext, SlashRunContext } from "./types";
+
+export function normalizeSlashContext<S extends CommandOptions>(interaction: ChatInputCommandInteraction, options: ResolveOptions<S>): SlashRunContext<S> {
+	return {
+		type: "slash",
+		interaction,
+		client: interaction.client,
+		author: interaction.user,
+		guild: interaction.guild,
+		member: interaction.member as GuildMember | null,
+		channel: interaction.channel,
+		channelId: interaction.channelId,
+		options,
+		reply: (content) => interaction.reply(content as Parameters<ChatInputCommandInteraction["reply"]>[0]),
+	};
+}
+
+export function normalizeLegacyContext<S extends CommandOptions>(message: Message, options: ResolveOptions<S>): LegacyRunContext<S> {
+	return {
+		type: "legacy",
+		message,
+		client: message.client,
+		author: message.author,
+		guild: message.guild,
+		member: message.member,
+		channel: message.channel,
+		channelId: message.channelId,
+		options,
+		reply: (content) => message.reply(content as Parameters<Message["reply"]>[0]),
+	};
+}

--- a/packages/core/src/cooldowns.test.ts
+++ b/packages/core/src/cooldowns.test.ts
@@ -1,13 +1,8 @@
 import { expect, test } from "bun:test";
-import type { ChatInputCommandInteraction } from "discord.js";
 import { type CacheAdapter, CooldownEngine } from "./cooldowns";
 import type { AnyCommand } from "./types";
 
-const fakeInteraction = (userId = "user-1", guildId: string | null = "guild-1") =>
-	({
-		user: { id: userId },
-		guildId,
-	}) as unknown as ChatInputCommandInteraction;
+const actor = (userId = "user-1", guildId: string | null = "guild-1") => ({ userId, guildId });
 
 const cmd = (overrides: Partial<AnyCommand> = {}): AnyCommand => ({
 	name: "test",
@@ -18,22 +13,22 @@ const cmd = (overrides: Partial<AnyCommand> = {}): AnyCommand => ({
 
 test("check returns null when the command has no cooldown configured", async () => {
 	const engine = new CooldownEngine();
-	const result = await engine.check(cmd(), fakeInteraction());
+	const result = await engine.check(cmd(), actor());
 	expect(result).toBeNull();
 });
 
 test("check returns null before start is called", async () => {
 	const engine = new CooldownEngine();
 	const c = cmd({ cooldown: { type: "perUser", duration: 1000 } });
-	const result = await engine.check(c, fakeInteraction());
+	const result = await engine.check(c, actor());
 	expect(result).toBeNull();
 });
 
 test("check returns the remaining ms while inside the cooldown window", async () => {
 	const engine = new CooldownEngine();
 	const c = cmd({ cooldown: { type: "perUser", duration: 5_000 } });
-	await engine.start(c, fakeInteraction());
-	const result = await engine.check(c, fakeInteraction());
+	await engine.start(c, actor());
+	const result = await engine.check(c, actor());
 	expect(result).not.toBeNull();
 	expect(result).toBeGreaterThan(0);
 	expect(result).toBeLessThanOrEqual(5_000);
@@ -42,18 +37,18 @@ test("check returns the remaining ms while inside the cooldown window", async ()
 test("check returns null after the cooldown expires", async () => {
 	const engine = new CooldownEngine();
 	const c = cmd({ cooldown: { type: "perUser", duration: 1 } });
-	await engine.start(c, fakeInteraction());
+	await engine.start(c, actor());
 	await new Promise((r) => setTimeout(r, 5));
-	const result = await engine.check(c, fakeInteraction());
+	const result = await engine.check(c, actor());
 	expect(result).toBeNull();
 });
 
 test("perUser: starting cooldown for one user does not block another user", async () => {
 	const engine = new CooldownEngine();
 	const c = cmd({ cooldown: { type: "perUser", duration: 5_000 } });
-	await engine.start(c, fakeInteraction("alice"));
-	const aliceBlocked = await engine.check(c, fakeInteraction("alice"));
-	const bobBlocked = await engine.check(c, fakeInteraction("bob"));
+	await engine.start(c, actor("alice"));
+	const aliceBlocked = await engine.check(c, actor("alice"));
+	const bobBlocked = await engine.check(c, actor("bob"));
 	expect(aliceBlocked).not.toBeNull();
 	expect(bobBlocked).toBeNull();
 });
@@ -61,9 +56,9 @@ test("perUser: starting cooldown for one user does not block another user", asyn
 test("perGuild: blocks every user in the same guild", async () => {
 	const engine = new CooldownEngine();
 	const c = cmd({ cooldown: { type: "perGuild", duration: 5_000 } });
-	await engine.start(c, fakeInteraction("alice", "guild-A"));
-	const sameGuildOther = await engine.check(c, fakeInteraction("bob", "guild-A"));
-	const otherGuild = await engine.check(c, fakeInteraction("alice", "guild-B"));
+	await engine.start(c, actor("alice", "guild-A"));
+	const sameGuildOther = await engine.check(c, actor("bob", "guild-A"));
+	const otherGuild = await engine.check(c, actor("alice", "guild-B"));
 	expect(sameGuildOther).not.toBeNull();
 	expect(otherGuild).toBeNull();
 });
@@ -71,10 +66,10 @@ test("perGuild: blocks every user in the same guild", async () => {
 test("perUserPerGuild: blocks user X in guild A but not user X in guild B", async () => {
 	const engine = new CooldownEngine();
 	const c = cmd({ cooldown: { type: "perUserPerGuild", duration: 5_000 } });
-	await engine.start(c, fakeInteraction("alice", "guild-A"));
-	const sameUserSameGuild = await engine.check(c, fakeInteraction("alice", "guild-A"));
-	const sameUserOtherGuild = await engine.check(c, fakeInteraction("alice", "guild-B"));
-	const otherUserSameGuild = await engine.check(c, fakeInteraction("bob", "guild-A"));
+	await engine.start(c, actor("alice", "guild-A"));
+	const sameUserSameGuild = await engine.check(c, actor("alice", "guild-A"));
+	const sameUserOtherGuild = await engine.check(c, actor("alice", "guild-B"));
+	const otherUserSameGuild = await engine.check(c, actor("bob", "guild-A"));
 	expect(sameUserSameGuild).not.toBeNull();
 	expect(sameUserOtherGuild).toBeNull();
 	expect(otherUserSameGuild).toBeNull();
@@ -83,9 +78,9 @@ test("perUserPerGuild: blocks user X in guild A but not user X in guild B", asyn
 test("global: blocks every user across all guilds", async () => {
 	const engine = new CooldownEngine();
 	const c = cmd({ cooldown: { type: "global", duration: 5_000 } });
-	await engine.start(c, fakeInteraction("alice", "guild-A"));
-	const sameUserSameGuild = await engine.check(c, fakeInteraction("alice", "guild-A"));
-	const otherUserOtherGuild = await engine.check(c, fakeInteraction("bob", "guild-B"));
+	await engine.start(c, actor("alice", "guild-A"));
+	const sameUserSameGuild = await engine.check(c, actor("alice", "guild-A"));
+	const otherUserOtherGuild = await engine.check(c, actor("bob", "guild-B"));
 	expect(sameUserSameGuild).not.toBeNull();
 	expect(otherUserOtherGuild).not.toBeNull();
 });
@@ -110,8 +105,8 @@ test("CacheAdapter: when provided, in-memory map is bypassed", async () => {
 
 	const engine = new CooldownEngine(adapter);
 	const c = cmd({ cooldown: { type: "perUser", duration: 5_000 } });
-	await engine.start(c, fakeInteraction());
-	const remaining = await engine.check(c, fakeInteraction());
+	await engine.start(c, actor());
+	const remaining = await engine.check(c, actor());
 
 	expect(setCalls).toBe(1);
 	expect(getCalls).toBe(1);
@@ -120,7 +115,7 @@ test("CacheAdapter: when provided, in-memory map is bypassed", async () => {
 
 test("start is a no-op when the command has no cooldown configured", async () => {
 	const engine = new CooldownEngine();
-	await engine.start(cmd(), fakeInteraction());
-	const result = await engine.check(cmd(), fakeInteraction());
+	await engine.start(cmd(), actor());
+	const result = await engine.check(cmd(), actor());
 	expect(result).toBeNull();
 });

--- a/packages/core/src/cooldowns.ts
+++ b/packages/core/src/cooldowns.ts
@@ -1,4 +1,3 @@
-import type { ChatInputCommandInteraction } from "discord.js";
 import type { AnyCommand } from "./types";
 
 export type CooldownType = "perUser" | "perGuild" | "perUserPerGuild" | "global";
@@ -7,6 +6,12 @@ export interface CooldownConfig {
 	type: CooldownType;
 	/** Duration in milliseconds */
 	duration: number;
+}
+
+/** Identifies the actor (and optionally the guild) for cooldown key derivation. */
+export interface CooldownActor {
+	userId: string;
+	guildId: string | null;
 }
 
 /**
@@ -29,14 +34,10 @@ export class CooldownEngine {
 		this.cache = cache;
 	}
 
-	/**
-	 * Returns the remaining cooldown in ms if the command is on cooldown for this
-	 * interaction's actor; null otherwise (no cooldown configured, never started,
-	 * or already expired).
-	 */
-	async check(command: AnyCommand, interaction: ChatInputCommandInteraction): Promise<number | null> {
+	/** Returns remaining ms if the command is on cooldown for this actor; null otherwise. */
+	async check(command: AnyCommand, actor: CooldownActor): Promise<number | null> {
 		if (!command.cooldown) return null;
-		const key = makeKey(command, interaction);
+		const key = makeKey(command, actor);
 		const expiresAt = await this.read(key);
 		if (expiresAt === null) return null;
 		const now = Date.now();
@@ -45,9 +46,9 @@ export class CooldownEngine {
 		return null;
 	}
 
-	async start(command: AnyCommand, interaction: ChatInputCommandInteraction): Promise<void> {
+	async start(command: AnyCommand, actor: CooldownActor): Promise<void> {
 		if (!command.cooldown) return;
-		const key = makeKey(command, interaction);
+		const key = makeKey(command, actor);
 		const expiresAt = Date.now() + command.cooldown.duration;
 		await this.write(key, expiresAt, command.cooldown.duration);
 	}
@@ -74,18 +75,17 @@ export class CooldownEngine {
 	}
 }
 
-function makeKey(command: AnyCommand, interaction: ChatInputCommandInteraction): string {
+function makeKey(command: AnyCommand, actor: CooldownActor): string {
 	const cooldown = command.cooldown;
 	if (!cooldown) throw new Error("makeKey called on a command without a cooldown");
-	const userId = interaction.user.id;
-	const guildId = interaction.guildId ?? "dm";
+	const guildId = actor.guildId ?? "dm";
 	switch (cooldown.type) {
 		case "perUser":
-			return `cd:${command.name}:user:${userId}`;
+			return `cd:${command.name}:user:${actor.userId}`;
 		case "perGuild":
 			return `cd:${command.name}:guild:${guildId}`;
 		case "perUserPerGuild":
-			return `cd:${command.name}:user:${userId}:guild:${guildId}`;
+			return `cd:${command.name}:user:${actor.userId}:guild:${guildId}`;
 		case "global":
 			return `cd:${command.name}:global`;
 	}

--- a/packages/core/src/dispatcher.test.ts
+++ b/packages/core/src/dispatcher.test.ts
@@ -5,6 +5,16 @@ import { Dispatcher } from "./dispatcher";
 const fakeInteraction = (commandName: string, optionValues: Record<string, unknown> = {}) =>
 	({
 		commandName,
+		user: { id: "user-1" },
+		guild: null,
+		guildId: null,
+		member: null,
+		channel: null,
+		channelId: "channel-1",
+		client: {} as unknown,
+		replied: false,
+		deferred: false,
+		reply: mock(async () => undefined),
 		options: {
 			getString: (name: string) => optionValues[name] ?? null,
 			getInteger: (name: string) => optionValues[name] ?? null,
@@ -51,7 +61,7 @@ test("registering a command with the same name overwrites the previous one", asy
 	expect(second).toHaveBeenCalledTimes(1);
 });
 
-test("dispatch extracts options from the interaction and passes them to run", async () => {
+test("dispatch extracts options from the interaction and passes them via ctx.options", async () => {
 	const dispatcher = new Dispatcher();
 	const run = mock(async (_ctx: unknown) => {});
 	dispatcher.register({
@@ -66,7 +76,7 @@ test("dispatch extracts options from the interaction and passes them to run", as
 	await dispatcher.dispatch(fakeInteraction("echo", { message: "hello" }));
 
 	expect(run).toHaveBeenCalledTimes(1);
-	expect(run.mock.calls[0]?.[0]).toMatchObject({ options: { message: "hello" } });
+	expect(run.mock.calls[0]?.[0]).toMatchObject({ options: { message: "hello" }, type: "slash" });
 });
 
 test("dispatch passes undefined for missing optional options", async () => {
@@ -96,4 +106,17 @@ test("dispatch passes empty options object when the command declares no schema",
 
 	expect(run).toHaveBeenCalledTimes(1);
 	expect(run.mock.calls[0]?.[0]).toMatchObject({ options: {} });
+});
+
+test("dispatch passes a unified ctx with reply/author/guild/channelId", async () => {
+	const dispatcher = new Dispatcher();
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({ name: "ping", description: "ping", run });
+
+	await dispatcher.dispatch(fakeInteraction("ping"));
+
+	const ctx = run.mock.calls[0]?.[0] as { type: string; channelId: string; reply: unknown };
+	expect(ctx?.type).toBe("slash");
+	expect(ctx?.channelId).toBe("channel-1");
+	expect(typeof ctx?.reply).toBe("function");
 });

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -1,8 +1,10 @@
-import { type ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { type ChatInputCommandInteraction, type GuildMember, type Message, MessageFlags } from "discord.js";
+import { normalizeLegacyContext, normalizeSlashContext } from "./context";
 import { type CacheAdapter, CooldownEngine } from "./cooldowns";
+import { parseLegacyArgs } from "./legacy-parser";
 import { extractOptions } from "./options";
 import type { AnyCommand } from "./types";
-import { type CanRunCommand, runValidatorChain, type Validator } from "./validators";
+import { type CanRunCommand, runValidatorChain, type Validator, type ValidatorContext, type ValidatorSource } from "./validators";
 
 interface DispatcherConfig {
 	botOwners: readonly string[];
@@ -13,6 +15,7 @@ interface DispatcherConfig {
 
 export class Dispatcher {
 	private readonly commands = new Map<string, AnyCommand>();
+	private readonly aliases = new Map<string, AnyCommand>();
 	private readonly config: DispatcherConfig;
 	private readonly cooldowns: CooldownEngine;
 
@@ -28,36 +31,108 @@ export class Dispatcher {
 
 	register(command: AnyCommand): void {
 		this.commands.set(command.name, command);
+		for (const alias of command.legacy?.aliases ?? []) {
+			this.aliases.set(alias, command);
+		}
 	}
 
 	async dispatch(interaction: ChatInputCommandInteraction): Promise<void> {
 		const command = this.commands.get(interaction.commandName);
 		if (!command) return;
 
-		const validation = await runValidatorChain(
-			{ interaction, command, botOwners: this.config.botOwners },
-			{ globalValidators: this.config.globalValidators, canRunCommand: this.config.canRunCommand }
-		);
+		const validatorCtx: ValidatorContext = {
+			command,
+			botOwners: this.config.botOwners,
+			user: interaction.user,
+			guild: interaction.guild,
+			member: interaction.member as GuildMember | null,
+			channelId: interaction.channelId,
+			source: { type: "slash", interaction },
+		};
+
+		const validation = await runValidatorChain(validatorCtx, {
+			globalValidators: this.config.globalValidators,
+			canRunCommand: this.config.canRunCommand,
+		});
 
 		if (!validation.ok) {
-			if (interaction.replied || interaction.deferred) return;
-			await interaction.reply({ content: validation.reason, flags: MessageFlags.Ephemeral });
+			await replyFailure(validatorCtx.source, validation.reason);
 			return;
 		}
 
-		const remaining = await this.cooldowns.check(command, interaction);
+		const actor = { userId: interaction.user.id, guildId: interaction.guildId };
+		const remaining = await this.cooldowns.check(command, actor);
 		if (remaining !== null) {
-			if (interaction.replied || interaction.deferred) return;
-			await interaction.reply({
-				content: `On cooldown — try again in ${(remaining / 1000).toFixed(1)}s.`,
-				flags: MessageFlags.Ephemeral,
-			});
+			await replyFailure(validatorCtx.source, formatCooldown(remaining));
 			return;
 		}
-
-		await this.cooldowns.start(command, interaction);
+		await this.cooldowns.start(command, actor);
 
 		const options = command.options ? extractOptions(interaction, command.options) : {};
-		await command.run({ interaction, options });
+		await command.run(normalizeSlashContext(interaction, options));
 	}
+
+	async dispatchMessage(message: Message, prefix: string, legacyDefaultEnabled: boolean): Promise<void> {
+		if (message.author.bot) return;
+		if (!message.content.startsWith(prefix)) return;
+		const stripped = message.content.slice(prefix.length).trim();
+		if (!stripped) return;
+		const tokens = stripped.split(/\s+/);
+		const name = tokens.shift();
+		if (!name) return;
+
+		const command = this.commands.get(name) ?? this.aliases.get(name);
+		if (!command) return;
+		const enabled = command.legacy?.enabled ?? legacyDefaultEnabled;
+		if (!enabled) return;
+
+		const validatorCtx: ValidatorContext = {
+			command,
+			botOwners: this.config.botOwners,
+			user: message.author,
+			guild: message.guild,
+			member: message.member,
+			channelId: message.channelId,
+			source: { type: "legacy", message },
+		};
+
+		const validation = await runValidatorChain(validatorCtx, {
+			globalValidators: this.config.globalValidators,
+			canRunCommand: this.config.canRunCommand,
+		});
+
+		if (!validation.ok) {
+			await replyFailure(validatorCtx.source, validation.reason);
+			return;
+		}
+
+		const actor = { userId: message.author.id, guildId: message.guildId };
+		const remaining = await this.cooldowns.check(command, actor);
+		if (remaining !== null) {
+			await replyFailure(validatorCtx.source, formatCooldown(remaining));
+			return;
+		}
+
+		const parsed = parseLegacyArgs(tokens, command.options, message);
+		if (!parsed.ok) {
+			await message.reply(parsed.error);
+			return;
+		}
+
+		await this.cooldowns.start(command, actor);
+		await command.run(normalizeLegacyContext(message, parsed.options));
+	}
+}
+
+function formatCooldown(remainingMs: number): string {
+	return `On cooldown — try again in ${(remainingMs / 1000).toFixed(1)}s.`;
+}
+
+async function replyFailure(source: ValidatorSource, reason: string): Promise<void> {
+	if (source.type === "slash") {
+		if (source.interaction.replied || source.interaction.deferred) return;
+		await source.interaction.reply({ content: reason, flags: MessageFlags.Ephemeral });
+		return;
+	}
+	await source.message.reply(reason);
 }

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -1,4 +1,4 @@
-import { type ApplicationCommandDataResolvable, type Client, Events, type Interaction } from "discord.js";
+import { type ApplicationCommandDataResolvable, type Client, Events, type Interaction, type Message } from "discord.js";
 import { Dispatcher } from "./dispatcher";
 import { buildOptionsData } from "./options";
 import type { AnyCommand, CommandHandler, CommandHandlerOptions } from "./types";
@@ -20,10 +20,19 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		dispatcher.register(command);
 	}
 
+	const legacyEnabled = options.legacy?.enabled === true;
+	const legacyPrefix = options.legacy?.defaultPrefix ?? "!";
+
 	const onInteraction = (interaction: Interaction) => {
 		if (!interaction.isChatInputCommand()) return;
 		dispatcher.dispatch(interaction).catch((err) => {
 			console.error("[djs-commands] Unhandled command error:", err);
+		});
+	};
+
+	const onMessage = (message: Message) => {
+		dispatcher.dispatchMessage(message, legacyPrefix, legacyEnabled).catch((err) => {
+			console.error("[djs-commands] Unhandled legacy command error:", err);
 		});
 	};
 
@@ -41,6 +50,9 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 
 	options.client.on(Events.InteractionCreate, onInteraction);
 	options.client.once(Events.ClientReady, onReady);
+	if (legacyEnabled) {
+		options.client.on(Events.MessageCreate, onMessage);
+	}
 
 	const bootPromise = (async () => {
 		for (const plugin of plugins) {
@@ -57,6 +69,9 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		destroy: async () => {
 			options.client.off(Events.InteractionCreate, onInteraction);
 			options.client.off(Events.ClientReady, onReady);
+			if (legacyEnabled) {
+				options.client.off(Events.MessageCreate, onMessage);
+			}
 			// Wait for boot to settle so we don't tear down mid-setup. Boot errors
 			// are surfaced via `ready`; destroy still tears plugins down.
 			await bootPromise.catch(() => {});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,9 +30,12 @@ export {
 	textInput,
 	thumbnail,
 } from "./components";
-export type { CacheAdapter, CooldownConfig, CooldownType } from "./cooldowns";
+export { normalizeLegacyContext, normalizeSlashContext } from "./context";
+export type { CacheAdapter, CooldownActor, CooldownConfig, CooldownType } from "./cooldowns";
 export { defineCommand } from "./define-command";
 export { createCommandHandler } from "./handler";
+export type { LegacyParseResult } from "./legacy-parser";
+export { parseLegacyArgs } from "./legacy-parser";
 export type {
 	AttachmentOption,
 	BooleanOption,
@@ -49,5 +52,16 @@ export type {
 	UserOption,
 } from "./options";
 export type { PluginManifest, PluginSetupContext } from "./plugin";
-export type { AnyCommand, Command, CommandHandler, CommandHandlerOptions, CommandRun, CommandRunContext } from "./types";
-export type { CanRunCommand, ValidationResult, Validator, ValidatorContext } from "./validators";
+export type {
+	AnyCommand,
+	Command,
+	CommandHandler,
+	CommandHandlerOptions,
+	CommandLegacyConfig,
+	CommandRun,
+	CommandRunContext,
+	HandlerLegacyConfig,
+	LegacyRunContext,
+	SlashRunContext,
+} from "./types";
+export type { CanRunCommand, ValidationResult, Validator, ValidatorContext, ValidatorSource } from "./validators";

--- a/packages/core/src/legacy-parser.test.ts
+++ b/packages/core/src/legacy-parser.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import type { Attachment, Message, User } from "discord.js";
+import { parseLegacyArgs } from "./legacy-parser";
+
+const fakeMessage = (overrides: { users?: Map<string, unknown>; roles?: Map<string, unknown>; channels?: Map<string, unknown>; attachment?: unknown } = {}) =>
+	({
+		client: { users: { cache: { get: (id: string) => overrides.users?.get(id) ?? null } } },
+		guild: {
+			channels: { cache: { get: (id: string) => overrides.channels?.get(id) ?? null } },
+			roles: { cache: { get: (id: string) => overrides.roles?.get(id) ?? null } },
+		},
+		attachments: { first: () => overrides.attachment ?? null },
+	}) as unknown as Message;
+
+test("returns empty options when schema is empty", () => {
+	const r = parseLegacyArgs([], {}, fakeMessage());
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.options).toEqual({});
+});
+
+test("parses a single required string", () => {
+	const r = parseLegacyArgs(["hello"], { msg: { type: "string", description: "x", required: true } }, fakeMessage());
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.options).toEqual({ msg: "hello" });
+});
+
+test("last string option consumes all remaining tokens", () => {
+	const r = parseLegacyArgs(
+		["alice", "hello", "world"],
+		{
+			user: { type: "string", description: "x", required: true },
+			body: { type: "string", description: "x", required: true },
+		},
+		fakeMessage()
+	);
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.options).toEqual({ user: "alice", body: "hello world" });
+});
+
+test("missing required argument fails with a descriptive error", () => {
+	const r = parseLegacyArgs([], { msg: { type: "string", description: "x", required: true } }, fakeMessage());
+	expect(r.ok).toBe(false);
+	if (!r.ok) expect(r.error).toMatch(/Missing required argument: msg/);
+});
+
+test("optional missing argument resolves to undefined", () => {
+	const r = parseLegacyArgs([], { msg: { type: "string", description: "x" } }, fakeMessage());
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.options.msg).toBeUndefined();
+});
+
+test("integer parses correctly and rejects non-numeric input", () => {
+	const ok = parseLegacyArgs(["42"], { n: { type: "integer", description: "n", required: true } }, fakeMessage());
+	expect(ok.ok).toBe(true);
+	if (ok.ok) expect(ok.options).toEqual({ n: 42 });
+
+	const bad = parseLegacyArgs(["nope"], { n: { type: "integer", description: "n", required: true } }, fakeMessage());
+	expect(bad.ok).toBe(false);
+});
+
+test("boolean accepts true/false/yes/no/1/0", () => {
+	for (const truthy of ["true", "yes", "y", "1", "on"]) {
+		const r = parseLegacyArgs([truthy], { b: { type: "boolean", description: "b", required: true } }, fakeMessage());
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.options.b).toBe(true);
+	}
+	for (const falsy of ["false", "no", "n", "0", "off"]) {
+		const r = parseLegacyArgs([falsy], { b: { type: "boolean", description: "b", required: true } }, fakeMessage());
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.options.b).toBe(false);
+	}
+});
+
+test("string choices: rejects values not in the choice set", () => {
+	const ok = parseLegacyArgs(["fast"], { mode: { type: "string", description: "m", choices: ["fast", "slow"], required: true } }, fakeMessage());
+	expect(ok.ok).toBe(true);
+
+	const bad = parseLegacyArgs(["medium"], { mode: { type: "string", description: "m", choices: ["fast", "slow"], required: true } }, fakeMessage());
+	expect(bad.ok).toBe(false);
+});
+
+test("user mention resolves to a User from client cache", () => {
+	const id = "123456789012345678";
+	const fakeUser = { id, tag: "Alice" } as unknown as User;
+	const r = parseLegacyArgs([`<@${id}>`], { who: { type: "user", description: "w", required: true } }, fakeMessage({ users: new Map([[id, fakeUser]]) }));
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.options.who).toBe(fakeUser);
+});
+
+test("user raw ID resolves to a User from client cache", () => {
+	const fakeUser = { id: "12345678901234567" } as unknown as User;
+	const r = parseLegacyArgs(
+		["12345678901234567"],
+		{ who: { type: "user", description: "w", required: true } },
+		fakeMessage({ users: new Map([["12345678901234567", fakeUser]]) })
+	);
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.options.who).toBe(fakeUser);
+});
+
+test("attachment option pulls from message.attachments without consuming tokens", () => {
+	const fakeAtt = { id: "att-1", url: "..." } as unknown as Attachment;
+	const r = parseLegacyArgs([], { file: { type: "attachment", description: "f", required: true } }, fakeMessage({ attachment: fakeAtt }));
+	expect(r.ok).toBe(true);
+	if (r.ok) expect(r.options.file).toBe(fakeAtt);
+});

--- a/packages/core/src/legacy-parser.ts
+++ b/packages/core/src/legacy-parser.ts
@@ -1,0 +1,140 @@
+import type { Message } from "discord.js";
+import type { CommandOption, CommandOptions, ResolveOptions } from "./options";
+
+export type LegacyParseResult<S extends CommandOptions> = { ok: true; options: ResolveOptions<S> } | { ok: false; error: string };
+
+const USER_MENTION = /^<@!?(\d+)>$/;
+const CHANNEL_MENTION = /^<#(\d+)>$/;
+const ROLE_MENTION = /^<@&(\d+)>$/;
+const RAW_ID = /^(\d{17,20})$/;
+const TRUE_VALUES = new Set(["true", "yes", "y", "1", "on"]);
+const FALSE_VALUES = new Set(["false", "no", "n", "0", "off"]);
+
+/**
+ * Parses positional argument tokens into a typed options object that matches
+ * a slash command's option schema. Tokens come from `message.content` already
+ * stripped of the prefix and command name (split by whitespace).
+ *
+ * Supported types: string, integer, number, boolean, user, channel, role,
+ * mentionable. Attachment options consume `message.attachments.first()` and
+ * do not advance the token cursor.
+ *
+ * Heuristic: when the LAST option is a string, it consumes all remaining
+ * tokens joined by spaces (so `!echo hello world` works for `{ message: string }`).
+ */
+export function parseLegacyArgs<S extends CommandOptions>(tokens: string[], schema: S | undefined, message: Message): LegacyParseResult<S> {
+	if (!schema || Object.keys(schema).length === 0) {
+		return { ok: true, options: {} as ResolveOptions<S> };
+	}
+
+	const result: Record<string, unknown> = {};
+	const queue = [...tokens];
+	const entries = Object.entries(schema);
+	const lastIndex = entries.length - 1;
+
+	for (let i = 0; i < entries.length; i++) {
+		const entry = entries[i];
+		if (!entry) continue;
+		const [name, opt] = entry;
+		const required = opt.required === true;
+
+		if (opt.type === "attachment") {
+			const att = message.attachments.first();
+			if (att) result[name] = att;
+			else if (required) return { ok: false, error: `Missing required attachment: ${name}` };
+			continue;
+		}
+
+		if (queue.length === 0) {
+			if (required) return { ok: false, error: `Missing required argument: ${name}` };
+			continue;
+		}
+
+		const isLast = i === lastIndex;
+		const raw = opt.type === "string" && isLast ? queue.splice(0).join(" ") : (queue.shift() ?? "");
+
+		const parsed = parseValue(opt, raw, message);
+		if (!parsed.ok) return { ok: false, error: `${name}: ${parsed.error}` };
+		result[name] = parsed.value;
+	}
+
+	return { ok: true, options: result as ResolveOptions<S> };
+}
+
+function parseValue(opt: CommandOption, raw: string, message: Message): { ok: true; value: unknown } | { ok: false; error: string } {
+	switch (opt.type) {
+		case "string": {
+			if (opt.choices && !opt.choices.includes(raw)) {
+				return { ok: false, error: `must be one of ${opt.choices.join(", ")}` };
+			}
+			return { ok: true, value: raw };
+		}
+		case "integer": {
+			const n = Number.parseInt(raw, 10);
+			if (Number.isNaN(n)) return { ok: false, error: `expected an integer, got "${raw}"` };
+			if (opt.choices && !opt.choices.includes(n)) {
+				return { ok: false, error: `must be one of ${opt.choices.join(", ")}` };
+			}
+			return { ok: true, value: n };
+		}
+		case "number": {
+			const n = Number.parseFloat(raw);
+			if (Number.isNaN(n)) return { ok: false, error: `expected a number, got "${raw}"` };
+			return { ok: true, value: n };
+		}
+		case "boolean": {
+			const lower = raw.toLowerCase();
+			if (TRUE_VALUES.has(lower)) return { ok: true, value: true };
+			if (FALSE_VALUES.has(lower)) return { ok: true, value: false };
+			return { ok: false, error: `expected true/false, got "${raw}"` };
+		}
+		case "user": {
+			const id = extractId(raw, USER_MENTION);
+			if (!id) return { ok: false, error: `expected a user mention or ID, got "${raw}"` };
+			const user = message.client.users.cache.get(id);
+			if (!user) return { ok: false, error: `user not found: ${id}` };
+			return { ok: true, value: user };
+		}
+		case "channel": {
+			const id = extractId(raw, CHANNEL_MENTION);
+			if (!id) return { ok: false, error: `expected a channel mention or ID, got "${raw}"` };
+			const channel = message.guild?.channels.cache.get(id);
+			if (!channel) return { ok: false, error: `channel not found: ${id}` };
+			return { ok: true, value: channel };
+		}
+		case "role": {
+			const id = extractId(raw, ROLE_MENTION);
+			if (!id) return { ok: false, error: `expected a role mention or ID, got "${raw}"` };
+			const role = message.guild?.roles.cache.get(id);
+			if (!role) return { ok: false, error: `role not found: ${id}` };
+			return { ok: true, value: role };
+		}
+		case "mentionable": {
+			const userId = extractId(raw, USER_MENTION);
+			if (userId) {
+				const user = message.client.users.cache.get(userId);
+				if (user) return { ok: true, value: user };
+			}
+			const roleId = extractId(raw, ROLE_MENTION);
+			if (roleId) {
+				const role = message.guild?.roles.cache.get(roleId);
+				if (role) return { ok: true, value: role };
+			}
+			const rawId = extractId(raw, RAW_ID);
+			if (rawId) {
+				const user = message.client.users.cache.get(rawId);
+				if (user) return { ok: true, value: user };
+				const role = message.guild?.roles.cache.get(rawId);
+				if (role) return { ok: true, value: role };
+			}
+			return { ok: false, error: `expected a user/role mention or ID, got "${raw}"` };
+		}
+		case "attachment":
+			return { ok: false, error: "attachment values come from message.attachments, not args" };
+	}
+}
+
+function extractId(raw: string, pattern: RegExp): string | null {
+	const match = pattern.exec(raw) ?? RAW_ID.exec(raw);
+	return match?.[1] ?? null;
+}

--- a/packages/core/src/plugin.test.ts
+++ b/packages/core/src/plugin.test.ts
@@ -10,6 +10,16 @@ const fakeChatInteraction = (commandName: string, optionValues: Record<string, u
 	({
 		isChatInputCommand: () => true,
 		commandName,
+		user: { id: "user-1" },
+		guild: null,
+		guildId: null,
+		member: null,
+		channel: null,
+		channelId: "channel-1",
+		client: {} as unknown,
+		replied: false,
+		deferred: false,
+		reply: mock(async () => undefined),
 		options: {
 			getString: (name: string) => optionValues[name] ?? null,
 			getInteger: (name: string) => optionValues[name] ?? null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,15 +1,40 @@
-import type { ChatInputCommandInteraction, Client, PermissionsString } from "discord.js";
+import type { ChatInputCommandInteraction, Client, Guild, GuildMember, Message, PermissionsString, TextBasedChannel, User } from "discord.js";
 import type { CacheAdapter, CooldownConfig } from "./cooldowns";
 import type { CommandOptions, ResolveOptions } from "./options";
 import type { PluginManifest } from "./plugin";
 import type { CanRunCommand, Validator } from "./validators";
 
-export interface CommandRunContext<S extends CommandOptions = Record<string, never>> {
-	interaction: ChatInputCommandInteraction;
+interface BaseRunContext<S extends CommandOptions = Record<string, never>> {
+	client: Client;
+	author: User;
+	guild: Guild | null;
+	member: GuildMember | null;
+	channel: TextBasedChannel | null;
+	channelId: string | null;
 	options: ResolveOptions<S>;
+	reply: (content: string | { content?: string; ephemeral?: boolean; [key: string]: unknown }) => Promise<unknown>;
 }
 
+export type SlashRunContext<S extends CommandOptions = Record<string, never>> = BaseRunContext<S> & {
+	type: "slash";
+	interaction: ChatInputCommandInteraction;
+};
+
+export type LegacyRunContext<S extends CommandOptions = Record<string, never>> = BaseRunContext<S> & {
+	type: "legacy";
+	message: Message;
+};
+
+export type CommandRunContext<S extends CommandOptions = Record<string, never>> = SlashRunContext<S> | LegacyRunContext<S>;
+
 export type CommandRun<S extends CommandOptions = Record<string, never>> = (ctx: CommandRunContext<S>) => void | Promise<void>;
+
+export interface CommandLegacyConfig {
+	/** Opt this command into legacy prefix invocation. Defaults to true when `legacy.enabled` on the handler is true. */
+	enabled?: boolean;
+	/** Alternative names that resolve to this command in legacy mode. */
+	aliases?: readonly string[];
+}
 
 export interface Command<S extends CommandOptions = Record<string, never>> {
 	name: string;
@@ -23,10 +48,18 @@ export interface Command<S extends CommandOptions = Record<string, never>> {
 	roles?: readonly string[];
 	validators?: readonly Validator[];
 	cooldown?: CooldownConfig;
+	legacy?: CommandLegacyConfig;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous command list erases the schema generic
 export type AnyCommand = Command<any>;
+
+export interface HandlerLegacyConfig {
+	/** Master switch — when false, the messageCreate listener is not attached. */
+	enabled: boolean;
+	/** Prefix used when no per-guild override exists. Storage-backed override lands in slice #59. */
+	defaultPrefix: string;
+}
 
 export interface CommandHandlerOptions {
 	client: Client;
@@ -36,6 +69,7 @@ export interface CommandHandlerOptions {
 	canRunCommand?: CanRunCommand;
 	plugins?: PluginManifest[];
 	cacheAdapter?: CacheAdapter;
+	legacy?: HandlerLegacyConfig;
 }
 
 export interface CommandHandler {

--- a/packages/core/src/validators.test.ts
+++ b/packages/core/src/validators.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
-import type { ChatInputCommandInteraction, GuildMember } from "discord.js";
+import type { ChatInputCommandInteraction, Guild, GuildMember, User } from "discord.js";
 import type { AnyCommand } from "./types";
-import { runValidatorChain, type Validator } from "./validators";
+import { runValidatorChain, type Validator, type ValidatorContext } from "./validators";
 
 const fakeMember = (perms: string[] = [], roleIds: string[] = []) =>
 	({
@@ -15,23 +15,20 @@ const fakeMember = (perms: string[] = [], roleIds: string[] = []) =>
 		},
 	}) as unknown as GuildMember;
 
-const fakeInteraction = (
-	overrides: Partial<{
-		commandName: string;
-		channelId: string;
-		user: { id: string };
-		guild: object | null;
-		member: GuildMember | null;
-	}> = {}
-) =>
-	({
-		commandName: "test",
-		channelId: "channel-1",
-		user: { id: "user-1" },
-		guild: null,
-		member: null,
-		...overrides,
-	}) as unknown as ChatInputCommandInteraction;
+const fakeUser = (id: string) => ({ id }) as unknown as User;
+const fakeGuild = (id: string) => ({ id }) as unknown as Guild;
+const fakeInteraction = () => ({}) as unknown as ChatInputCommandInteraction;
+
+const ctx = (overrides: Partial<ValidatorContext> = {}): ValidatorContext => ({
+	command: { name: "test", description: "test", run: async () => {} },
+	botOwners: [],
+	user: fakeUser("user-1"),
+	guild: null,
+	member: null,
+	channelId: "channel-1",
+	source: { type: "slash", interaction: fakeInteraction() },
+	...overrides,
+});
 
 const baseCommand = (overrides: Partial<AnyCommand> = {}): AnyCommand => ({
 	name: "test",
@@ -43,130 +40,131 @@ const baseCommand = (overrides: Partial<AnyCommand> = {}): AnyCommand => ({
 // ─── ownerOnly ──────────────────────────────────────────────────────────────
 
 test("ownerOnly: blocks non-owners", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({ user: { id: "regular" } }),
-		command: baseCommand({ ownerOnly: true }),
-		botOwners: ["owner-1"],
-	});
+	const result = await runValidatorChain(
+		ctx({
+			user: fakeUser("regular"),
+			botOwners: ["owner-1"],
+			command: baseCommand({ ownerOnly: true }),
+		})
+	);
 	expect(result.ok).toBe(false);
 });
 
 test("ownerOnly: passes for owners", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({ user: { id: "owner-1" } }),
-		command: baseCommand({ ownerOnly: true }),
-		botOwners: ["owner-1"],
-	});
+	const result = await runValidatorChain(
+		ctx({
+			user: fakeUser("owner-1"),
+			botOwners: ["owner-1"],
+			command: baseCommand({ ownerOnly: true }),
+		})
+	);
 	expect(result.ok).toBe(true);
 });
 
 test("ownerOnly: is a no-op when not set on the command", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction(),
-		command: baseCommand(),
-		botOwners: [],
-	});
+	const result = await runValidatorChain(ctx({ command: baseCommand() }));
 	expect(result.ok).toBe(true);
 });
 
 // ─── guildOnly ──────────────────────────────────────────────────────────────
 
 test("guildOnly: blocks DMs", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({ guild: null }),
-		command: baseCommand({ guildOnly: true }),
-		botOwners: [],
-	});
+	const result = await runValidatorChain(
+		ctx({
+			guild: null,
+			command: baseCommand({ guildOnly: true }),
+		})
+	);
 	expect(result.ok).toBe(false);
 });
 
 test("guildOnly: passes inside a guild", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({ guild: { id: "g1" } }),
-		command: baseCommand({ guildOnly: true }),
-		botOwners: [],
-	});
+	const result = await runValidatorChain(
+		ctx({
+			guild: fakeGuild("g1"),
+			command: baseCommand({ guildOnly: true }),
+		})
+	);
 	expect(result.ok).toBe(true);
 });
 
 // ─── channelOnly ────────────────────────────────────────────────────────────
 
 test("channelOnly: blocks disallowed channel", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({ channelId: "channel-99" }),
-		command: baseCommand({ channels: ["channel-1", "channel-2"] }),
-		botOwners: [],
-	});
+	const result = await runValidatorChain(
+		ctx({
+			channelId: "channel-99",
+			command: baseCommand({ channels: ["channel-1", "channel-2"] }),
+		})
+	);
 	expect(result.ok).toBe(false);
 });
 
 test("channelOnly: passes for allowed channel", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({ channelId: "channel-1" }),
-		command: baseCommand({ channels: ["channel-1"] }),
-		botOwners: [],
-	});
+	const result = await runValidatorChain(
+		ctx({
+			channelId: "channel-1",
+			command: baseCommand({ channels: ["channel-1"] }),
+		})
+	);
 	expect(result.ok).toBe(true);
 });
 
 // ─── permissions ────────────────────────────────────────────────────────────
 
 test("permissions: blocks when missing one of the required perms", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({
-			guild: { id: "g1" },
+	const result = await runValidatorChain(
+		ctx({
+			guild: fakeGuild("g1"),
 			member: fakeMember(["KickMembers"]),
-		}),
-		command: baseCommand({ permissions: ["KickMembers", "BanMembers"] }),
-		botOwners: [],
-	});
+			command: baseCommand({ permissions: ["KickMembers", "BanMembers"] }),
+		})
+	);
 	expect(result.ok).toBe(false);
 });
 
 test("permissions: passes when all required perms are present", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({
-			guild: { id: "g1" },
+	const result = await runValidatorChain(
+		ctx({
+			guild: fakeGuild("g1"),
 			member: fakeMember(["KickMembers", "BanMembers"]),
-		}),
-		command: baseCommand({ permissions: ["KickMembers", "BanMembers"] }),
-		botOwners: [],
-	});
+			command: baseCommand({ permissions: ["KickMembers", "BanMembers"] }),
+		})
+	);
 	expect(result.ok).toBe(true);
 });
 
 test("permissions: blocks in DM context", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({ guild: null }),
-		command: baseCommand({ permissions: ["KickMembers"] }),
-		botOwners: [],
-	});
+	const result = await runValidatorChain(
+		ctx({
+			guild: null,
+			command: baseCommand({ permissions: ["KickMembers"] }),
+		})
+	);
 	expect(result.ok).toBe(false);
 });
 
 // ─── roles ──────────────────────────────────────────────────────────────────
 
 test("roles: blocks when missing one of the required roles", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({
-			guild: { id: "g1" },
+	const result = await runValidatorChain(
+		ctx({
+			guild: fakeGuild("g1"),
 			member: fakeMember([], ["role-1"]),
-		}),
-		command: baseCommand({ roles: ["role-1", "role-2"] }),
-		botOwners: [],
-	});
+			command: baseCommand({ roles: ["role-1", "role-2"] }),
+		})
+	);
 	expect(result.ok).toBe(false);
 });
 
 test("roles: passes when all required roles are present", async () => {
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({
-			guild: { id: "g1" },
+	const result = await runValidatorChain(
+		ctx({
+			guild: fakeGuild("g1"),
 			member: fakeMember([], ["role-1", "role-2"]),
-		}),
-		command: baseCommand({ roles: ["role-1", "role-2"] }),
-		botOwners: [],
-	});
+			command: baseCommand({ roles: ["role-1", "role-2"] }),
+		})
+	);
 	expect(result.ok).toBe(true);
 });
 
@@ -178,11 +176,12 @@ test("chain short-circuits on first failure: built-in failure skips later valida
 		secondCalled = true;
 		return { ok: true };
 	};
-	const result = await runValidatorChain({
-		interaction: fakeInteraction({ guild: null }),
-		command: baseCommand({ guildOnly: true, validators: [second] }),
-		botOwners: [],
-	});
+	const result = await runValidatorChain(
+		ctx({
+			guild: null,
+			command: baseCommand({ guildOnly: true, validators: [second] }),
+		})
+	);
 	expect(result.ok).toBe(false);
 	expect(secondCalled).toBe(false);
 });
@@ -200,11 +199,10 @@ test("global validators run after built-ins", async () => {
 		return { ok: true };
 	};
 	const result = await runValidatorChain(
-		{
-			interaction: fakeInteraction({ guild: { id: "g1" } }),
+		ctx({
+			guild: fakeGuild("g1"),
 			command: baseCommand({ guildOnly: true, validators: [cmdV] }),
-			botOwners: [],
-		},
+		}),
 		{ globalValidators: [globalV] }
 	);
 	expect(result.ok).toBe(true);
@@ -213,14 +211,7 @@ test("global validators run after built-ins", async () => {
 
 test("a failing custom validator returns its reason", async () => {
 	const failing: Validator = () => ({ ok: false, reason: "custom failure" });
-	const result = await runValidatorChain(
-		{
-			interaction: fakeInteraction(),
-			command: baseCommand(),
-			botOwners: [],
-		},
-		{ globalValidators: [failing] }
-	);
+	const result = await runValidatorChain(ctx(), { globalValidators: [failing] });
 	expect(result.ok).toBe(false);
 	if (!result.ok) expect(result.reason).toBe("custom failure");
 });
@@ -228,50 +219,28 @@ test("a failing custom validator returns its reason", async () => {
 // ─── canRunCommand hook ────────────────────────────────────────────────────
 
 test("canRunCommand: returning false fails with default reason", async () => {
-	const result = await runValidatorChain(
-		{
-			interaction: fakeInteraction(),
-			command: baseCommand(),
-			botOwners: [],
-		},
-		{ canRunCommand: () => false }
-	);
+	const result = await runValidatorChain(ctx(), { canRunCommand: () => false });
 	expect(result.ok).toBe(false);
 });
 
 test("canRunCommand: returning a string uses it as the reason", async () => {
-	const result = await runValidatorChain(
-		{
-			interaction: fakeInteraction(),
-			command: baseCommand(),
-			botOwners: [],
-		},
-		{ canRunCommand: () => "rate limited" }
-	);
+	const result = await runValidatorChain(ctx(), { canRunCommand: () => "rate limited" });
 	expect(result.ok).toBe(false);
 	if (!result.ok) expect(result.reason).toBe("rate limited");
 });
 
 test("canRunCommand: returning true passes", async () => {
-	const result = await runValidatorChain(
-		{
-			interaction: fakeInteraction(),
-			command: baseCommand(),
-			botOwners: [],
-		},
-		{ canRunCommand: () => true }
-	);
+	const result = await runValidatorChain(ctx(), { canRunCommand: () => true });
 	expect(result.ok).toBe(true);
 });
 
 test("canRunCommand: runs after all other validators", async () => {
 	let hookCalled = false;
 	const result = await runValidatorChain(
-		{
-			interaction: fakeInteraction({ guild: null }),
+		ctx({
+			guild: null,
 			command: baseCommand({ guildOnly: true }),
-			botOwners: [],
-		},
+		}),
 		{
 			canRunCommand: () => {
 				hookCalled = true;

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -1,44 +1,47 @@
-import type { ChatInputCommandInteraction, GuildMember } from "discord.js";
+import type { ChatInputCommandInteraction, Guild, GuildMember, Message, User } from "discord.js";
 import type { AnyCommand } from "./types";
 
 export type ValidationResult = { ok: true } | { ok: false; reason: string };
 
+export type ValidatorSource = { type: "slash"; interaction: ChatInputCommandInteraction } | { type: "legacy"; message: Message };
+
 export interface ValidatorContext {
-	interaction: ChatInputCommandInteraction;
 	command: AnyCommand;
 	botOwners: readonly string[];
+	user: User;
+	guild: Guild | null;
+	member: GuildMember | null;
+	channelId: string;
+	source: ValidatorSource;
 }
 
 export type Validator = (ctx: ValidatorContext) => ValidationResult | Promise<ValidationResult>;
 
-export type CanRunCommand = (interaction: ChatInputCommandInteraction) => boolean | string | Promise<boolean | string>;
+export type CanRunCommand = (ctx: ValidatorContext) => boolean | string | Promise<boolean | string>;
 
-const ownerOnly: Validator = ({ command, interaction, botOwners }) => {
+const ownerOnly: Validator = ({ command, user, botOwners }) => {
 	if (!command.ownerOnly) return { ok: true };
-	if (botOwners.includes(interaction.user.id)) return { ok: true };
+	if (botOwners.includes(user.id)) return { ok: true };
 	return { ok: false, reason: "This command is restricted to bot owners." };
 };
 
-const guildOnly: Validator = ({ command, interaction }) => {
+const guildOnly: Validator = ({ command, guild }) => {
 	if (!command.guildOnly) return { ok: true };
-	if (interaction.guild) return { ok: true };
+	if (guild) return { ok: true };
 	return { ok: false, reason: "This command can only be used in a server." };
 };
 
-const channelOnly: Validator = ({ command, interaction }) => {
+const channelOnly: Validator = ({ command, channelId }) => {
 	const allowed = command.channels;
 	if (!allowed?.length) return { ok: true };
-	if (allowed.includes(interaction.channelId)) return { ok: true };
+	if (allowed.includes(channelId)) return { ok: true };
 	return { ok: false, reason: "This command isn't allowed in this channel." };
 };
 
-const permissions: Validator = ({ command, interaction }) => {
+const permissions: Validator = ({ command, guild, member }) => {
 	const required = command.permissions;
 	if (!required?.length) return { ok: true };
-	if (!interaction.guild) {
-		return { ok: false, reason: "Permission checks require a server context." };
-	}
-	const member = interaction.member as GuildMember | null;
+	if (!guild) return { ok: false, reason: "Permission checks require a server context." };
 	if (!member?.permissions || typeof member.permissions === "string") {
 		return { ok: false, reason: "Could not determine your permissions." };
 	}
@@ -50,13 +53,10 @@ const permissions: Validator = ({ command, interaction }) => {
 	return { ok: true };
 };
 
-const roles: Validator = ({ command, interaction }) => {
+const roles: Validator = ({ command, guild, member }) => {
 	const required = command.roles;
 	if (!required?.length) return { ok: true };
-	if (!interaction.guild) {
-		return { ok: false, reason: "Role checks require a server context." };
-	}
-	const member = interaction.member as GuildMember | null;
+	if (!guild) return { ok: false, reason: "Role checks require a server context." };
 	if (!member?.roles || !("cache" in member.roles)) {
 		return { ok: false, reason: "Could not determine your roles." };
 	}
@@ -85,7 +85,7 @@ export async function runValidatorChain(ctx: ValidatorContext, options: Validato
 	}
 
 	if (options.canRunCommand) {
-		const r = await options.canRunCommand(ctx.interaction);
+		const r = await options.canRunCommand(ctx);
 		if (r === false) return { ok: false, reason: "You can't run this command right now." };
 		if (typeof r === "string") return { ok: false, reason: r };
 	}


### PR DESCRIPTION
## Summary

Optional legacy-prefix mode driven by `legacy: { enabled, defaultPrefix }` on `createCommandHandler` and per-command `legacy: { enabled?, aliases? }` on `defineCommand`. A Context Normalizer maps slash interactions and message events into a unified `ctx` so a single `run` handler serves both modes.

Closes #58.

## Breaking change (pre-1.0)

`run` handlers now take a single `ctx` argument instead of `{ interaction, options }`:

```ts
// before
run: async ({ interaction, options }) => {
  await interaction.reply(options.message);
},

// after
run: async (ctx) => {
  await ctx.reply(ctx.options.message);
  // ctx.type === "slash" → ctx.interaction
  // ctx.type === "legacy" → ctx.message
},
```

`ctx.reply` works for both modes. Narrow on `ctx.type` for source-specific features (e.g., `ctx.interaction.deferReply()`, Components V2 `flags`).

## What changed

- **New module: `context.ts`** — `normalizeSlashContext` / `normalizeLegacyContext` produce a unified `BaseRunContext` (`reply`, `author`, `guild`, `member`, `channel`, `channelId`, `client`, `options`) plus a `type` discriminator and the raw source.
- **New module: `legacy-parser.ts`** — positional arg parser keyed off the slash schema. Supports `string`, `integer`, `number`, `boolean`, `user`, `channel`, `role`, `mentionable`, `attachment`. Heuristic: a *last* string option consumes all remaining tokens (so `!echo hello world` works for `{ msg: string }`).
- **`Command<S>`** extended with `legacy?: { enabled?, aliases? }`.
- **`CommandHandlerOptions`** extended with `legacy?: { enabled, defaultPrefix }`.
- **`ValidatorContext` refactored** — raw `interaction` replaced with unified fields (`user`, `guild`, `member`, `channelId`, `source`). Built-in validators rewritten against the new shape. `canRunCommand` now receives a `ValidatorContext`.
- **`CommandRunContext`** is now a discriminated union (`SlashRunContext` | `LegacyRunContext`).
- **`Dispatcher`** gains a `dispatchMessage(message, prefix, legacyDefaultEnabled)` path. Both paths build the ValidatorContext from a unified shape and run the same chain.
- **Cooldown engine** — `check`/`start` take an actor `{ userId, guildId }` (was `interaction`); works across both dispatch paths.
- **Handler** wires `messageCreate` when `legacy.enabled`.
- **12 new legacy-parser unit tests** + 1 new dispatcher test (verifies unified ctx shape).
- **`examples/minimal`**: `/ping` and `!ping` from one `defineCommand`. `echoPlugin` updated to `ctx.reply`.
- **`examples/components-v2-showcase`**: narrows on `ctx.type === "slash"` for Components V2 reply.

## Local verification

```
$ rm -rf apps/docs/.source && bun run ci
$ biome check                  ✓ 72 files
$ tsc (typecheck)              ✓ 7 tasks across 5 packages
$ knip                         ✓ clean
$ bun test                     ✓ 60/60 across 6 files
```

## Test plan
- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer skims the breaking-change pattern (run handler signature)
- [ ] Reviewer eyeballs the legacy parser heuristic (last-string-consumes-rest)
- [ ] Optional: clone, fill `examples/minimal/.env`, run `bun run --cwd examples/minimal dev`, confirm `/ping`, `!ping`, and `!p` (alias) all reply `pong`

## Future
- Persistent per-guild prefix override via Storage (slice #59)
- Quote-aware tokenization (currently splits by whitespace)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for legacy text-based commands alongside slash commands with configurable prefix and aliases
  * Unified command execution context for both slash and text command invocations
  * Commands can now optionally enable legacy mode with custom prefixes and command aliases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->