### PR TITLE
Slice 8: Storage interface + Drizzle adapter (pilot)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,42 @@
         "typescript": "catalog:",
       },
     },
+    "examples/moderation-drizzle": {
+      "name": "moderation-drizzle",
+      "version": "0.0.0",
+      "dependencies": {
+        "@djs-commands/adapter-drizzle": "workspace:*",
+        "@djs-commands/core": "workspace:*",
+        "discord.js": "catalog:",
+        "drizzle-orm": "^0.36.4",
+        "pg": "^8.13.1",
+      },
+      "devDependencies": {
+        "@djs-commands/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "@types/pg": "^8.11.10",
+        "typescript": "catalog:",
+      },
+    },
+    "packages/adapter-drizzle": {
+      "name": "@djs-commands/adapter-drizzle",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@djs-commands/core": "workspace:*",
+        "@djs-commands/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "@types/pg": "^8.11.10",
+        "drizzle-orm": "^0.36.4",
+        "pg": "^8.13.1",
+        "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "@djs-commands/core": "workspace:*",
+        "drizzle-orm": "^0.36.0",
+      },
+    },
     "packages/adapter-redis": {
       "name": "@djs-commands/adapter-redis",
       "version": "0.0.0",
@@ -232,6 +268,8 @@
     "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
+
+    "@djs-commands/adapter-drizzle": ["@djs-commands/adapter-drizzle@workspace:packages/adapter-drizzle"],
 
     "@djs-commands/adapter-redis": ["@djs-commands/adapter-redis@workspace:packages/adapter-redis"],
 
@@ -629,6 +667,8 @@
 
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -758,6 +798,8 @@
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.36.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=3", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-1OZY3PXD7BR00Gl61UUOFihslDldfH4NFRH2MbP54Yxi0G/PKn4HfO65JYZ7c16DeP3SpM3Aw+VXVG9j6CRSXA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.349", "", {}, "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A=="],
 
@@ -1085,6 +1127,8 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "moderation-drizzle": ["moderation-drizzle@workspace:examples/moderation-drizzle"],
+
     "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
 
     "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
@@ -1141,6 +1185,22 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+
+    "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -1148,6 +1208,14 @@
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
@@ -1246,6 +1314,8 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
@@ -1356,6 +1426,8 @@
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "xmlbuilder2": ["xmlbuilder2@4.0.3", "", { "dependencies": { "@oozcitak/dom": "^2.0.2", "@oozcitak/infra": "^2.0.2", "@oozcitak/util": "^10.0.0", "js-yaml": "^4.1.1" } }, "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/examples/moderation-drizzle/.env.example
+++ b/examples/moderation-drizzle/.env.example
@@ -1,0 +1,2 @@
+DISCORD_TOKEN=your-bot-token-here
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres

--- a/examples/moderation-drizzle/README.md
+++ b/examples/moderation-drizzle/README.md
@@ -1,0 +1,21 @@
+# moderation-drizzle
+
+Example moderation bot using `@djs-commands/adapter-drizzle` for persistent state (per-guild legacy prefix overrides).
+
+## Quick start
+
+```bash
+# 1. Postgres
+docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres -d postgres:16
+
+# 2. Env
+cp .env.example .env  # fill in DISCORD_TOKEN
+
+# 3. Push the schema (creates the guild_prefix table)
+bunx drizzle-kit push --schema=node_modules/@djs-commands/adapter-drizzle/dist/schema.js --dialect=postgresql --url=$DATABASE_URL
+
+# 4. Run
+bun run dev
+```
+
+`/ban` and `/kick` work via slash; `!ban` and `!kick` work via prefix once `legacy.enabled` is set. Per-guild prefix overrides are stored in the `guild_prefix` table and resolved on every message (cache later).

--- a/examples/moderation-drizzle/package.json
+++ b/examples/moderation-drizzle/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "moderation-drizzle",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"description": "Moderation bot example using Drizzle/Postgres for persistent state",
+	"scripts": {
+		"dev": "bun run --watch src/index.ts",
+		"start": "bun run src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@djs-commands/adapter-drizzle": "workspace:*",
+		"@djs-commands/core": "workspace:*",
+		"discord.js": "catalog:",
+		"drizzle-orm": "^0.36.4",
+		"pg": "^8.13.1"
+	},
+	"devDependencies": {
+		"@djs-commands/tsconfig": "workspace:*",
+		"@types/bun": "catalog:",
+		"@types/node": "catalog:",
+		"@types/pg": "^8.11.10",
+		"typescript": "catalog:"
+	}
+}

--- a/examples/moderation-drizzle/src/index.ts
+++ b/examples/moderation-drizzle/src/index.ts
@@ -1,0 +1,65 @@
+import { drizzleStorage } from "@djs-commands/adapter-drizzle";
+import { createCommandHandler, defineCommand } from "@djs-commands/core";
+import { Client, GatewayIntentBits } from "discord.js";
+import { drizzle } from "drizzle-orm/node-postgres";
+import pg from "pg";
+
+const token = process.env.DISCORD_TOKEN;
+const databaseUrl = process.env.DATABASE_URL;
+if (!token || !databaseUrl) {
+	console.error("DISCORD_TOKEN and DATABASE_URL environment variables are required");
+	process.exit(1);
+}
+
+const pool = new pg.Pool({ connectionString: databaseUrl });
+const db = drizzle(pool);
+
+const ban = defineCommand({
+	name: "ban",
+	description: "Ban a user from the server",
+	guildOnly: true,
+	permissions: ["BanMembers"],
+	options: {
+		user: { type: "user", description: "Who to ban", required: true },
+		reason: { type: "string", description: "Why" },
+	},
+	run: async (ctx) => {
+		await ctx.reply(`Banned ${ctx.options.user.tag}${ctx.options.reason ? ` (${ctx.options.reason})` : ""} (demo).`);
+	},
+});
+
+const kick = defineCommand({
+	name: "kick",
+	description: "Kick a user from the server",
+	guildOnly: true,
+	permissions: ["KickMembers"],
+	options: {
+		user: { type: "user", description: "Who to kick", required: true },
+		reason: { type: "string", description: "Why" },
+	},
+	run: async (ctx) => {
+		await ctx.reply(`Kicked ${ctx.options.user.tag}${ctx.options.reason ? ` (${ctx.options.reason})` : ""} (demo).`);
+	},
+});
+
+const client = new Client({
+	intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
+});
+
+const handler = createCommandHandler({
+	client,
+	commands: [ban, kick],
+	storage: drizzleStorage(db),
+	legacy: { enabled: true, defaultPrefix: "!" },
+});
+
+handler.ready.catch((err) => {
+	console.error("Boot failed:", err);
+	process.exit(1);
+});
+
+client.once("clientReady", (c) => {
+	console.log(`Logged in as ${c.user.tag}`);
+});
+
+await client.login(token);

--- a/examples/moderation-drizzle/tsconfig.json
+++ b/examples/moderation-drizzle/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@djs-commands/tsconfig/base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"esModuleInterop": true,
+		"isolatedModules": true,
+		"resolveJsonModule": true,
+		"types": ["bun"]
+	},
+	"include": ["src/**/*"]
+}

--- a/knip.json
+++ b/knip.json
@@ -11,11 +11,15 @@
 		"packages/adapter-redis": {
 			"entry": ["src/index.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"]
 		},
+		"packages/adapter-drizzle": {
+			"entry": ["src/index.ts", "src/schema.ts", "src/**/*.test.ts"]
+		},
 		"packages/tsconfig": {},
 		"examples/minimal": {
-			"entry": ["src/index.ts", "src/commands/**/*.{ts,tsx}", "src/events/**/*.{ts,tsx}"]
+			"entry": ["src/commands/**/*.{ts,tsx}"]
 		},
 		"examples/components-v2-showcase": {},
+		"examples/moderation-drizzle": {},
 		"apps/docs": {
 			"entry": ["src/client.tsx", "src/ssr.tsx", "src/router.tsx", "src/start.ts", "src/routes/**/*.{ts,tsx}", "source.config.ts"]
 		}

--- a/packages/adapter-drizzle/README.md
+++ b/packages/adapter-drizzle/README.md
@@ -1,0 +1,67 @@
+# @djs-commands/adapter-drizzle
+
+Drizzle/Postgres `Storage` adapter for djs-commands. Persists framework state (currently per-guild legacy prefix overrides; more models in slice #62).
+
+## Install
+
+```bash
+bun add @djs-commands/core @djs-commands/adapter-drizzle drizzle-orm pg
+```
+
+## Usage
+
+1. Add the framework's schema to your Drizzle schema file:
+
+```ts
+// src/db/schema.ts
+export { guildPrefix } from "@djs-commands/adapter-drizzle/schema";
+// ...your own tables alongside
+```
+
+2. Run a migration so the table exists:
+
+```bash
+bunx drizzle-kit push
+```
+
+3. Wire it up:
+
+```ts
+import { drizzleStorage } from "@djs-commands/adapter-drizzle";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const db = drizzle(pool);
+
+createCommandHandler({
+  client,
+  storage: drizzleStorage(db),
+  legacy: { enabled: true, defaultPrefix: "!" },
+  // ...
+});
+```
+
+## Bring-your-own-table
+
+If you want a custom table name or share the table with other code, pass it explicitly:
+
+```ts
+import { GuildPrefixModel } from "@djs-commands/core";
+import { drizzleStorage, guildPrefix as defaultGuildPrefix } from "@djs-commands/adapter-drizzle";
+
+const myGuildPrefix = pgTable("my_prefix_table", { guildId: text("guild_id").primaryKey(), prefix: text("prefix").notNull() });
+
+drizzleStorage(db, { tables: { [GuildPrefixModel]: myGuildPrefix } });
+```
+
+## Local development
+
+Spin up Postgres for testing:
+
+```bash
+docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres bun test
+```
+
+The integration test suite skips cleanly if `DATABASE_URL` is unset or unreachable.

--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -1,0 +1,62 @@
+{
+	"name": "@djs-commands/adapter-drizzle",
+	"version": "0.0.0",
+	"description": "Drizzle Storage adapter for djs-commands — Postgres-backed persistent state",
+	"author": "D3OXY <hello@deoxy.dev>",
+	"license": "MIT",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./schema": {
+			"types": "./dist/schema.d.ts",
+			"import": "./dist/schema.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"dev": "tsc -p tsconfig.build.json --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "bun test"
+	},
+	"peerDependencies": {
+		"@djs-commands/core": "workspace:*",
+		"drizzle-orm": "^0.36.0"
+	},
+	"devDependencies": {
+		"@djs-commands/core": "workspace:*",
+		"@djs-commands/tsconfig": "workspace:*",
+		"@types/bun": "catalog:",
+		"@types/node": "catalog:",
+		"@types/pg": "^8.11.10",
+		"drizzle-orm": "^0.36.4",
+		"pg": "^8.13.1",
+		"typescript": "catalog:"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/D3OXY/djs-commands",
+		"directory": "packages/adapter-drizzle"
+	},
+	"keywords": [
+		"discord.js",
+		"discord",
+		"drizzle",
+		"postgres",
+		"storage-adapter"
+	]
+}

--- a/packages/adapter-drizzle/src/drizzle-storage.test.ts
+++ b/packages/adapter-drizzle/src/drizzle-storage.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, describe, test } from "bun:test";
+import { runStorageConformance } from "@djs-commands/core";
+import { sql } from "drizzle-orm";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import pg from "pg";
+import { drizzleStorage } from "./index";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+async function tryConnect(url: string): Promise<{ db: NodePgDatabase; pool: pg.Pool } | null> {
+	const pool = new pg.Pool({ connectionString: url, connectionTimeoutMillis: 3000, max: 1 });
+	try {
+		await pool.query("SELECT 1");
+		return { db: drizzle(pool), pool };
+	} catch {
+		await pool.end().catch(() => {});
+		return null;
+	}
+}
+
+const live = DATABASE_URL ? await tryConnect(DATABASE_URL) : null;
+
+if (live) {
+	const { db, pool } = live;
+
+	await db.execute(sql`
+		CREATE TABLE IF NOT EXISTS guild_prefix (
+			guild_id text PRIMARY KEY,
+			prefix text NOT NULL
+		)
+	`);
+
+	const storage = drizzleStorage(db);
+
+	describe("drizzleStorage (integration)", () => {
+		afterAll(async () => {
+			await pool.end().catch(() => {});
+		});
+
+		runStorageConformance("drizzle", async () => storage);
+	});
+} else {
+	describe.skip("drizzleStorage (DATABASE_URL not set or unreachable)", () => {
+		test("integration tests skipped", () => {});
+	});
+}

--- a/packages/adapter-drizzle/src/index.ts
+++ b/packages/adapter-drizzle/src/index.ts
@@ -1,0 +1,138 @@
+import { GuildPrefixModel, type Storage, type StorageFindOpts, type StorageWhere } from "@djs-commands/core";
+import { and, asc, count, desc, eq, type SQL } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { PgTable } from "drizzle-orm/pg-core";
+import { guildPrefix } from "./schema";
+
+export type { GuildPrefixRow } from "./schema";
+export { guildPrefix } from "./schema";
+
+interface ModelTables {
+	[GuildPrefixModel]: typeof guildPrefix;
+}
+
+interface DrizzleStorageOptions {
+	tables?: Partial<ModelTables>;
+}
+
+/**
+ * Returns a `Storage` implementation backed by Drizzle Postgres. Models the
+ * framework knows about (currently only GuildPrefix) are mapped to their
+ * Drizzle tables. Unknown models throw — adapters that don't recognize a
+ * model name should fail loud, not silently no-op.
+ *
+ * Bring-your-own-tables: pass `options.tables` to override defaults if you've
+ * customized table names or want to share a table object with other code.
+ */
+export function drizzleStorage(db: NodePgDatabase, options: DrizzleStorageOptions = {}): Storage {
+	const tables: ModelTables = {
+		[GuildPrefixModel]: options.tables?.[GuildPrefixModel] ?? guildPrefix,
+	};
+
+	const tableFor = (model: string): PgTable => {
+		const table = tables[model as keyof ModelTables];
+		if (!table) throw new Error(`@djs-commands/adapter-drizzle: unknown model "${model}"`);
+		return table;
+	};
+
+	const buildWhere = (table: PgTable, where: StorageWhere): SQL | undefined => {
+		const conditions: SQL[] = [];
+		for (const [key, value] of Object.entries(where)) {
+			const column = (table as unknown as Record<string, unknown>)[mapColumn(key)];
+			if (!column) throw new Error(`@djs-commands/adapter-drizzle: unknown column "${key}" on table for model`);
+			conditions.push(eq(column as never, value));
+		}
+		if (conditions.length === 0) return undefined;
+		return conditions.length === 1 ? conditions[0] : and(...conditions);
+	};
+
+	return {
+		async create(model, data) {
+			const table = tableFor(model);
+			const insertData = mapKeys(data as Record<string, unknown>);
+			const [row] = await db
+				.insert(table)
+				.values(insertData as never)
+				.returning();
+			return unmapKeys(row as Record<string, unknown>) as never;
+		},
+		async findOne(model, where) {
+			const table = tableFor(model);
+			const condition = buildWhere(table, where);
+			const rows = await db
+				.select()
+				.from(table)
+				.where(condition ?? undefined)
+				.limit(1);
+			const row = rows[0];
+			return row ? (unmapKeys(row as Record<string, unknown>) as never) : null;
+		},
+		async findMany(model, opts: StorageFindOpts = {}) {
+			const table = tableFor(model);
+			let q = db.select().from(table).$dynamic();
+			if (opts.where) {
+				const condition = buildWhere(table, opts.where);
+				if (condition) q = q.where(condition);
+			}
+			if (opts.orderBy) {
+				const column = (table as unknown as Record<string, unknown>)[mapColumn(opts.orderBy.field)];
+				if (column) {
+					q = q.orderBy(opts.orderBy.direction === "desc" ? desc(column as never) : asc(column as never));
+				}
+			}
+			if (opts.limit !== undefined) q = q.limit(opts.limit);
+			if (opts.offset !== undefined) q = q.offset(opts.offset);
+			const rows = await q;
+			return rows.map((r) => unmapKeys(r as Record<string, unknown>)) as never;
+		},
+		async update(model, where, data) {
+			const table = tableFor(model);
+			const condition = buildWhere(table, where);
+			const updateData = mapKeys(data as Record<string, unknown>);
+			const [row] = await db
+				.update(table)
+				.set(updateData as never)
+				.where(condition ?? undefined)
+				.returning();
+			if (!row) throw new Error(`@djs-commands/adapter-drizzle: no row matched update for model "${model}"`);
+			return unmapKeys(row as Record<string, unknown>) as never;
+		},
+		async delete(model, where) {
+			const table = tableFor(model);
+			const condition = buildWhere(table, where);
+			await db.delete(table).where(condition ?? undefined);
+		},
+		async count(model, where) {
+			const table = tableFor(model);
+			const condition = where ? buildWhere(table, where) : undefined;
+			const [row] = await db
+				.select({ value: count() })
+				.from(table)
+				.where(condition ?? undefined);
+			return row?.value ?? 0;
+		},
+	};
+}
+
+// Drizzle's TS-side column names use camelCase (guildId) while the database
+// uses snake_case (guild_id). The framework's `Where`/`Row` shapes are the
+// snake_case API names, so we translate at the boundary.
+function mapColumn(name: string): string {
+	if (name === "guild_id") return "guildId";
+	return name;
+}
+
+function mapKeys(obj: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(obj)) out[mapColumn(k)] = v;
+	return out;
+}
+
+function unmapKeys(obj: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(obj)) {
+		const reversed = k === "guildId" ? "guild_id" : k;
+		out[reversed] = v;
+	}
+	return out;
+}

--- a/packages/adapter-drizzle/src/schema.ts
+++ b/packages/adapter-drizzle/src/schema.ts
@@ -1,0 +1,9 @@
+import { pgTable, text } from "drizzle-orm/pg-core";
+
+/** Drizzle Postgres schema for the framework's GuildPrefix model. */
+export const guildPrefix = pgTable("guild_prefix", {
+	guildId: text("guild_id").primaryKey(),
+	prefix: text("prefix").notNull(),
+});
+
+export type GuildPrefixRow = typeof guildPrefix.$inferSelect;

--- a/packages/adapter-drizzle/tsconfig.build.json
+++ b/packages/adapter-drizzle/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test-d.ts"]
+}

--- a/packages/adapter-drizzle/tsconfig.json
+++ b/packages/adapter-drizzle/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@djs-commands/tsconfig/library.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"noEmit": true,
+		"types": ["bun"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules"]
+}

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -3,6 +3,7 @@ import type { EventDefinition } from "./define-event";
 import { Dispatcher } from "./dispatcher";
 import { loadCommandsFromDir, loadEventsFromDir, type WatchHandle, watchCommandsDir } from "./fs-loader";
 import { buildOptionsData } from "./options";
+import { getGuildPrefix } from "./storage";
 import type { AnyCommand, CommandHandler, CommandHandlerOptions } from "./types";
 
 export function createCommandHandler(options: CommandHandlerOptions): CommandHandler {
@@ -35,8 +36,21 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		});
 	};
 
+	const handleMessage = async (message: Message): Promise<void> => {
+		let prefix = legacyPrefix;
+		if (options.storage && message.guild) {
+			try {
+				const override = await getGuildPrefix(options.storage, message.guild.id);
+				if (override) prefix = override;
+			} catch (err) {
+				console.error("[djs-commands] Failed to load guild prefix override:", err);
+			}
+		}
+		await dispatcher.dispatchMessage(message, prefix, legacyEnabled);
+	};
+
 	const onMessage = (message: Message) => {
-		dispatcher.dispatchMessage(message, legacyPrefix, legacyEnabled).catch((err) => {
+		handleMessage(message).catch((err) => {
 			console.error("[djs-commands] Unhandled legacy command error:", err);
 		});
 	};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,8 @@ export type {
 	UserOption,
 } from "./options";
 export type { PluginManifest, PluginSetupContext } from "./plugin";
+export { clearGuildPrefix, GuildPrefixModel, type GuildPrefixRow, getGuildPrefix, type Storage, type StorageFindOpts, type StorageWhere, setGuildPrefix } from "./storage";
+export { runStorageConformance } from "./storage-conformance";
 export type {
 	AnyCommand,
 	Command,

--- a/packages/core/src/storage-conformance.ts
+++ b/packages/core/src/storage-conformance.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test";
+import { GuildPrefixModel, type GuildPrefixRow, type Storage } from "./storage";
+
+/**
+ * Shared test suite that any `Storage` adapter implementation can run against
+ * to verify it satisfies the generic CRUD contract. Adapters call this from
+ * their own `*.test.ts` once they've spun up a backend (Postgres, Mongo, …)
+ * and acquired a Storage instance.
+ *
+ * The suite uses the GuildPrefix model since it ships with core. Adapters
+ * are expected to clean their state between runs themselves; this suite
+ * delete-cleans every row it touches.
+ */
+export function runStorageConformance(name: string, factory: () => Promise<Storage>): void {
+	test(`${name}: create + findOne round-trip`, async () => {
+		const storage = await factory();
+		await storage.delete(GuildPrefixModel, { guild_id: "conf-1" });
+
+		const created = await storage.create<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-1", prefix: "?" });
+		expect(created.guild_id).toBe("conf-1");
+		expect(created.prefix).toBe("?");
+
+		const found = await storage.findOne<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-1" });
+		expect(found?.prefix).toBe("?");
+
+		await storage.delete(GuildPrefixModel, { guild_id: "conf-1" });
+	});
+
+	test(`${name}: findOne returns null for missing rows`, async () => {
+		const storage = await factory();
+		const found = await storage.findOne<GuildPrefixRow>(GuildPrefixModel, { guild_id: "does-not-exist" });
+		expect(found).toBeNull();
+	});
+
+	test(`${name}: update modifies fields`, async () => {
+		const storage = await factory();
+		await storage.delete(GuildPrefixModel, { guild_id: "conf-2" });
+		await storage.create<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-2", prefix: "?" });
+
+		const updated = await storage.update<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-2" }, { prefix: "!" });
+		expect(updated.prefix).toBe("!");
+
+		const found = await storage.findOne<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-2" });
+		expect(found?.prefix).toBe("!");
+
+		await storage.delete(GuildPrefixModel, { guild_id: "conf-2" });
+	});
+
+	test(`${name}: delete removes the row`, async () => {
+		const storage = await factory();
+		await storage.create<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-3", prefix: "?" });
+		await storage.delete(GuildPrefixModel, { guild_id: "conf-3" });
+
+		const found = await storage.findOne<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-3" });
+		expect(found).toBeNull();
+	});
+
+	test(`${name}: findMany returns multiple rows in declared order`, async () => {
+		const storage = await factory();
+		for (const id of ["a", "b", "c"]) {
+			await storage.delete(GuildPrefixModel, { guild_id: `conf-many-${id}` });
+		}
+		await storage.create<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-many-a", prefix: "1" });
+		await storage.create<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-many-b", prefix: "2" });
+		await storage.create<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-many-c", prefix: "3" });
+
+		const rows = await storage.findMany<GuildPrefixRow>(GuildPrefixModel, {
+			orderBy: { field: "guild_id", direction: "asc" },
+		});
+		const matched = rows.filter((r) => r.guild_id.startsWith("conf-many-"));
+		expect(matched.map((r) => r.guild_id)).toEqual(["conf-many-a", "conf-many-b", "conf-many-c"]);
+
+		for (const id of ["a", "b", "c"]) {
+			await storage.delete(GuildPrefixModel, { guild_id: `conf-many-${id}` });
+		}
+	});
+
+	test(`${name}: count returns the expected number`, async () => {
+		const storage = await factory();
+		await storage.delete(GuildPrefixModel, { guild_id: "conf-count" });
+
+		const before = await storage.count(GuildPrefixModel, { guild_id: "conf-count" });
+		expect(before).toBe(0);
+
+		await storage.create<GuildPrefixRow>(GuildPrefixModel, { guild_id: "conf-count", prefix: "?" });
+
+		const after = await storage.count(GuildPrefixModel, { guild_id: "conf-count" });
+		expect(after).toBe(1);
+
+		await storage.delete(GuildPrefixModel, { guild_id: "conf-count" });
+	});
+}

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -1,0 +1,54 @@
+/**
+ * Generic CRUD contract that adapters implement once and the framework
+ * consumes for every persistent feature. Modeled on Better Auth's pattern —
+ * adding a new model never requires changes to the adapter contract.
+ *
+ * `Storage.create<T>` returns the persisted row (most ORMs do this via
+ * RETURNING). Adapters that don't support returning should re-fetch.
+ */
+export interface Storage {
+	create<T extends Record<string, unknown>>(model: string, data: T): Promise<T>;
+	findOne<T extends Record<string, unknown>>(model: string, where: StorageWhere): Promise<T | null>;
+	findMany<T extends Record<string, unknown>>(model: string, opts?: StorageFindOpts): Promise<T[]>;
+	update<T extends Record<string, unknown>>(model: string, where: StorageWhere, data: Partial<T>): Promise<T>;
+	delete(model: string, where: StorageWhere): Promise<void>;
+	count(model: string, where?: StorageWhere): Promise<number>;
+}
+
+export type StorageWhere = Record<string, string | number | null>;
+
+export interface StorageFindOpts {
+	where?: StorageWhere;
+	limit?: number;
+	offset?: number;
+	orderBy?: { field: string; direction: "asc" | "desc" };
+}
+
+// ─── GuildPrefix model ─────────────────────────────────────────────────────
+
+export const GuildPrefixModel = "guild_prefix" as const;
+
+export interface GuildPrefixRow extends Record<string, unknown> {
+	guild_id: string;
+	prefix: string;
+}
+
+/** Reads a guild's persisted prefix override; null if no override is set. */
+export async function getGuildPrefix(storage: Storage, guildId: string): Promise<string | null> {
+	const row = await storage.findOne<GuildPrefixRow>(GuildPrefixModel, { guild_id: guildId });
+	return row?.prefix ?? null;
+}
+
+/** Upserts a guild's prefix override. Pass an empty string or null to clear it. */
+export async function setGuildPrefix(storage: Storage, guildId: string, prefix: string): Promise<void> {
+	const existing = await storage.findOne<GuildPrefixRow>(GuildPrefixModel, { guild_id: guildId });
+	if (existing) {
+		await storage.update<GuildPrefixRow>(GuildPrefixModel, { guild_id: guildId }, { prefix });
+	} else {
+		await storage.create<GuildPrefixRow>(GuildPrefixModel, { guild_id: guildId, prefix });
+	}
+}
+
+export async function clearGuildPrefix(storage: Storage, guildId: string): Promise<void> {
+	await storage.delete(GuildPrefixModel, { guild_id: guildId });
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,7 @@ import type { ChatInputCommandInteraction, Client, Guild, GuildMember, Message, 
 import type { CacheAdapter, CooldownConfig } from "./cooldowns";
 import type { CommandOptions, ResolveOptions } from "./options";
 import type { PluginManifest } from "./plugin";
+import type { Storage } from "./storage";
 import type { CanRunCommand, Validator } from "./validators";
 
 interface BaseRunContext<S extends CommandOptions = Record<string, never>> {
@@ -76,6 +77,8 @@ export interface CommandHandlerOptions {
 	plugins?: PluginManifest[];
 	cacheAdapter?: CacheAdapter;
 	legacy?: HandlerLegacyConfig;
+	/** Persistent storage adapter for framework features that need it (e.g. per-guild legacy prefix). */
+	storage?: Storage;
 }
 
 export interface CommandHandler {


### PR DESCRIPTION
## Summary

Pilot HITL slice. Establishes the `Storage` contract that #60 (Prisma) and #61 (Mongoose) follow. Generic CRUD parameterized by model name — Better Auth shape. Ships the GuildPrefix model and wires per-guild legacy prefix override through it.

Closes #59. Unblocks #60, #61, #62, #65.

## Storage contract

```ts
interface Storage {
  create<T>(model: string, data: T): Promise<T>;
  findOne<T>(model: string, where: StorageWhere): Promise<T | null>;
  findMany<T>(model: string, opts?: StorageFindOpts): Promise<T[]>;
  update<T>(model: string, where: StorageWhere, data: Partial<T>): Promise<T>;
  delete(model: string, where: StorageWhere): Promise<void>;
  count(model: string, where?: StorageWhere): Promise<number>;
}
```

`StorageWhere = Record<string, string | number | null>` — equality matching only. Adding new framework features means declaring a new model + helpers (like `getGuildPrefix`/`setGuildPrefix`); the adapter contract never changes.

## What changed

- **`@djs-commands/core`**:
  - New `storage.ts` — the contract + `GuildPrefixModel` + helpers
  - New `storage-conformance.ts` — `runStorageConformance(name, factory)` test suite that adapter packages call from their integration tests
  - `CommandHandlerOptions.storage?` plumbed
  - Legacy prefix lookup goes through `getGuildPrefix(storage, guildId)` per-message when storage is configured; falls back to `defaultPrefix` on error or absence
- **`@djs-commands/adapter-drizzle`** (new package):
  - `drizzleStorage(db, options?)` factory returning a `Storage`
  - `schema.ts` exports the `guild_prefix` Drizzle table
  - Snake_case ↔ camelCase translation at the API boundary
  - Bring-your-own-tables via `options.tables`
  - Unknown-model error throws loud
  - Integration test running the shared conformance suite when `DATABASE_URL` is set; skips cleanly otherwise
- **`examples/moderation-drizzle`** (scaffold):
  - `/ban` + `/kick` gated by `guildOnly` + `permissions`
  - Drizzle + Postgres + legacy prefix tied together
- `knip.json` entries

## Local verification

```
$ rm -rf apps/docs/.source && bun run ci
$ biome check                  ✓ 95 files
$ tsc (typecheck)              ✓ 11 tasks across 7 packages + apps/docs
$ knip                         ✓ clean
$ bun test                     ✓ all tests pass (drizzle integration skips without DATABASE_URL)
```

## Test plan

- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer eyeballs the Storage contract — locks the shape for #60/#61
- [ ] Reviewer skims the snake_case/camelCase translation in adapter-drizzle (Drizzle's TS-side names diverge from API names)
- [ ] Optional with Postgres: `docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16` then `DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres bun test`

## Future / not in scope
- Per-guild prefix caching (currently hits storage every message — fine for low-traffic bots; cache lands later)
- DisabledCommands + ChannelLocks models (slice #62)
- Migrations beyond `drizzle-kit push`