### PR TITLE
Slice 10: Mongoose adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,22 @@
         "drizzle-orm": "^0.36.0",
       },
     },
+    "packages/adapter-mongoose": {
+      "name": "@djs-commands/adapter-mongoose",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@djs-commands/core": "workspace:*",
+        "@djs-commands/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "mongoose": "^8.8.3",
+        "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "@djs-commands/core": "workspace:*",
+        "mongoose": "^8.0.0",
+      },
+    },
     "packages/adapter-prisma": {
       "name": "@djs-commands/adapter-prisma",
       "version": "0.0.0",
@@ -309,6 +325,8 @@
 
     "@djs-commands/adapter-drizzle": ["@djs-commands/adapter-drizzle@workspace:packages/adapter-drizzle"],
 
+    "@djs-commands/adapter-mongoose": ["@djs-commands/adapter-mongoose@workspace:packages/adapter-mongoose"],
+
     "@djs-commands/adapter-prisma": ["@djs-commands/adapter-prisma@workspace:packages/adapter-prisma"],
 
     "@djs-commands/adapter-redis": ["@djs-commands/adapter-redis@workspace:packages/adapter-redis"],
@@ -418,6 +436,8 @@
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
+    "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.11", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -713,17 +733,17 @@
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-hTEiNu2ABZZOO1qbjnKASI8eF3BdOOzU6iKv5w5uGOK65DDMc10cS40N1kqM99YT0uSAGUwNu6GdFctRPeEeVA=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nKRFI5ZhCGUi4eXNlrojzWcT/CehMj0raot1WE4lw5qf66ZxZHbRbBqcwNEy+ZLY7RkJJRY+TaU89fuj3BcgGg=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MinO40EEcP5mJiTVpfjtEulsEBhVeryfq21QhYtJZ8hQJLHGgy459rcmDVAY8/JERe4dkVU4KW+zoLF22o01EA=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.8", "", { "os": "linux", "cpu": "x64" }, "sha512-Wf/kQpVDCaWM3P5d6lKvJnqjYn/ofUBGbT4h4vRFrdC4N6B/nsun03S2kQNJJMXpXg39woeS4CI367RMU3/OAg=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.9", "", { "os": "linux", "cpu": "x64" }, "sha512-7JNLw88Isk+gMlbsC8pulLDkrqe2B827ZsKFEHilb17AC6Xn/62pzH7afjY7fEU6Ayp4XP/vGhlRWOzqBvBvIQ=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-v6S3HuKVoa9CEx16IxKj1i/+crxXx22A9O80zW1350zyUlcX0T/zLOxVf1k+ruK/7ssXnDJVg8uSYOxlYRedlA=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-0pnXDwPw1rHii98JZPRg7SvsjIzy7jrhkwGU9Jy5fVYoMdYd3P2vbtLfII+OJ0Mm4Ar5yykdHDTz3RWiRI1o9g=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.8", "", { "os": "win32", "cpu": "x64" }, "sha512-JaefWOJNBazDylAn3f+lLB34XMNu8nEBbgPRP/Ewysg81cBubGfcyyyzpQOGVuMwfaqdNAE/kitG7w3AbJn9/g=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.9", "", { "os": "win32", "cpu": "x64" }, "sha512-vjDQycz4gQVvIq4n2rPtiiIESwJlAc406qtkiZlqyL+fHZEd9SxYNlBIFYtc5cuMuwrk+sIKrhN7XvwjmvS9YQ=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-Or6ljjB4TiiwCdVKDYWew0SokQ9kep5zruL8P3nbum9WdkH5XA41rQID4Ulc215Z+R3DrB+qXSHPsJjU3/n2ng=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-V6NiH43oCctepbOdQFp7UjqLyK8p6Tt824QA+G4TE+B1BBHu80A0W8OCL+H7uBJ3XZjAj/hvPDw3k3l65DoDGw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -752,6 +772,10 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
+
+    "@types/whatwg-url": ["@types/whatwg-url@11.0.5", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -800,6 +824,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "bson": ["bson@6.10.4", "", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
@@ -1093,6 +1119,8 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
+    "kareem": ["kareem@2.6.3", "", {}, "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q=="],
+
     "knip": ["knip@5.88.1", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "peerDependencies": { "@types/node": ">=18", "typescript": ">=5.0.4 <7" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-tpy5o7zu1MjawVkLPuahymVJekYY3kYjvzcoInhIchgePxTlo+api90tBv2KfhAIe5uXh+mez1tAfmbv8/TiZg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
@@ -1181,6 +1209,8 @@
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
+    "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
@@ -1261,11 +1291,21 @@
 
     "moderation-drizzle": ["moderation-drizzle@workspace:examples/moderation-drizzle"],
 
+    "mongodb": ["mongodb@6.20.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^6.10.4", "mongodb-connection-string-url": "^3.0.2" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.1.0 || ^2.0.0", "gcp-metadata": "^5.2.0", "kerberos": "^2.0.1", "mongodb-client-encryption": ">=6.0.0 <7", "snappy": "^7.3.2", "socks": "^2.7.1" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ=="],
+
+    "mongodb-connection-string-url": ["mongodb-connection-string-url@3.0.2", "", { "dependencies": { "@types/whatwg-url": "^11.0.2", "whatwg-url": "^14.1.0 || ^13.0.0" } }, "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA=="],
+
+    "mongoose": ["mongoose@8.23.1", "", { "dependencies": { "bson": "^6.10.4", "kareem": "2.6.3", "mongodb": "~6.20.0", "mpath": "0.9.0", "mquery": "5.0.0", "ms": "2.1.3", "sift": "17.1.3" } }, "sha512-gHSPD8qEwRmiXapK17hEnFWZdcFENMegHTcw5XIIg2+7R8eXQvdwSiMpD/A2oG8tKzFLLHyRXd8/eaDPAVwZgQ=="],
+
     "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
 
     "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
 
     "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
+
+    "mpath": ["mpath@0.9.0", "", {}, "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="],
+
+    "mquery": ["mquery@5.0.0", "", { "dependencies": { "debug": "4.x" } }, "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -1369,6 +1409,8 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
@@ -1461,6 +1503,8 @@
 
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
+    "sift": ["sift@17.1.3", "", {}, "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -1474,6 +1518,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
 
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
@@ -1515,6 +1561,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
@@ -1525,7 +1573,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "turbo": ["turbo@2.9.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.8", "@turbo/darwin-arm64": "2.9.8", "@turbo/linux-64": "2.9.8", "@turbo/linux-arm64": "2.9.8", "@turbo/windows-64": "2.9.8", "@turbo/windows-arm64": "2.9.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A=="],
+    "turbo": ["turbo@2.9.9", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.9", "@turbo/darwin-arm64": "2.9.9", "@turbo/linux-64": "2.9.9", "@turbo/linux-arm64": "2.9.9", "@turbo/windows-64": "2.9.9", "@turbo/windows-arm64": "2.9.9" }, "bin": { "turbo": "bin/turbo" } }, "sha512-3xfzXE/yTjhh0S5dIWlE+3E+J9A09REpLI1ZqVh2+HrNZoVzZn0pkvjiRgVK/Ev3PF9XnaTwCntTx+CADWXcyA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -1583,11 +1631,15 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/knip.json
+++ b/knip.json
@@ -17,6 +17,9 @@
 		"packages/adapter-prisma": {
 			"entry": ["src/index.ts", "src/**/*.test.ts"]
 		},
+		"packages/adapter-mongoose": {
+			"entry": ["src/index.ts", "src/models.ts", "src/**/*.test.ts"]
+		},
 		"packages/cli": {
 			"entry": ["src/cli.ts", "src/**/*.test.ts"]
 		},

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -1,0 +1,81 @@
+# @djs-commands/adapter-mongoose
+
+Mongoose/MongoDB `Storage` adapter for djs-commands. Persists framework state
+(currently per-guild legacy prefix overrides; more models in slice #62).
+
+This is the continuity path for v1 (`@d3oxy/djs-commands`) users — v1 was
+Mongo-first. The adapter targets `mongoose@^8` (v1 used `mongoose@^7`); the
+breaking changes between the two are documented in
+[Mongoose's migrating-to-8 guide](https://mongoosejs.com/docs/migrating_to_8.html).
+
+## Install
+
+```bash
+bun add @djs-commands/core @djs-commands/adapter-mongoose mongoose
+```
+
+`mongoose` and `@djs-commands/core` are peer dependencies — install them in
+your app.
+
+## Usage
+
+Pass a Mongoose `Connection` (created with `mongoose.createConnection(url)`)
+into `mongooseStorage`, then hand the returned `Storage` to your command
+handler.
+
+```ts
+import { Client, GatewayIntentBits } from "discord.js";
+import { createCommandHandler } from "@djs-commands/core";
+import { mongooseStorage } from "@djs-commands/adapter-mongoose";
+import mongoose from "mongoose";
+
+const connection = mongoose.createConnection(process.env.MONGO_URL!);
+await connection.asPromise();
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+createCommandHandler({
+  client,
+  storage: mongooseStorage(connection),
+  legacy: { enabled: true, defaultPrefix: "!" },
+  // ...
+});
+
+await client.login(process.env.DISCORD_TOKEN);
+```
+
+The adapter lazy-creates the GuildPrefix model on the connection the first
+time it's needed. Mongoose caches models by name on the connection, so
+re-instantiating the storage with the same connection is cheap.
+
+## Bring-your-own-model
+
+If you've already registered a compatible model on the connection (e.g. to
+share with other code), pass it explicitly:
+
+```ts
+import { createGuildPrefixModel, mongooseStorage } from "@djs-commands/adapter-mongoose";
+
+const guildPrefix = createGuildPrefixModel(connection);
+
+mongooseStorage(connection, { models: { guildPrefix } });
+```
+
+`createGuildPrefixModel` is also exported as a named entry point for
+Mongoose-discovery tooling:
+
+```ts
+import { createGuildPrefixModel } from "@djs-commands/adapter-mongoose/models";
+```
+
+## Local development
+
+Spin up MongoDB for testing:
+
+```bash
+docker run --rm -p 27017:27017 mongo:7
+MONGO_URL=mongodb://localhost:27017/djs-commands-test bun test
+```
+
+The integration test suite skips cleanly if `MONGO_URL` is unset or
+unreachable — CI without Mongo will not fail.

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,0 +1,60 @@
+{
+	"name": "@djs-commands/adapter-mongoose",
+	"version": "0.0.0",
+	"description": "Mongoose Storage adapter for djs-commands — MongoDB-backed persistent state",
+	"author": "D3OXY <hello@deoxy.dev>",
+	"license": "MIT",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./models": {
+			"types": "./dist/models.d.ts",
+			"import": "./dist/models.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"dev": "tsc -p tsconfig.build.json --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "bun test"
+	},
+	"peerDependencies": {
+		"@djs-commands/core": "workspace:*",
+		"mongoose": "^8.0.0"
+	},
+	"devDependencies": {
+		"@djs-commands/core": "workspace:*",
+		"@djs-commands/tsconfig": "workspace:*",
+		"@types/bun": "catalog:",
+		"@types/node": "catalog:",
+		"mongoose": "^8.8.3",
+		"typescript": "catalog:"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/D3OXY/djs-commands",
+		"directory": "packages/adapter-mongoose"
+	},
+	"keywords": [
+		"discord.js",
+		"discord",
+		"mongoose",
+		"mongodb",
+		"storage-adapter"
+	]
+}

--- a/packages/adapter-mongoose/src/index.ts
+++ b/packages/adapter-mongoose/src/index.ts
@@ -1,0 +1,96 @@
+import { GuildPrefixModel, type Storage, type StorageFindOpts, type StorageWhere } from "@djs-commands/core";
+import type mongoose from "mongoose";
+import { createGuildPrefixModel, type GuildPrefixDoc } from "./models";
+
+export type { GuildPrefixDoc } from "./models";
+export { createGuildPrefixModel } from "./models";
+
+interface ModelMap {
+	[GuildPrefixModel]: mongoose.Model<GuildPrefixDoc>;
+}
+
+interface MongooseStorageOptions {
+	models?: {
+		guildPrefix?: mongoose.Model<GuildPrefixDoc>;
+	};
+}
+
+/**
+ * Returns a `Storage` implementation backed by Mongoose. Models the framework
+ * knows about (currently only GuildPrefix) are mapped to their Mongoose
+ * models. Unknown models throw — adapters that don't recognize a model name
+ * should fail loud, not silently no-op.
+ *
+ * Bring-your-own-models: pass `options.models` to override defaults if you've
+ * already registered a compatible model on the connection.
+ */
+export function mongooseStorage(connection: mongoose.Connection, options: MongooseStorageOptions = {}): Storage {
+	const models: ModelMap = {
+		[GuildPrefixModel]: options.models?.guildPrefix ?? createGuildPrefixModel(connection),
+	};
+
+	const modelFor = (name: string): mongoose.Model<Record<string, unknown>> => {
+		const model = models[name as keyof ModelMap];
+		if (!model) throw new Error(`@djs-commands/adapter-mongoose: unknown model "${name}"`);
+		return model as unknown as mongoose.Model<Record<string, unknown>>;
+	};
+
+	return {
+		async create(name, data) {
+			const model = modelFor(name);
+			const created = await model.create(data);
+			return stripInternalFields(created.toObject()) as never;
+		},
+		async findOne(name, where) {
+			const model = modelFor(name);
+			const doc = await model
+				.findOne(where as StorageWhere)
+				.lean<Record<string, unknown> | null>()
+				.exec();
+			return doc ? (stripInternalFields(doc) as never) : null;
+		},
+		async findMany(name, opts: StorageFindOpts = {}) {
+			const model = modelFor(name);
+			let q = model.find((opts.where ?? {}) as StorageWhere);
+			if (opts.orderBy) {
+				q = q.sort({ [opts.orderBy.field]: opts.orderBy.direction === "desc" ? -1 : 1 });
+			}
+			if (opts.offset !== undefined) q = q.skip(opts.offset);
+			if (opts.limit !== undefined) q = q.limit(opts.limit);
+			const rows = await q.lean<Record<string, unknown>[]>().exec();
+			return rows.map((r) => stripInternalFields(r)) as never;
+		},
+		async update(name, where, data) {
+			const model = modelFor(name);
+			const updated = await model
+				.findOneAndUpdate(where as StorageWhere, { $set: data }, { new: true })
+				.lean<Record<string, unknown> | null>()
+				.exec();
+			if (!updated) throw new Error(`@djs-commands/adapter-mongoose: no document matched update for model "${name}"`);
+			return stripInternalFields(updated) as never;
+		},
+		async delete(name, where) {
+			const model = modelFor(name);
+			await model.deleteOne(where as StorageWhere).exec();
+		},
+		async count(name, where) {
+			const model = modelFor(name);
+			return model.countDocuments((where ?? {}) as StorageWhere).exec();
+		},
+	};
+}
+
+/**
+ * Removes Mongo's internal `_id` and `__v` fields from a plain document.
+ * `_id: false` + `versionKey: false` on the schema prevent these from
+ * appearing in the first place, but a defensive strip protects against
+ * caller-provided models that don't share those options.
+ */
+function stripInternalFields(doc: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(doc)) {
+		if (k === "_id" || k === "__v") continue;
+		out[k] = v;
+	}
+	return out;
+}

--- a/packages/adapter-mongoose/src/models.ts
+++ b/packages/adapter-mongoose/src/models.ts
@@ -1,0 +1,37 @@
+import mongoose from "mongoose";
+
+/**
+ * Schema shape for the framework's GuildPrefix model. Mongoose works with
+ * flexible schemas so we use the framework's snake_case field name (`guild_id`)
+ * directly — no camelCase translation layer needed at the boundary.
+ */
+export interface GuildPrefixDoc {
+	guild_id: string;
+	prefix: string;
+}
+
+const guildPrefixSchema = new mongoose.Schema<GuildPrefixDoc>(
+	{
+		guild_id: { type: String, required: true, unique: true },
+		prefix: { type: String, required: true },
+	},
+	{
+		// Disable Mongo's auto-`_id` so the document shape matches the
+		// framework's `Record<string, unknown>` row contract exactly.
+		_id: false,
+		// Disable the version key (`__v`) for the same reason.
+		versionKey: false,
+		collection: "guild_prefix",
+	}
+);
+
+/**
+ * Returns a Mongoose model for the framework's GuildPrefix collection bound to
+ * the given connection. Calling this multiple times for the same connection is
+ * safe — Mongoose caches models by name on the connection.
+ */
+export function createGuildPrefixModel(connection: mongoose.Connection): mongoose.Model<GuildPrefixDoc> {
+	const existing = connection.models.GuildPrefix as mongoose.Model<GuildPrefixDoc> | undefined;
+	if (existing) return existing;
+	return connection.model<GuildPrefixDoc>("GuildPrefix", guildPrefixSchema);
+}

--- a/packages/adapter-mongoose/src/mongoose-storage.test.ts
+++ b/packages/adapter-mongoose/src/mongoose-storage.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, describe, test } from "bun:test";
+import { runStorageConformance } from "@djs-commands/core";
+import mongoose from "mongoose";
+import { mongooseStorage } from "./index";
+
+const MONGO_URL = process.env.MONGO_URL;
+
+async function tryConnect(url: string): Promise<mongoose.Connection | null> {
+	const connection = mongoose.createConnection(url, {
+		serverSelectionTimeoutMS: 3_000,
+		connectTimeoutMS: 3_000,
+	});
+	// Swallow background errors so an unreachable host doesn't crash the test
+	// process before the asPromise() awaiter rejects.
+	connection.on("error", () => {});
+	try {
+		await connection.asPromise();
+		return connection;
+	} catch {
+		try {
+			await connection.close();
+		} catch {
+			// ignore
+		}
+		return null;
+	}
+}
+
+const liveConnection = MONGO_URL ? await tryConnect(MONGO_URL) : null;
+
+if (liveConnection) {
+	const storage = mongooseStorage(liveConnection);
+
+	describe("mongooseStorage (integration)", () => {
+		afterAll(async () => {
+			try {
+				await liveConnection.close();
+			} catch {
+				// ignore
+			}
+		});
+
+		runStorageConformance("mongoose", async () => storage);
+	});
+} else {
+	describe.skip("mongooseStorage (MONGO_URL not set or unreachable)", () => {
+		test("integration tests skipped", () => {});
+	});
+}

--- a/packages/adapter-mongoose/tsconfig.build.json
+++ b/packages/adapter-mongoose/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test-d.ts"]
+}

--- a/packages/adapter-mongoose/tsconfig.json
+++ b/packages/adapter-mongoose/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@djs-commands/tsconfig/library.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"noEmit": true,
+		"types": ["bun"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `@djs-commands/adapter-mongoose`, the MongoDB/Mongoose `Storage` adapter — the continuity path for v1 users (v1 was Mongo-first).
- Targets `mongoose@^8` (v1 used `mongoose@^7`); breaking-change story is referenced in the README. v2 is a clean break, so taking the latest stable major is the right call.
- Schema disables `_id` and `versionKey` so document shape matches the framework's `Record<string, unknown>` row contract exactly. Queries use `.lean()` to return plain objects, and `findOneAndUpdate(..., { new: true })` honours "update returns the row".

## Conformance suite reuse

The integration test calls `runStorageConformance("mongoose", ...)` from `@djs-commands/core` — same shared suite the Drizzle pilot uses. Skips cleanly when `MONGO_URL` is unset or unreachable (3s timeout), matching `packages/adapter-drizzle/src/drizzle-storage.test.ts`.

## Why mongoose@^8 not v1's v7

v2 is a clean break under a new npm org (`@djs-commands/*`) so we don't owe v1 a non-breaking upgrade path within a single package. Targeting `mongoose@^8` lets us:

- Inherit fixes & API improvements (e.g. `connection.asPromise()` ergonomics, default `strictQuery: false`).
- Stay on a supported major aligned with current Node LTS.

The migration story (mostly: drop `mongoose.Promise = global.Promise`, no more `findOneAndUpdate` `useFindAndModify`, `Document.save()` returns the doc not the model) is documented in the README link to Mongoose's official 8.x migration guide.

## Local verification

- `bun install` clean.
- `bun run check` clean (Biome).
- `bun run typecheck` clean across all 12 task targets.
- `bun run knip` clean.
- `bun test` — adapter-mongoose suite reports `1 skip` when `MONGO_URL` unset (expected on this CI).

A live smoke test wasn't run here (no Docker daemon available in this environment); the README documents `docker run --rm -p 27017:27017 mongo:7 && MONGO_URL=mongodb://localhost:27017/djs-commands-test bun test` for local verification.

## Test plan

- [ ] Reviewer runs `MONGO_URL=mongodb://localhost:27017/djs-commands-test bun test` locally with a fresh Mongo container and confirms all 6 conformance assertions pass.
- [ ] Verify `findOneAndUpdate` returns the post-update document (the framework relies on this).
- [ ] Confirm `_id` and `__v` are absent from returned objects.
- [ ] Verify unknown-model error throws loud (e.g. `mongooseStorage(conn).create("nonsense", {})`).
- [ ] `rm -rf apps/docs/.source && bun run ci` is green on the reviewer's machine.

Closes #61