### PR TITLE
Slice 14: create-djs-commands CLI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -119,6 +119,23 @@
         "ioredis": "^5.0.0",
       },
     },
+    "packages/cli": {
+      "name": "@djs-commands/cli",
+      "version": "0.0.0",
+      "bin": {
+        "create-djs-commands": "./dist/cli.js",
+      },
+      "dependencies": {
+        "@clack/prompts": "^0.11.0",
+        "picocolors": "^1.1.1",
+      },
+      "devDependencies": {
+        "@djs-commands/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/core": {
       "name": "@djs-commands/core",
       "version": "0.0.0",
@@ -257,6 +274,10 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
+    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+
+    "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
+
     "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
 
     "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
@@ -272,6 +293,8 @@
     "@djs-commands/adapter-drizzle": ["@djs-commands/adapter-drizzle@workspace:packages/adapter-drizzle"],
 
     "@djs-commands/adapter-redis": ["@djs-commands/adapter-redis@workspace:packages/adapter-redis"],
+
+    "@djs-commands/cli": ["@djs-commands/cli@workspace:packages/cli"],
 
     "@djs-commands/core": ["@djs-commands/core@workspace:packages/core"],
 
@@ -1302,6 +1325,8 @@
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 

--- a/knip.json
+++ b/knip.json
@@ -14,6 +14,9 @@
 		"packages/adapter-drizzle": {
 			"entry": ["src/index.ts", "src/schema.ts", "src/**/*.test.ts"]
 		},
+		"packages/cli": {
+			"entry": ["src/cli.ts", "src/**/*.test.ts"]
+		},
 		"packages/tsconfig": {},
 		"examples/minimal": {
 			"entry": ["src/commands/**/*.{ts,tsx}"]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,45 @@
+# @djs-commands/cli
+
+Scaffolding CLI for djs-commands v2.
+
+## Quick start
+
+```bash
+npx create-djs-commands my-bot
+# or
+bunx create-djs-commands my-bot
+# or
+pnpm dlx create-djs-commands my-bot
+```
+
+Runs an interactive wizard. Pass flags to skip prompts:
+
+```bash
+npx create-djs-commands my-bot \
+  --adapter drizzle \
+  --legacy \
+  --components-v2 \
+  --package-manager bun
+```
+
+## Flags
+
+| Flag | Values | Default |
+|---|---|---|
+| `--adapter` | `drizzle` / `prisma` / `mongoose` / `none` | wizard |
+| `--legacy` | (boolean) | `false` |
+| `--components-v2` | (boolean) | `false` |
+| `--package-manager`, `--pm` | `bun` / `pnpm` / `npm` | `bun` |
+| `--no-git` | (boolean) | `false` |
+| `--skip-install` | (boolean) | `false` |
+| `-h`, `--help` | | |
+
+## What gets scaffolded
+
+- `package.json` with the right dependencies for your adapter and package manager
+- `tsconfig.json` (strict, ESM, Bundler resolution)
+- `src/index.ts` wired to `createCommandHandler`
+- `src/commands/ping.ts` as a starting command
+- `.env.example`, `.gitignore`, `README.md`
+
+The bot uses fs-autoloader (`commandDir`), so any new file under `src/commands/` auto-registers on save in dev mode.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,52 @@
+{
+	"name": "@djs-commands/cli",
+	"version": "0.0.0",
+	"description": "Scaffolding CLI for djs-commands — `npx create-djs-commands`",
+	"author": "D3OXY <hello@deoxy.dev>",
+	"license": "MIT",
+	"type": "module",
+	"main": "./dist/cli.js",
+	"types": "./dist/cli.d.ts",
+	"bin": {
+		"create-djs-commands": "./dist/cli.js"
+	},
+	"files": [
+		"dist",
+		"templates",
+		"README.md"
+	],
+	"scripts": {
+		"build": "bun build src/cli.ts --target=node --outfile=dist/cli.js --banner='#!/usr/bin/env node' && chmod +x dist/cli.js",
+		"dev": "bun run --watch src/cli.ts",
+		"typecheck": "tsc --noEmit",
+		"test": "bun test"
+	},
+	"dependencies": {
+		"@clack/prompts": "^0.11.0",
+		"picocolors": "^1.1.1"
+	},
+	"devDependencies": {
+		"@djs-commands/tsconfig": "workspace:*",
+		"@types/bun": "catalog:",
+		"@types/node": "catalog:",
+		"typescript": "catalog:"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/D3OXY/djs-commands",
+		"directory": "packages/cli"
+	},
+	"keywords": [
+		"discord.js",
+		"discord",
+		"bot",
+		"scaffold",
+		"create-djs-commands"
+	]
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,31 @@
+import pico from "picocolors";
+import { HELP_TEXT, parseFlags } from "./options";
+import { scaffold } from "./scaffold";
+import { runWizard } from "./wizard";
+
+async function main(): Promise<void> {
+	const flags = parseFlags(process.argv.slice(2));
+
+	if (flags.help) {
+		console.log(HELP_TEXT);
+		return;
+	}
+
+	const opts = await runWizard(flags);
+	const result = await scaffold(opts, { skipInstall: flags.skipInstall === true });
+
+	console.log();
+	console.log(pico.green("✓ Created"), pico.bold(result.targetDir));
+	console.log();
+	console.log("Next steps:");
+	console.log(pico.dim(`  cd ${opts.projectName}`));
+	console.log(pico.dim("  cp .env.example .env  # add DISCORD_TOKEN"));
+	const dev = opts.packageManager === "bun" ? "bun run dev" : opts.packageManager === "pnpm" ? "pnpm dev" : "npm run dev";
+	console.log(pico.dim(`  ${dev}`));
+	console.log();
+}
+
+main().catch((err) => {
+	console.error(pico.red("✗"), err instanceof Error ? err.message : String(err));
+	process.exit(1);
+});

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -1,0 +1,70 @@
+export type Adapter = "drizzle" | "prisma" | "mongoose" | "none";
+export type PackageManager = "bun" | "pnpm" | "npm";
+
+export interface ScaffoldOptions {
+	projectName: string;
+	adapter: Adapter;
+	legacy: boolean;
+	componentsV2: boolean;
+	packageManager: PackageManager;
+	initGit: boolean;
+}
+
+export interface ParsedFlags extends Partial<ScaffoldOptions> {
+	help?: boolean;
+	skipInstall?: boolean;
+}
+
+export function parseFlags(argv: readonly string[]): ParsedFlags & { positional: string[] } {
+	const flags: ParsedFlags & { positional: string[] } = { positional: [] };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (!arg) continue;
+		if (arg === "--help" || arg === "-h") {
+			flags.help = true;
+		} else if (arg === "--legacy") {
+			flags.legacy = true;
+		} else if (arg === "--components-v2") {
+			flags.componentsV2 = true;
+		} else if (arg === "--no-git") {
+			flags.initGit = false;
+		} else if (arg === "--skip-install") {
+			flags.skipInstall = true;
+		} else if (arg === "--adapter") {
+			const value = argv[++i] as Adapter | undefined;
+			if (value && ["drizzle", "prisma", "mongoose", "none"].includes(value)) {
+				flags.adapter = value;
+			}
+		} else if (arg.startsWith("--adapter=")) {
+			const value = arg.slice("--adapter=".length) as Adapter;
+			if (["drizzle", "prisma", "mongoose", "none"].includes(value)) flags.adapter = value;
+		} else if (arg === "--package-manager" || arg === "--pm") {
+			const value = argv[++i] as PackageManager | undefined;
+			if (value && ["bun", "pnpm", "npm"].includes(value)) flags.packageManager = value;
+		} else if (arg.startsWith("--package-manager=") || arg.startsWith("--pm=")) {
+			const value = arg.split("=")[1] as PackageManager;
+			if (["bun", "pnpm", "npm"].includes(value)) flags.packageManager = value;
+		} else if (!arg.startsWith("-")) {
+			flags.positional.push(arg);
+		}
+	}
+	return flags;
+}
+
+export const HELP_TEXT = `
+create-djs-commands — scaffold a new Discord.js bot using @djs-commands
+
+Usage:
+  npx create-djs-commands [project-name] [flags]
+
+Flags:
+  --adapter <drizzle|prisma|mongoose|none>   Persistent storage adapter
+  --legacy                                   Enable legacy prefix mode (e.g. !ping)
+  --components-v2                            Add @djs-commands/jsx for Components V2
+  --package-manager <bun|pnpm|npm>           Package manager (default: bun)
+  --no-git                                   Don't initialize a git repository
+  --skip-install                             Don't run dependency install
+  -h, --help                                 Show this message
+
+Run with no arguments for an interactive wizard.
+`;

--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scaffold } from "./scaffold";
+
+let dir: string;
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "djs-commands-cli-"));
+});
+
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+test("scaffolds a baseline bot with the bun + drizzle defaults", async () => {
+	const result = await scaffold(
+		{
+			projectName: "test-bot",
+			adapter: "drizzle",
+			legacy: false,
+			componentsV2: false,
+			packageManager: "bun",
+			initGit: false,
+		},
+		{ cwd: dir, skipInstall: true, stdio: "ignore" }
+	);
+
+	expect(result.files.sort()).toEqual([".env.example", ".gitignore", "README.md", "package.json", "src/commands/ping.ts", "src/index.ts", "tsconfig.json"]);
+
+	const pkg = JSON.parse(await readFile(join(result.targetDir, "package.json"), "utf8"));
+	expect(pkg.name).toBe("test-bot");
+	expect(pkg.dependencies["@djs-commands/core"]).toBeDefined();
+	expect(pkg.dependencies["@djs-commands/adapter-drizzle"]).toBeDefined();
+	expect(pkg.dependencies["drizzle-orm"]).toBeDefined();
+	expect(pkg.dependencies.pg).toBeDefined();
+});
+
+test("adapter=none excludes ORM dependencies", async () => {
+	const result = await scaffold(
+		{
+			projectName: "no-db-bot",
+			adapter: "none",
+			legacy: false,
+			componentsV2: false,
+			packageManager: "bun",
+			initGit: false,
+		},
+		{ cwd: dir, skipInstall: true, stdio: "ignore" }
+	);
+
+	const pkg = JSON.parse(await readFile(join(result.targetDir, "package.json"), "utf8"));
+	expect(pkg.dependencies["drizzle-orm"]).toBeUndefined();
+	expect(pkg.dependencies["@prisma/client"]).toBeUndefined();
+	expect(pkg.dependencies.mongoose).toBeUndefined();
+});
+
+test("adapter=prisma adds prisma + @prisma/client", async () => {
+	const result = await scaffold(
+		{
+			projectName: "prisma-bot",
+			adapter: "prisma",
+			legacy: false,
+			componentsV2: false,
+			packageManager: "bun",
+			initGit: false,
+		},
+		{ cwd: dir, skipInstall: true, stdio: "ignore" }
+	);
+
+	const pkg = JSON.parse(await readFile(join(result.targetDir, "package.json"), "utf8"));
+	expect(pkg.dependencies["@djs-commands/adapter-prisma"]).toBeDefined();
+	expect(pkg.dependencies["@prisma/client"]).toBeDefined();
+	expect(pkg.devDependencies.prisma).toBeDefined();
+});
+
+test("adapter=mongoose adds mongoose and a Mongo URL in env", async () => {
+	const result = await scaffold(
+		{
+			projectName: "mongo-bot",
+			adapter: "mongoose",
+			legacy: false,
+			componentsV2: false,
+			packageManager: "bun",
+			initGit: false,
+		},
+		{ cwd: dir, skipInstall: true, stdio: "ignore" }
+	);
+
+	const pkg = JSON.parse(await readFile(join(result.targetDir, "package.json"), "utf8"));
+	expect(pkg.dependencies.mongoose).toBeDefined();
+
+	const env = await readFile(join(result.targetDir, ".env.example"), "utf8");
+	expect(env).toContain("MONGO_URL=");
+});
+
+test("legacy mode is reflected in src/index.ts and src/commands/ping.ts", async () => {
+	const result = await scaffold(
+		{
+			projectName: "legacy-bot",
+			adapter: "none",
+			legacy: true,
+			componentsV2: false,
+			packageManager: "bun",
+			initGit: false,
+		},
+		{ cwd: dir, skipInstall: true, stdio: "ignore" }
+	);
+
+	const index = await readFile(join(result.targetDir, "src/index.ts"), "utf8");
+	expect(index).toContain("legacy: { enabled: true");
+	expect(index).toContain("GatewayIntentBits.MessageContent");
+
+	const ping = await readFile(join(result.targetDir, "src/commands/ping.ts"), "utf8");
+	expect(ping).toContain("legacy:");
+});
+
+test("componentsV2 adds @djs-commands/jsx", async () => {
+	const result = await scaffold(
+		{
+			projectName: "jsx-bot",
+			adapter: "none",
+			legacy: false,
+			componentsV2: true,
+			packageManager: "bun",
+			initGit: false,
+		},
+		{ cwd: dir, skipInstall: true, stdio: "ignore" }
+	);
+
+	const pkg = JSON.parse(await readFile(join(result.targetDir, "package.json"), "utf8"));
+	expect(pkg.dependencies["@djs-commands/jsx"]).toBeDefined();
+});
+
+test("packageManager=pnpm uses tsx for dev script", async () => {
+	const result = await scaffold(
+		{
+			projectName: "pnpm-bot",
+			adapter: "none",
+			legacy: false,
+			componentsV2: false,
+			packageManager: "pnpm",
+			initGit: false,
+		},
+		{ cwd: dir, skipInstall: true, stdio: "ignore" }
+	);
+
+	const pkg = JSON.parse(await readFile(join(result.targetDir, "package.json"), "utf8"));
+	expect(pkg.scripts.dev).toContain("tsx");
+	expect(pkg.devDependencies.tsx).toBeDefined();
+});

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -1,0 +1,58 @@
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import type { ScaffoldOptions } from "./options";
+import { buildFiles, installCommand } from "./templates";
+
+interface ScaffoldResult {
+	targetDir: string;
+	files: string[];
+}
+
+interface ScaffoldRunOptions {
+	cwd?: string;
+	skipInstall?: boolean;
+	stdio?: "inherit" | "ignore";
+}
+
+export async function scaffold(opts: ScaffoldOptions, runOpts: ScaffoldRunOptions = {}): Promise<ScaffoldResult> {
+	const cwd = runOpts.cwd ?? process.cwd();
+	const targetDir = resolve(cwd, opts.projectName);
+
+	await mkdir(targetDir, { recursive: true });
+
+	const files = buildFiles(opts);
+	const writtenPaths: string[] = [];
+	for (const file of files) {
+		const fullPath = join(targetDir, file.path);
+		await mkdir(dirname(fullPath), { recursive: true });
+		await writeFile(fullPath, file.content);
+		writtenPaths.push(file.path);
+	}
+
+	if (!runOpts.skipInstall) {
+		const { cmd, args } = installCommand(opts.packageManager);
+		await runCommand(cmd, args, { cwd: targetDir, stdio: runOpts.stdio ?? "inherit" });
+	}
+
+	if (opts.initGit) {
+		try {
+			await runCommand("git", ["init", "--quiet"], { cwd: targetDir, stdio: runOpts.stdio ?? "ignore" });
+		} catch {
+			// git not installed or some other failure — non-fatal
+		}
+	}
+
+	return { targetDir, files: writtenPaths };
+}
+
+function runCommand(cmd: string, args: string[], opts: { cwd: string; stdio: "inherit" | "ignore" }): Promise<void> {
+	return new Promise((resolveRun, rejectRun) => {
+		const child = spawn(cmd, args, { cwd: opts.cwd, stdio: opts.stdio });
+		child.on("close", (code) => {
+			if (code === 0) resolveRun();
+			else rejectRun(new Error(`${cmd} exited with code ${code}`));
+		});
+		child.on("error", rejectRun);
+	});
+}

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -1,0 +1,252 @@
+import type { Adapter, PackageManager, ScaffoldOptions } from "./options";
+
+interface FileContent {
+	path: string;
+	content: string;
+}
+
+const DEPS = {
+	core: "^0.0.0",
+	jsx: "^0.0.0",
+	adapterDrizzle: "^0.0.0",
+	adapterPrisma: "^0.0.0",
+	adapterMongoose: "^0.0.0",
+	discordJs: "^14.26.0",
+	drizzleOrm: "^0.36.4",
+	pg: "^8.13.1",
+	prismaClient: "^5.22.0",
+	mongoose: "^8.8.0",
+	typescript: "^5.9.3",
+	typesNode: "^22.0.0",
+	tsx: "^4.21.0",
+} as const;
+
+function packageJson(opts: ScaffoldOptions): string {
+	const dependencies: Record<string, string> = {
+		"@djs-commands/core": DEPS.core,
+		"discord.js": DEPS.discordJs,
+	};
+	if (opts.componentsV2) dependencies["@djs-commands/jsx"] = DEPS.jsx;
+	if (opts.adapter === "drizzle") {
+		dependencies["@djs-commands/adapter-drizzle"] = DEPS.adapterDrizzle;
+		dependencies["drizzle-orm"] = DEPS.drizzleOrm;
+		dependencies.pg = DEPS.pg;
+	}
+	if (opts.adapter === "prisma") {
+		dependencies["@djs-commands/adapter-prisma"] = DEPS.adapterPrisma;
+		dependencies["@prisma/client"] = DEPS.prismaClient;
+	}
+	if (opts.adapter === "mongoose") {
+		dependencies["@djs-commands/adapter-mongoose"] = DEPS.adapterMongoose;
+		dependencies.mongoose = DEPS.mongoose;
+	}
+
+	const devDependencies: Record<string, string> = {
+		"@types/node": DEPS.typesNode,
+		typescript: DEPS.typescript,
+	};
+	if (opts.packageManager !== "bun") devDependencies.tsx = DEPS.tsx;
+	if (opts.adapter === "prisma") devDependencies.prisma = DEPS.prismaClient;
+
+	const dev = opts.packageManager === "bun" ? "bun run --watch src/index.ts" : "tsx watch src/index.ts";
+	const start = opts.packageManager === "bun" ? "bun run src/index.ts" : "tsx src/index.ts";
+
+	const pkg = {
+		name: opts.projectName,
+		version: "0.0.0",
+		private: true,
+		type: "module",
+		scripts: {
+			dev,
+			start,
+			typecheck: "tsc --noEmit",
+		},
+		dependencies,
+		devDependencies,
+	};
+
+	return JSON.stringify(pkg, null, "\t");
+}
+
+function tsconfigJson(): string {
+	return JSON.stringify(
+		{
+			compilerOptions: {
+				strict: true,
+				skipLibCheck: true,
+				module: "ESNext",
+				moduleResolution: "Bundler",
+				target: "ES2022",
+				lib: ["ES2022"],
+				esModuleInterop: true,
+				resolveJsonModule: true,
+				noEmit: true,
+				types: ["node"],
+			},
+			include: ["src/**/*"],
+		},
+		null,
+		"\t"
+	);
+}
+
+function gitignore(): string {
+	return ["node_modules/", "dist/", ".env", "*.log", ".DS_Store", ""].join("\n");
+}
+
+function envExample(adapter: Adapter): string {
+	const lines = ["DISCORD_TOKEN=your-bot-token-here"];
+	if (adapter === "drizzle" || adapter === "prisma") {
+		lines.push("DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres");
+	}
+	if (adapter === "mongoose") {
+		lines.push("MONGO_URL=mongodb://localhost:27017/mybot");
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function indexTs(opts: ScaffoldOptions): string {
+	const imports = [`import { createCommandHandler } from "@djs-commands/core";`, `import { Client, GatewayIntentBits } from "discord.js";`];
+	const intents = ["GatewayIntentBits.Guilds"];
+	if (opts.legacy) {
+		intents.push("GatewayIntentBits.GuildMessages");
+		intents.push("GatewayIntentBits.MessageContent");
+	}
+
+	let storageSetup = "";
+	let storageOption = "";
+	if (opts.adapter === "drizzle") {
+		imports.push(`import { drizzleStorage } from "@djs-commands/adapter-drizzle";`, `import { drizzle } from "drizzle-orm/node-postgres";`, `import pg from "pg";`);
+		storageSetup = `
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const db = drizzle(pool);
+`;
+		storageOption = "\n\tstorage: drizzleStorage(db),";
+	} else if (opts.adapter === "prisma") {
+		imports.push(`import { prismaStorage } from "@djs-commands/adapter-prisma";`, `import { PrismaClient } from "@prisma/client";`);
+		storageSetup = `
+const prisma = new PrismaClient();
+`;
+		storageOption = "\n\tstorage: prismaStorage(prisma),";
+	} else if (opts.adapter === "mongoose") {
+		imports.push(`import { mongooseStorage } from "@djs-commands/adapter-mongoose";`, `import mongoose from "mongoose";`);
+		storageSetup = `
+const connection = mongoose.createConnection(process.env.MONGO_URL!);
+`;
+		storageOption = "\n\tstorage: mongooseStorage(connection),";
+	}
+
+	const dirImport = opts.packageManager === "bun" ? '"./commands"' : 'fileURLToPath(new URL("./commands", import.meta.url))';
+	if (opts.packageManager !== "bun") {
+		imports.unshift(`import { fileURLToPath } from "node:url";`);
+	}
+
+	const legacyOption = opts.legacy ? '\n\tlegacy: { enabled: true, defaultPrefix: "!" },' : "";
+
+	return `${imports.join("\n")}
+${storageSetup}
+const token = process.env.DISCORD_TOKEN;
+if (!token) {
+\tconsole.error("DISCORD_TOKEN environment variable is required");
+\tprocess.exit(1);
+}
+
+const client = new Client({ intents: [${intents.join(", ")}] });
+
+const handler = createCommandHandler({
+\tclient,
+\tcommandDir: ${dirImport},${storageOption}${legacyOption}
+});
+
+handler.ready.catch((err) => {
+\tconsole.error("Boot failed:", err);
+\tprocess.exit(1);
+});
+
+client.once("clientReady", (c) => {
+\tconsole.log(\`Logged in as \${c.user.tag}\`);
+});
+
+await client.login(token);
+`;
+}
+
+function pingCommandTs(opts: ScaffoldOptions): string {
+	const legacyConfig = opts.legacy ? `,\n\tlegacy: { enabled: true, aliases: ["p"] }` : "";
+	return `import { defineCommand } from "@djs-commands/core";
+
+export default defineCommand({
+\tname: "ping",
+\tdescription: "Replies with pong"${legacyConfig},
+\trun: async (ctx) => {
+\t\tawait ctx.reply("pong");
+\t},
+});
+`;
+}
+
+function readme(opts: ScaffoldOptions): string {
+	const installCmd = opts.packageManager === "bun" ? "bun install" : opts.packageManager === "pnpm" ? "pnpm install" : "npm install";
+	const devCmd = opts.packageManager === "bun" ? "bun run dev" : opts.packageManager === "pnpm" ? "pnpm dev" : "npm run dev";
+	const dbSetup =
+		opts.adapter === "drizzle"
+			? `\n## Database (Postgres + Drizzle)
+
+\`\`\`bash
+docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres -d postgres:16
+\`\`\`
+
+Then push the schema using drizzle-kit (see [@djs-commands/adapter-drizzle](https://github.com/D3OXY/djs-commands/tree/main/packages/adapter-drizzle) for the model fragment).
+`
+			: opts.adapter === "prisma"
+				? `\n## Database (Postgres + Prisma)
+
+\`\`\`bash
+docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres -d postgres:16
+${opts.packageManager} prisma migrate dev
+\`\`\`
+`
+				: opts.adapter === "mongoose"
+					? `\n## Database (MongoDB + Mongoose)
+
+\`\`\`bash
+docker run --rm -p 27017:27017 -d mongo:7
+\`\`\`
+`
+					: "";
+
+	return `# ${opts.projectName}
+
+Scaffolded with \`create-djs-commands\`.
+
+## Setup
+
+\`\`\`bash
+${installCmd}
+cp .env.example .env  # add your DISCORD_TOKEN
+${devCmd}
+\`\`\`
+${dbSetup}
+## Adding commands
+
+Drop a \`defineCommand({...})\` default export into \`src/commands/\` — it'll auto-load on save.
+`;
+}
+
+export function buildFiles(opts: ScaffoldOptions): FileContent[] {
+	return [
+		{ path: "package.json", content: packageJson(opts) },
+		{ path: "tsconfig.json", content: tsconfigJson() },
+		{ path: ".gitignore", content: gitignore() },
+		{ path: ".env.example", content: envExample(opts.adapter) },
+		{ path: "src/index.ts", content: indexTs(opts) },
+		{ path: "src/commands/ping.ts", content: pingCommandTs(opts) },
+		{ path: "README.md", content: readme(opts) },
+	];
+}
+
+export function installCommand(pm: PackageManager): { cmd: string; args: string[] } {
+	if (pm === "bun") return { cmd: "bun", args: ["install"] };
+	if (pm === "pnpm") return { cmd: "pnpm", args: ["install"] };
+	return { cmd: "npm", args: ["install"] };
+}

--- a/packages/cli/src/wizard.ts
+++ b/packages/cli/src/wizard.ts
@@ -1,0 +1,91 @@
+import { cancel, confirm, intro, isCancel, outro, select, text } from "@clack/prompts";
+import pico from "picocolors";
+import type { Adapter, PackageManager, ParsedFlags, ScaffoldOptions } from "./options";
+
+function exitOnCancel<T>(value: T | symbol): T {
+	if (isCancel(value)) {
+		cancel("Cancelled.");
+		process.exit(0);
+	}
+	return value as T;
+}
+
+export async function runWizard(flags: ParsedFlags & { positional: string[] }): Promise<ScaffoldOptions> {
+	intro(pico.bgCyan(pico.black(" create-djs-commands ")));
+
+	const projectName =
+		flags.projectName ??
+		flags.positional[0] ??
+		exitOnCancel(
+			await text({
+				message: "Project name",
+				placeholder: "my-bot",
+				defaultValue: "my-bot",
+				validate: (value) => {
+					if (value.length === 0) return "Project name is required";
+					if (!/^[a-z0-9][a-z0-9-_]*$/i.test(value)) return "Use letters, numbers, hyphens, or underscores";
+					return undefined;
+				},
+			})
+		);
+
+	const adapter =
+		flags.adapter ??
+		exitOnCancel(
+			await select<Adapter>({
+				message: "Persistent storage adapter",
+				options: [
+					{ value: "drizzle", label: "Drizzle (Postgres)" },
+					{ value: "prisma", label: "Prisma" },
+					{ value: "mongoose", label: "Mongoose (MongoDB)" },
+					{ value: "none", label: "None — in-memory only" },
+				],
+				initialValue: "drizzle",
+			})
+		);
+
+	const legacy =
+		flags.legacy ??
+		exitOnCancel(
+			await confirm({
+				message: "Enable legacy prefix mode (e.g. !ping)?",
+				initialValue: false,
+			})
+		);
+
+	const componentsV2 =
+		flags.componentsV2 ??
+		exitOnCancel(
+			await confirm({
+				message: "Add @djs-commands/jsx for Components V2?",
+				initialValue: false,
+			})
+		);
+
+	const packageManager =
+		flags.packageManager ??
+		exitOnCancel(
+			await select<PackageManager>({
+				message: "Package manager",
+				options: [
+					{ value: "bun", label: "bun" },
+					{ value: "pnpm", label: "pnpm" },
+					{ value: "npm", label: "npm" },
+				],
+				initialValue: "bun",
+			})
+		);
+
+	const initGit =
+		flags.initGit ??
+		exitOnCancel(
+			await confirm({
+				message: "Initialize a git repository?",
+				initialValue: true,
+			})
+		);
+
+	outro(pico.green("Scaffolding…"));
+
+	return { projectName, adapter, legacy, componentsV2, packageManager, initGit };
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@djs-commands/tsconfig/library.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"noEmit": true,
+		"types": ["bun"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

Node-runnable scaffolding CLI for djs-commands v2. Composable: one base template + flag-driven overlays for adapter, legacy mode, Components V2, and package manager.

```bash
npx create-djs-commands my-bot
# or with flags:
npx create-djs-commands my-bot --adapter drizzle --legacy --pm bun
```

Closes #65.

## What changed

- New package `packages/cli/` (`@djs-commands/cli`)
  - `bin: create-djs-commands` → `dist/cli.js`, built via `bun build --target=node` to a single Node-compatible JS file with a #!shebang. Runs under `npx`, `pnpm dlx`, `bunx` — no Bun required for end users.
  - `@clack/prompts` wizard for interactive use; matching flags for non-interactive (`--adapter`, `--legacy`, `--components-v2`, `--pm`, `--no-git`, `--skip-install`).
- `src/templates.ts` — file generators for `package.json`, `tsconfig.json`, `.gitignore`, `.env.example`, `src/index.ts` (storage + intents + legacy wiring conditional on opts), `src/commands/ping.ts`, `README.md`.
- 7 unit tests via tmpdir fixtures: bun+drizzle baseline, adapter=none excludes ORM deps, prisma adds `prisma`+`@prisma/client`, mongoose adds mongoose + `MONGO_URL` env line, legacy reflects in index.ts intents + ping.ts, jsx flag adds `@djs-commands/jsx`, pnpm uses tsx for dev.
- `knip.json` cli workspace entry.

## Wizard preview

```
◆ Project name
│  my-bot
◆ Persistent storage adapter
│  ● Drizzle (Postgres)
│  ○ Prisma
│  ○ Mongoose (MongoDB)
│  ○ None — in-memory only
◆ Enable legacy prefix mode (e.g. !ping)?
│  ○ Yes  ● No
◆ Add @djs-commands/jsx for Components V2?
│  ○ Yes  ● No
◆ Package manager
│  ● bun  ○ pnpm  ○ npm
◆ Initialize a git repository?
│  ● Yes  ○ No
```

## Local verification

```
$ rm -rf apps/docs/.source && bun run ci
$ biome check                  ✓ 103 files
$ tsc (typecheck)              ✓ 12 tasks across 8 packages + 2 examples + apps/docs
$ knip                         ✓ clean
$ bun test                     ✓ all tests pass (incl. 7 new CLI scaffold tests)
```

## Test plan
- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer skims the template generators in `templates.ts` (this is the lock-in surface for what users get)
- [ ] Optional: `bun run --cwd packages/cli build && node packages/cli/dist/cli.js test-bot --adapter drizzle --pm bun --skip-install --no-git` and inspect the generated dir

## Future
- Validate generated project compiles in-test via `bun install && bun run typecheck` (currently only checks the file shape; running install in tests is slow — left as a follow-up)
- Templates for sharded bots, user-installable apps (post-2.0)
- Git config for the user's name/email (currently uses git defaults)