### PR TITLE
Slice 5: fs-autoloader + hot reload

### DIFF
--- a/examples/minimal/src/commands/ping.ts
+++ b/examples/minimal/src/commands/ping.ts
@@ -1,0 +1,11 @@
+import { defineCommand } from "@djs-commands/core";
+
+export default defineCommand({
+	name: "ping",
+	description: "Replies with pong",
+	cooldown: { type: "perUser", duration: 5_000 },
+	legacy: { enabled: true, aliases: ["p"] },
+	run: async (ctx) => {
+		await ctx.reply("pong");
+	},
+});

--- a/examples/minimal/src/commands/shutdown.ts
+++ b/examples/minimal/src/commands/shutdown.ts
@@ -1,0 +1,11 @@
+import { defineCommand } from "@djs-commands/core";
+
+export default defineCommand({
+	name: "shutdown",
+	description: "Owner-only command (demo)",
+	ownerOnly: true,
+	guildOnly: true,
+	run: async (ctx) => {
+		await ctx.reply("Pretending to shut down…");
+	},
+});

--- a/examples/minimal/src/index.ts
+++ b/examples/minimal/src/index.ts
@@ -1,32 +1,7 @@
-import { createCommandHandler, defineCommand } from "@djs-commands/core";
+import { fileURLToPath } from "node:url";
+import { createCommandHandler } from "@djs-commands/core";
 import { Client, GatewayIntentBits } from "discord.js";
 import { echoPlugin } from "./echo-plugin";
-
-// One definition, two invocation styles: `/ping` (slash) and `!ping` (legacy).
-// `ctx.reply` works for both. Use `ctx.type` to narrow if you need raw access
-// to ctx.interaction or ctx.message.
-const ping = defineCommand({
-	name: "ping",
-	description: "Replies with pong",
-	cooldown: { type: "perUser", duration: 5_000 },
-	legacy: { enabled: true, aliases: ["p"] },
-	run: async (ctx) => {
-		await ctx.reply("pong");
-	},
-});
-
-// Demonstrates validators: gated by ownerOnly + guildOnly.
-// The framework auto-replies ephemerally with the failure reason if
-// validation fails, so the run handler only sees authorized invocations.
-const shutdown = defineCommand({
-	name: "shutdown",
-	description: "Owner-only command (demo)",
-	ownerOnly: true,
-	guildOnly: true,
-	run: async (ctx) => {
-		await ctx.reply("Pretending to shut down…");
-	},
-});
 
 const token = process.env.DISCORD_TOKEN;
 if (!token) {
@@ -38,11 +13,14 @@ const client = new Client({
 	intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
 });
 
+// `commandDir` walks the directory recursively, dynamically importing each
+// module's default export. Hot reload is on automatically when NODE_ENV !==
+// "production". Existing commands continue to work via `commands: [...]`
+// alongside the directory loader.
 const handler = createCommandHandler({
 	client,
-	commands: [ping, shutdown],
+	commandDir: fileURLToPath(new URL("./commands", import.meta.url)),
 	plugins: [echoPlugin()],
-	// Comma-separated user IDs allowed to run owner-gated commands.
 	botOwners:
 		process.env.BOT_OWNERS?.split(",")
 			.map((id) => id.trim())

--- a/knip.json
+++ b/knip.json
@@ -12,7 +12,9 @@
 			"entry": ["src/index.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"]
 		},
 		"packages/tsconfig": {},
-		"examples/minimal": {},
+		"examples/minimal": {
+			"entry": ["src/index.ts", "src/commands/**/*.{ts,tsx}", "src/events/**/*.{ts,tsx}"]
+		},
 		"examples/components-v2-showcase": {},
 		"apps/docs": {
 			"entry": ["src/client.tsx", "src/ssr.tsx", "src/router.tsx", "src/start.ts", "src/routes/**/*.{ts,tsx}", "source.config.ts"]

--- a/packages/core/src/define-event.ts
+++ b/packages/core/src/define-event.ts
@@ -1,0 +1,11 @@
+import type { ClientEvents } from "discord.js";
+
+export interface EventDefinition<E extends keyof ClientEvents = keyof ClientEvents> {
+	event: E;
+	once?: boolean;
+	handler: (...args: ClientEvents[E]) => void | Promise<void>;
+}
+
+export function defineEvent<E extends keyof ClientEvents>(def: EventDefinition<E>): EventDefinition<E> {
+	return def;
+}

--- a/packages/core/src/fs-loader.test.ts
+++ b/packages/core/src/fs-loader.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadCommandsFromDir, loadEventsFromDir } from "./fs-loader";
+
+let dir: string;
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "djs-commands-fs-loader-"));
+});
+
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+const PING_SOURCE = `
+export default {
+	name: "ping",
+	description: "Replies with pong",
+	run: async () => {},
+};
+`;
+
+const ECHO_SOURCE = `
+export default {
+	name: "echo",
+	description: "Echoes",
+	run: async () => {},
+};
+`;
+
+const NOT_A_COMMAND = `
+export default { foo: "bar" };
+`;
+
+const NAMED_EXPORT = `
+export const command = {
+	name: "kick",
+	description: "Kick",
+	run: async () => {},
+};
+`;
+
+const READY_EVENT = `
+export default {
+	event: "clientReady",
+	once: true,
+	handler: () => {},
+};
+`;
+
+test("loadCommandsFromDir picks up files whose default export is a Command", async () => {
+	await writeFile(join(dir, "ping.ts"), PING_SOURCE);
+	await writeFile(join(dir, "echo.ts"), ECHO_SOURCE);
+
+	const commands = await loadCommandsFromDir(dir);
+
+	const names = commands.map((c) => c.name).sort();
+	expect(names).toEqual(["echo", "ping"]);
+});
+
+test("loadCommandsFromDir walks subdirectories recursively", async () => {
+	await mkdir(join(dir, "moderation"), { recursive: true });
+	await writeFile(join(dir, "moderation", "ping.ts"), PING_SOURCE);
+	await writeFile(join(dir, "echo.ts"), ECHO_SOURCE);
+
+	const commands = await loadCommandsFromDir(dir);
+
+	expect(commands.map((c) => c.name).sort()).toEqual(["echo", "ping"]);
+});
+
+test("loadCommandsFromDir ignores files that don't export a valid command", async () => {
+	await writeFile(join(dir, "ping.ts"), PING_SOURCE);
+	await writeFile(join(dir, "not-a-command.ts"), NOT_A_COMMAND);
+
+	const commands = await loadCommandsFromDir(dir);
+
+	expect(commands.map((c) => c.name)).toEqual(["ping"]);
+});
+
+test("loadCommandsFromDir falls back to a `command` named export when no default", async () => {
+	await writeFile(join(dir, "kick.ts"), NAMED_EXPORT);
+
+	const commands = await loadCommandsFromDir(dir);
+
+	expect(commands.map((c) => c.name)).toEqual(["kick"]);
+});
+
+test("loadCommandsFromDir returns an empty array when the directory doesn't exist", async () => {
+	const commands = await loadCommandsFromDir(join(dir, "does-not-exist"));
+	expect(commands).toEqual([]);
+});
+
+test("loadCommandsFromDir ignores non-source files (e.g. .json, .md)", async () => {
+	await writeFile(join(dir, "ping.ts"), PING_SOURCE);
+	await writeFile(join(dir, "config.json"), '{"foo": "bar"}');
+	await writeFile(join(dir, "README.md"), "# commands");
+
+	const commands = await loadCommandsFromDir(dir);
+
+	expect(commands.map((c) => c.name)).toEqual(["ping"]);
+});
+
+test("loadEventsFromDir picks up files whose default export is an EventDefinition", async () => {
+	await writeFile(join(dir, "ready.ts"), READY_EVENT);
+
+	const events = await loadEventsFromDir(dir);
+
+	expect(events).toHaveLength(1);
+	expect(events[0]?.event).toBe("clientReady");
+	expect(events[0]?.once).toBe(true);
+});
+
+test("loadEventsFromDir ignores command-shaped files", async () => {
+	await writeFile(join(dir, "ping.ts"), PING_SOURCE);
+	await writeFile(join(dir, "ready.ts"), READY_EVENT);
+
+	const events = await loadEventsFromDir(dir);
+
+	expect(events).toHaveLength(1);
+	expect(events[0]?.event).toBe("clientReady");
+});

--- a/packages/core/src/fs-loader.ts
+++ b/packages/core/src/fs-loader.ts
@@ -1,0 +1,107 @@
+import { type FSWatcher, watch } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { extname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { EventDefinition } from "./define-event";
+import type { AnyCommand } from "./types";
+
+const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mts", ".mjs", ".cjs"]);
+
+interface DirEntry {
+	name: string;
+	isDirectory(): boolean;
+	isFile(): boolean;
+}
+
+async function* walk(dir: string): AsyncIterable<string> {
+	let entries: DirEntry[];
+	try {
+		entries = (await readdir(dir, { withFileTypes: true })) as unknown as DirEntry[];
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			yield* walk(full);
+		} else if (entry.isFile() && SOURCE_EXTS.has(extname(entry.name))) {
+			yield full;
+		}
+	}
+}
+
+function isCommand(v: unknown): v is AnyCommand {
+	if (!v || typeof v !== "object") return false;
+	const c = v as Record<string, unknown>;
+	return typeof c.name === "string" && typeof c.description === "string" && typeof c.run === "function";
+}
+
+function isEvent(v: unknown): v is EventDefinition {
+	if (!v || typeof v !== "object") return false;
+	const e = v as Record<string, unknown>;
+	return typeof e.event === "string" && typeof e.handler === "function";
+}
+
+async function importModule(file: string, cacheBust?: number): Promise<unknown> {
+	const baseUrl = pathToFileURL(file).href;
+	const url = cacheBust !== undefined ? `${baseUrl}?v=${cacheBust}` : baseUrl;
+	const mod = (await import(url)) as Record<string, unknown>;
+	return mod.default ?? mod.command ?? mod.event ?? null;
+}
+
+export async function loadCommandsFromDir(dir: string): Promise<AnyCommand[]> {
+	const absolute = resolve(dir);
+	const commands: AnyCommand[] = [];
+	for await (const file of walk(absolute)) {
+		const candidate = await importModule(file);
+		if (isCommand(candidate)) commands.push(candidate);
+	}
+	return commands;
+}
+
+export async function loadEventsFromDir(dir: string): Promise<EventDefinition[]> {
+	const absolute = resolve(dir);
+	const events: EventDefinition[] = [];
+	for await (const file of walk(absolute)) {
+		const candidate = await importModule(file);
+		if (isEvent(candidate)) events.push(candidate);
+	}
+	return events;
+}
+
+export interface WatchHandle {
+	stop: () => void;
+}
+
+/**
+ * Watches a directory recursively for source-file changes and re-imports them
+ * with cache-busting query strings. Each callback fires after a successful
+ * re-import; the command may be `null` if the file was deleted or no longer
+ * exports a valid command.
+ */
+export function watchCommandsDir(dir: string, options: { onCommandChange?: (file: string, command: AnyCommand | null) => void }): WatchHandle {
+	const absolute = resolve(dir);
+	let watcher: FSWatcher;
+	try {
+		watcher = watch(absolute, { recursive: true }, (_event, filename) => {
+			if (!filename) return;
+			if (!SOURCE_EXTS.has(extname(filename))) return;
+			const file = join(absolute, filename);
+			importModule(file, Date.now())
+				.then((candidate) => {
+					if (isCommand(candidate)) {
+						options.onCommandChange?.(file, candidate);
+					} else {
+						options.onCommandChange?.(file, null);
+					}
+				})
+				.catch((err) => {
+					console.error(`[djs-commands] Failed to hot-reload ${file}:`, err);
+				});
+		});
+	} catch (err) {
+		console.error(`[djs-commands] Could not watch ${absolute}:`, err);
+		return { stop: () => {} };
+	}
+	return { stop: () => watcher.close() };
+}

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -1,11 +1,15 @@
 import { type ApplicationCommandDataResolvable, type Client, Events, type Interaction, type Message } from "discord.js";
+import type { EventDefinition } from "./define-event";
 import { Dispatcher } from "./dispatcher";
+import { loadCommandsFromDir, loadEventsFromDir, type WatchHandle, watchCommandsDir } from "./fs-loader";
 import { buildOptionsData } from "./options";
 import type { AnyCommand, CommandHandler, CommandHandlerOptions } from "./types";
 
 export function createCommandHandler(options: CommandHandlerOptions): CommandHandler {
 	const plugins = options.plugins ?? [];
-	const allCommands: AnyCommand[] = [...options.commands];
+	const dev = options.dev ?? process.env.NODE_ENV !== "production";
+
+	const allCommands: AnyCommand[] = [...(options.commands ?? [])];
 	for (const plugin of plugins) {
 		if (plugin.commands) allCommands.push(...plugin.commands);
 	}
@@ -16,6 +20,7 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		canRunCommand: options.canRunCommand,
 		cacheAdapter: options.cacheAdapter,
 	});
+
 	for (const command of allCommands) {
 		dispatcher.register(command);
 	}
@@ -54,7 +59,39 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		options.client.on(Events.MessageCreate, onMessage);
 	}
 
+	const loadedEventListeners: { event: string; handler: (...args: unknown[]) => void }[] = [];
+	let watchHandle: WatchHandle | null = null;
+
 	const bootPromise = (async () => {
+		// Load fs-discovered commands first so they're registered before plugin setup runs.
+		if (options.commandDir) {
+			const discovered = await loadCommandsFromDir(options.commandDir);
+			for (const command of discovered) {
+				allCommands.push(command);
+				dispatcher.register(command);
+			}
+		}
+
+		if (options.eventDir) {
+			const events = await loadEventsFromDir(options.eventDir);
+			for (const evt of events) {
+				registerEvent(options.client, evt, loadedEventListeners);
+			}
+		}
+
+		if (dev && options.commandDir) {
+			watchHandle = watchCommandsDir(options.commandDir, {
+				onCommandChange: (file, command) => {
+					if (!command) {
+						console.warn(`[djs-commands] ${file} changed but no longer exports a valid command`);
+						return;
+					}
+					dispatcher.register(command);
+					console.log(`[djs-commands] hot-reloaded ${command.name}`);
+				},
+			});
+		}
+
 		for (const plugin of plugins) {
 			if (!plugin.setup) continue;
 			try {
@@ -72,6 +109,10 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 			if (legacyEnabled) {
 				options.client.off(Events.MessageCreate, onMessage);
 			}
+			watchHandle?.stop();
+			for (const { event, handler } of loadedEventListeners) {
+				options.client.off(event, handler);
+			}
 			// Wait for boot to settle so we don't tear down mid-setup. Boot errors
 			// are surfaced via `ready`; destroy still tears plugins down.
 			await bootPromise.catch(() => {});
@@ -86,4 +127,18 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		},
 		ready: bootPromise,
 	};
+}
+
+function registerEvent(client: Client, evt: EventDefinition, listeners: { event: string; handler: (...args: unknown[]) => void }[]): void {
+	const handler = ((...args: unknown[]) => {
+		const result = (evt.handler as (...a: unknown[]) => void | Promise<void>)(...args);
+		if (result && typeof (result as Promise<void>).catch === "function") {
+			(result as Promise<void>).catch((err) => {
+				console.error(`[djs-commands] Event '${String(evt.event)}' handler error:`, err);
+			});
+		}
+	}) as (...args: unknown[]) => void;
+	if (evt.once) client.once(evt.event, handler);
+	else client.on(evt.event, handler);
+	listeners.push({ event: evt.event, handler });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,8 @@ export {
 export { normalizeLegacyContext, normalizeSlashContext } from "./context";
 export type { CacheAdapter, CooldownActor, CooldownConfig, CooldownType } from "./cooldowns";
 export { defineCommand } from "./define-command";
+export { defineEvent, type EventDefinition } from "./define-event";
+export { loadCommandsFromDir, loadEventsFromDir, watchCommandsDir } from "./fs-loader";
 export { createCommandHandler } from "./handler";
 export type { LegacyParseResult } from "./legacy-parser";
 export { parseLegacyArgs } from "./legacy-parser";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -63,7 +63,13 @@ export interface HandlerLegacyConfig {
 
 export interface CommandHandlerOptions {
 	client: Client;
-	commands: AnyCommand[];
+	commands?: AnyCommand[];
+	/** Directory to recursively load command files from. Each file's default export is registered if it looks like a Command. */
+	commandDir?: string;
+	/** Directory to recursively load event files from. Each file's default export is registered if it looks like an EventDefinition (see defineEvent). */
+	eventDir?: string;
+	/** Enable hot-reload of command files while the process runs. Defaults to true when NODE_ENV !== "production". */
+	dev?: boolean;
 	botOwners?: readonly string[];
 	validators?: readonly Validator[];
 	canRunCommand?: CanRunCommand;


### PR DESCRIPTION
## Summary

Default command/event loading via `commandDir` and `eventDir` on `createCommandHandler`. Recursively walks the directory, dynamically imports each source file, and registers any module whose default (or `command`/`event` named) export matches the shape. Explicit `commands: [...]` arrays continue to work and compose with the directory loader. Hot reload is on automatically when `NODE_ENV !== "production"`.

Closes #56.

## What changed

- **`fs-loader.ts`** (new) — `loadCommandsFromDir`, `loadEventsFromDir`, `watchCommandsDir`. The watcher uses cache-busting `?v=<timestamp>` query strings on dynamic imports so each reload pulls a fresh module.
- **`define-event.ts`** (new) — `defineEvent({ event, once?, handler })` typed against `keyof ClientEvents` so `handler` args are inferred from the event name.
- **`CommandHandlerOptions`** extended:
  - `commands?` is now optional (was required) — directory-only setups OK
  - `commandDir?`, `eventDir?` for recursive boot-time load
  - `dev?` defaults to `NODE_ENV !== "production"`, gates the watcher
- **`handler.ts`** wires the loader, the watcher (dev only), and event listener cleanup on `destroy()`.
- **8 unit tests** in `fs-loader.test.ts` using a real tmpdir fixture: default export, named `command`/`event` export, recursive walk, shape filtering, missing dir, non-source files.
- **`examples/minimal`**: `/ping` and `/shutdown` moved into `src/commands/{ping,shutdown}.ts`. `index.ts` switched to `commandDir`. `echoPlugin` still registered via `plugins: [...]`.
- **`knip.json`**: `examples/minimal` entry list now includes `src/commands/**` so knip doesn't flag dynamically-loaded files as unused.

## API preview

```ts
// src/commands/ping.ts
export default defineCommand({
	name: "ping",
	description: "...",
	run: async (ctx) => ctx.reply("pong"),
});

// src/index.ts
createCommandHandler({
	client,
	commandDir: fileURLToPath(new URL("./commands", import.meta.url)),
	eventDir: fileURLToPath(new URL("./events", import.meta.url)),
	// dev: true (default when NODE_ENV !== "production") → hot reload on save
});
```

## Local verification

```
$ rm -rf apps/docs/.source && bun run ci
$ biome check                  ✓ 84 files
$ tsc (typecheck)              ✓ 8 tasks (5 packages + 2 examples + docs)
$ knip                         ✓ clean
$ bun test                     ✓ 68/68 across 7 files
```

## Test plan
- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer skims the watcher's cache-bust trick (`?v=<timestamp>`) and the dev-mode default
- [ ] Optional: clone, run `bun run --cwd examples/minimal dev`, edit `examples/minimal/src/commands/ping.ts` reply text, save — confirm the next `/ping` shows the new text without a restart

## Future
- Caching/dedup of repeated cache-busted modules (currently leaks a small bit of memory per reload)
- Watch eventDir too (currently only commandDir is hot-reloadable)
- Quote-aware tokenization for legacy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event definitions for Discord.js client events with full type support
  * Commands and events can now be dynamically loaded from directories via `commandDir` and `eventDir` configuration
  * Hot-reload support for commands during development mode for faster iteration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->