### PR TITLE
Slice 11: DisabledCommands + ChannelLocks models

### DIFF
--- a/packages/adapter-drizzle/src/index.ts
+++ b/packages/adapter-drizzle/src/index.ts
@@ -1,14 +1,16 @@
-import { GuildPrefixModel, type Storage, type StorageFindOpts, type StorageWhere } from "@djs-commands/core";
+import { ChannelLocksModel, DisabledCommandsModel, GuildPrefixModel, type Storage, type StorageFindOpts, type StorageWhere } from "@djs-commands/core";
 import { and, asc, count, desc, eq, type SQL } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { PgTable } from "drizzle-orm/pg-core";
-import { guildPrefix } from "./schema";
+import { channelLocks, disabledCommands, guildPrefix } from "./schema";
 
-export type { GuildPrefixRow } from "./schema";
-export { guildPrefix } from "./schema";
+export type { ChannelLockRow, DisabledCommandRow, GuildPrefixRow } from "./schema";
+export { channelLocks, disabledCommands, guildPrefix } from "./schema";
 
 interface ModelTables {
 	[GuildPrefixModel]: typeof guildPrefix;
+	[DisabledCommandsModel]: typeof disabledCommands;
+	[ChannelLocksModel]: typeof channelLocks;
 }
 
 interface DrizzleStorageOptions {
@@ -17,9 +19,9 @@ interface DrizzleStorageOptions {
 
 /**
  * Returns a `Storage` implementation backed by Drizzle Postgres. Models the
- * framework knows about (currently only GuildPrefix) are mapped to their
- * Drizzle tables. Unknown models throw — adapters that don't recognize a
- * model name should fail loud, not silently no-op.
+ * framework knows about (GuildPrefix, DisabledCommands, ChannelLocks) are
+ * mapped to their Drizzle tables. Unknown models throw — adapters that don't
+ * recognize a model name should fail loud, not silently no-op.
  *
  * Bring-your-own-tables: pass `options.tables` to override defaults if you've
  * customized table names or want to share a table object with other code.
@@ -27,6 +29,8 @@ interface DrizzleStorageOptions {
 export function drizzleStorage(db: NodePgDatabase, options: DrizzleStorageOptions = {}): Storage {
 	const tables: ModelTables = {
 		[GuildPrefixModel]: options.tables?.[GuildPrefixModel] ?? guildPrefix,
+		[DisabledCommandsModel]: options.tables?.[DisabledCommandsModel] ?? disabledCommands,
+		[ChannelLocksModel]: options.tables?.[ChannelLocksModel] ?? channelLocks,
 	};
 
 	const tableFor = (model: string): PgTable => {
@@ -38,7 +42,7 @@ export function drizzleStorage(db: NodePgDatabase, options: DrizzleStorageOption
 	const buildWhere = (table: PgTable, where: StorageWhere): SQL | undefined => {
 		const conditions: SQL[] = [];
 		for (const [key, value] of Object.entries(where)) {
-			const column = (table as unknown as Record<string, unknown>)[mapColumn(key)];
+			const column = (table as unknown as Record<string, unknown>)[snakeToCamel(key)];
 			if (!column) throw new Error(`@djs-commands/adapter-drizzle: unknown column "${key}" on table for model`);
 			conditions.push(eq(column as never, value));
 		}
@@ -49,12 +53,12 @@ export function drizzleStorage(db: NodePgDatabase, options: DrizzleStorageOption
 	return {
 		async create(model, data) {
 			const table = tableFor(model);
-			const insertData = mapKeys(data as Record<string, unknown>);
+			const insertData = mapKeysToCamel(data as Record<string, unknown>);
 			const [row] = await db
 				.insert(table)
 				.values(insertData as never)
 				.returning();
-			return unmapKeys(row as Record<string, unknown>) as never;
+			return mapKeysToSnake(row as Record<string, unknown>) as never;
 		},
 		async findOne(model, where) {
 			const table = tableFor(model);
@@ -65,7 +69,7 @@ export function drizzleStorage(db: NodePgDatabase, options: DrizzleStorageOption
 				.where(condition ?? undefined)
 				.limit(1);
 			const row = rows[0];
-			return row ? (unmapKeys(row as Record<string, unknown>) as never) : null;
+			return row ? (mapKeysToSnake(row as Record<string, unknown>) as never) : null;
 		},
 		async findMany(model, opts: StorageFindOpts = {}) {
 			const table = tableFor(model);
@@ -75,7 +79,7 @@ export function drizzleStorage(db: NodePgDatabase, options: DrizzleStorageOption
 				if (condition) q = q.where(condition);
 			}
 			if (opts.orderBy) {
-				const column = (table as unknown as Record<string, unknown>)[mapColumn(opts.orderBy.field)];
+				const column = (table as unknown as Record<string, unknown>)[snakeToCamel(opts.orderBy.field)];
 				if (column) {
 					q = q.orderBy(opts.orderBy.direction === "desc" ? desc(column as never) : asc(column as never));
 				}
@@ -83,19 +87,19 @@ export function drizzleStorage(db: NodePgDatabase, options: DrizzleStorageOption
 			if (opts.limit !== undefined) q = q.limit(opts.limit);
 			if (opts.offset !== undefined) q = q.offset(opts.offset);
 			const rows = await q;
-			return rows.map((r) => unmapKeys(r as Record<string, unknown>)) as never;
+			return rows.map((r) => mapKeysToSnake(r as Record<string, unknown>)) as never;
 		},
 		async update(model, where, data) {
 			const table = tableFor(model);
 			const condition = buildWhere(table, where);
-			const updateData = mapKeys(data as Record<string, unknown>);
+			const updateData = mapKeysToCamel(data as Record<string, unknown>);
 			const [row] = await db
 				.update(table)
 				.set(updateData as never)
 				.where(condition ?? undefined)
 				.returning();
 			if (!row) throw new Error(`@djs-commands/adapter-drizzle: no row matched update for model "${model}"`);
-			return unmapKeys(row as Record<string, unknown>) as never;
+			return mapKeysToSnake(row as Record<string, unknown>) as never;
 		},
 		async delete(model, where) {
 			const table = tableFor(model);
@@ -114,25 +118,24 @@ export function drizzleStorage(db: NodePgDatabase, options: DrizzleStorageOption
 	};
 }
 
-// Drizzle's TS-side column names use camelCase (guildId) while the database
-// uses snake_case (guild_id). The framework's `Where`/`Row` shapes are the
-// snake_case API names, so we translate at the boundary.
-function mapColumn(name: string): string {
-	if (name === "guild_id") return "guildId";
-	return name;
+// Drizzle's TS-side column names use camelCase while the database uses
+// snake_case. The framework's API uses snake_case, so translate at the boundary.
+function snakeToCamel(s: string): string {
+	return s.replace(/_([a-z])/g, (_, c) => (c as string).toUpperCase());
 }
 
-function mapKeys(obj: Record<string, unknown>): Record<string, unknown> {
+function camelToSnake(s: string): string {
+	return s.replace(/([A-Z])/g, (_, c) => `_${(c as string).toLowerCase()}`);
+}
+
+function mapKeysToCamel(obj: Record<string, unknown>): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
-	for (const [k, v] of Object.entries(obj)) out[mapColumn(k)] = v;
+	for (const [k, v] of Object.entries(obj)) out[snakeToCamel(k)] = v;
 	return out;
 }
 
-function unmapKeys(obj: Record<string, unknown>): Record<string, unknown> {
+function mapKeysToSnake(obj: Record<string, unknown>): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
-	for (const [k, v] of Object.entries(obj)) {
-		const reversed = k === "guildId" ? "guild_id" : k;
-		out[reversed] = v;
-	}
+	for (const [k, v] of Object.entries(obj)) out[camelToSnake(k)] = v;
 	return out;
 }

--- a/packages/adapter-drizzle/src/schema.ts
+++ b/packages/adapter-drizzle/src/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text } from "drizzle-orm/pg-core";
+import { pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 
 /** Drizzle Postgres schema for the framework's GuildPrefix model. */
 export const guildPrefix = pgTable("guild_prefix", {
@@ -7,3 +7,28 @@ export const guildPrefix = pgTable("guild_prefix", {
 });
 
 export type GuildPrefixRow = typeof guildPrefix.$inferSelect;
+
+/** Per-guild kill switch for a command. */
+export const disabledCommands = pgTable(
+	"disabled_commands",
+	{
+		guildId: text("guild_id").notNull(),
+		commandName: text("command_name").notNull(),
+	},
+	(t) => [primaryKey({ columns: [t.guildId, t.commandName] })]
+);
+
+export type DisabledCommandRow = typeof disabledCommands.$inferSelect;
+
+/** Per-guild allow-list of channels a command may run in. */
+export const channelLocks = pgTable(
+	"channel_locks",
+	{
+		guildId: text("guild_id").notNull(),
+		commandName: text("command_name").notNull(),
+		channelId: text("channel_id").notNull(),
+	},
+	(t) => [primaryKey({ columns: [t.guildId, t.commandName, t.channelId] })]
+);
+
+export type ChannelLockRow = typeof channelLocks.$inferSelect;

--- a/packages/adapter-mongoose/src/index.ts
+++ b/packages/adapter-mongoose/src/index.ts
@@ -1,25 +1,29 @@
-import { GuildPrefixModel, type Storage, type StorageFindOpts, type StorageWhere } from "@djs-commands/core";
+import { ChannelLocksModel, DisabledCommandsModel, GuildPrefixModel, type Storage, type StorageFindOpts, type StorageWhere } from "@djs-commands/core";
 import type mongoose from "mongoose";
-import { createGuildPrefixModel, type GuildPrefixDoc } from "./models";
+import { type ChannelLockDoc, createChannelLockModel, createDisabledCommandModel, createGuildPrefixModel, type DisabledCommandDoc, type GuildPrefixDoc } from "./models";
 
-export type { GuildPrefixDoc } from "./models";
-export { createGuildPrefixModel } from "./models";
+export type { ChannelLockDoc, DisabledCommandDoc, GuildPrefixDoc } from "./models";
+export { createChannelLockModel, createDisabledCommandModel, createGuildPrefixModel } from "./models";
 
 interface ModelMap {
 	[GuildPrefixModel]: mongoose.Model<GuildPrefixDoc>;
+	[DisabledCommandsModel]: mongoose.Model<DisabledCommandDoc>;
+	[ChannelLocksModel]: mongoose.Model<ChannelLockDoc>;
 }
 
 interface MongooseStorageOptions {
 	models?: {
 		guildPrefix?: mongoose.Model<GuildPrefixDoc>;
+		disabledCommands?: mongoose.Model<DisabledCommandDoc>;
+		channelLocks?: mongoose.Model<ChannelLockDoc>;
 	};
 }
 
 /**
  * Returns a `Storage` implementation backed by Mongoose. Models the framework
- * knows about (currently only GuildPrefix) are mapped to their Mongoose
- * models. Unknown models throw — adapters that don't recognize a model name
- * should fail loud, not silently no-op.
+ * knows about (GuildPrefix, DisabledCommands, ChannelLocks) are mapped to their
+ * Mongoose models. Unknown models throw — adapters that don't recognize a model
+ * name should fail loud, not silently no-op.
  *
  * Bring-your-own-models: pass `options.models` to override defaults if you've
  * already registered a compatible model on the connection.
@@ -27,6 +31,8 @@ interface MongooseStorageOptions {
 export function mongooseStorage(connection: mongoose.Connection, options: MongooseStorageOptions = {}): Storage {
 	const models: ModelMap = {
 		[GuildPrefixModel]: options.models?.guildPrefix ?? createGuildPrefixModel(connection),
+		[DisabledCommandsModel]: options.models?.disabledCommands ?? createDisabledCommandModel(connection),
+		[ChannelLocksModel]: options.models?.channelLocks ?? createChannelLockModel(connection),
 	};
 
 	const modelFor = (name: string): mongoose.Model<Record<string, unknown>> => {

--- a/packages/adapter-mongoose/src/models.ts
+++ b/packages/adapter-mongoose/src/models.ts
@@ -1,10 +1,15 @@
 import mongoose from "mongoose";
 
-/**
- * Schema shape for the framework's GuildPrefix model. Mongoose works with
- * flexible schemas so we use the framework's snake_case field name (`guild_id`)
- * directly — no camelCase translation layer needed at the boundary.
- */
+const SCHEMA_OPTS = {
+	// Disable Mongo's auto-`_id` so document shapes match the framework's
+	// `Record<string, unknown>` row contract exactly.
+	_id: false,
+	// Disable the version key (`__v`) for the same reason.
+	versionKey: false,
+} as const;
+
+// ─── GuildPrefix ───────────────────────────────────────────────────────────
+
 export interface GuildPrefixDoc {
 	guild_id: string;
 	prefix: string;
@@ -15,23 +20,57 @@ const guildPrefixSchema = new mongoose.Schema<GuildPrefixDoc>(
 		guild_id: { type: String, required: true, unique: true },
 		prefix: { type: String, required: true },
 	},
-	{
-		// Disable Mongo's auto-`_id` so the document shape matches the
-		// framework's `Record<string, unknown>` row contract exactly.
-		_id: false,
-		// Disable the version key (`__v`) for the same reason.
-		versionKey: false,
-		collection: "guild_prefix",
-	}
+	{ ...SCHEMA_OPTS, collection: "guild_prefix" }
 );
 
-/**
- * Returns a Mongoose model for the framework's GuildPrefix collection bound to
- * the given connection. Calling this multiple times for the same connection is
- * safe — Mongoose caches models by name on the connection.
- */
 export function createGuildPrefixModel(connection: mongoose.Connection): mongoose.Model<GuildPrefixDoc> {
 	const existing = connection.models.GuildPrefix as mongoose.Model<GuildPrefixDoc> | undefined;
 	if (existing) return existing;
 	return connection.model<GuildPrefixDoc>("GuildPrefix", guildPrefixSchema);
+}
+
+// ─── DisabledCommands ──────────────────────────────────────────────────────
+
+export interface DisabledCommandDoc {
+	guild_id: string;
+	command_name: string;
+}
+
+const disabledCommandSchema = new mongoose.Schema<DisabledCommandDoc>(
+	{
+		guild_id: { type: String, required: true },
+		command_name: { type: String, required: true },
+	},
+	{ ...SCHEMA_OPTS, collection: "disabled_commands" }
+);
+disabledCommandSchema.index({ guild_id: 1, command_name: 1 }, { unique: true });
+
+export function createDisabledCommandModel(connection: mongoose.Connection): mongoose.Model<DisabledCommandDoc> {
+	const existing = connection.models.DisabledCommand as mongoose.Model<DisabledCommandDoc> | undefined;
+	if (existing) return existing;
+	return connection.model<DisabledCommandDoc>("DisabledCommand", disabledCommandSchema);
+}
+
+// ─── ChannelLocks ──────────────────────────────────────────────────────────
+
+export interface ChannelLockDoc {
+	guild_id: string;
+	command_name: string;
+	channel_id: string;
+}
+
+const channelLockSchema = new mongoose.Schema<ChannelLockDoc>(
+	{
+		guild_id: { type: String, required: true },
+		command_name: { type: String, required: true },
+		channel_id: { type: String, required: true },
+	},
+	{ ...SCHEMA_OPTS, collection: "channel_locks" }
+);
+channelLockSchema.index({ guild_id: 1, command_name: 1, channel_id: 1 }, { unique: true });
+
+export function createChannelLockModel(connection: mongoose.Connection): mongoose.Model<ChannelLockDoc> {
+	const existing = connection.models.ChannelLock as mongoose.Model<ChannelLockDoc> | undefined;
+	if (existing) return existing;
+	return connection.model<ChannelLockDoc>("ChannelLock", channelLockSchema);
 }

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -1,4 +1,4 @@
-import { GuildPrefixModel, type Storage, type StorageFindOpts, type StorageWhere } from "@djs-commands/core";
+import { ChannelLocksModel, DisabledCommandsModel, GuildPrefixModel, type Storage, type StorageFindOpts, type StorageWhere } from "@djs-commands/core";
 
 /**
  * Minimal structural shape of a generated Prisma Client. We only need the
@@ -19,6 +19,8 @@ export type PrismaClientLike = Record<string, unknown>;
 
 interface ModelDelegates {
 	[GuildPrefixModel]: PrismaDelegate;
+	[DisabledCommandsModel]: PrismaDelegate;
+	[ChannelLocksModel]: PrismaDelegate;
 }
 
 interface PrismaStorageOptions {
@@ -44,6 +46,25 @@ export const GUILD_PREFIX_PRISMA_MODEL = `model GuildPrefix {
 }
 `;
 
+export const DISABLED_COMMANDS_PRISMA_MODEL = `model DisabledCommand {
+    guildId     String @map("guild_id")
+    commandName String @map("command_name")
+
+    @@id([guildId, commandName])
+    @@map("disabled_commands")
+}
+`;
+
+export const CHANNEL_LOCKS_PRISMA_MODEL = `model ChannelLock {
+    guildId     String @map("guild_id")
+    commandName String @map("command_name")
+    channelId   String @map("channel_id")
+
+    @@id([guildId, commandName, channelId])
+    @@map("channel_locks")
+}
+`;
+
 /**
  * Returns a `Storage` implementation backed by a Prisma Client. Models the
  * framework knows about (currently only GuildPrefix) are looked up on the
@@ -55,14 +76,24 @@ export const GUILD_PREFIX_PRISMA_MODEL = `model GuildPrefix {
  * lookup if you've renamed the model in your schema.
  */
 export function prismaStorage(prisma: PrismaClientLike, options: PrismaStorageOptions = {}): Storage {
-	const delegates: ModelDelegates = {
-		[GuildPrefixModel]: options.delegates?.[GuildPrefixModel] ?? resolveDelegate(prisma, GuildPrefixModel),
-	};
+	const overrides = options.delegates ?? {};
+	const cache = new Map<string, PrismaDelegate>();
 
+	// Lazy delegate resolution — we only look up a delegate when the model is
+	// actually used at runtime. This avoids requiring every Prisma client we
+	// touch to have all framework models generated; users that only use
+	// GuildPrefix don't pay for DisabledCommands / ChannelLocks delegate
+	// existence checks at construction time.
 	const delegateFor = (model: string): PrismaDelegate => {
-		const delegate = delegates[model as keyof ModelDelegates];
-		if (!delegate) throw new Error(`@djs-commands/adapter-prisma: unknown model "${model}"`);
-		return delegate;
+		const cached = cache.get(model);
+		if (cached) return cached;
+		if (model === GuildPrefixModel || model === DisabledCommandsModel || model === ChannelLocksModel) {
+			const override = overrides[model as keyof ModelDelegates];
+			const resolved = override ?? resolveDelegate(prisma, prismaDelegateName(model));
+			cache.set(model, resolved);
+			return resolved;
+		}
+		throw new Error(`@djs-commands/adapter-prisma: unknown model "${model}"`);
 	};
 
 	return {
@@ -121,25 +152,36 @@ export function prismaStorage(prisma: PrismaClientLike, options: PrismaStorageOp
 }
 
 /**
- * Maps a framework model name (e.g. `"guild_prefix"`) to its Prisma delegate.
- * Prisma exposes models as camelCase properties on the client, so we translate
- * `snake_case` → `camelCase` and read it off the client.
+ * The Prisma delegate name for each framework model. We can't just snake→camel
+ * the model name because the framework's plural/singular doesn't always match
+ * Prisma's convention (e.g. `disabled_commands` model → `disabledCommand`
+ * delegate per the Prisma model fragment we ship).
  */
-function resolveDelegate(prisma: PrismaClientLike, model: string): PrismaDelegate {
-	const key = snakeToCamel(model);
+function prismaDelegateName(model: string): string {
+	if (model === GuildPrefixModel) return "guildPrefix";
+	if (model === DisabledCommandsModel) return "disabledCommand";
+	if (model === ChannelLocksModel) return "channelLock";
+	return snakeToCamel(model);
+}
+
+/**
+ * Reads a Prisma delegate by camelCase name from the client. Throws loud if
+ * the delegate isn't on the client (means the model wasn't merged into
+ * `schema.prisma` or the client wasn't regenerated).
+ */
+function resolveDelegate(prisma: PrismaClientLike, key: string): PrismaDelegate {
 	const delegate = (prisma as Record<string, unknown>)[key];
 	if (!delegate || typeof delegate !== "object") {
-		throw new Error(`@djs-commands/adapter-prisma: Prisma client has no delegate for model "${model}" (expected prisma.${key})`);
+		throw new Error(`@djs-commands/adapter-prisma: Prisma client has no delegate for "prisma.${key}"`);
 	}
 	return delegate as PrismaDelegate;
 }
 
-// Prisma's TS-side field names use camelCase (guildId) while the database
-// uses snake_case (guild_id) via @map. The framework's `Where`/`Row` shapes are
-// the snake_case API names, so we translate at the boundary.
+// Prisma's TS-side field names use camelCase while the database uses
+// snake_case via @map. The framework's API uses snake_case, so translate at
+// the boundary.
 function mapColumn(name: string): string {
-	if (name === "guild_id") return "guildId";
-	return name;
+	return snakeToCamel(name);
 }
 
 function mapKeys(obj: Record<string, unknown>): Record<string, unknown> {
@@ -150,13 +192,14 @@ function mapKeys(obj: Record<string, unknown>): Record<string, unknown> {
 
 function unmapKeys(obj: Record<string, unknown>): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
-	for (const [k, v] of Object.entries(obj)) {
-		const reversed = k === "guildId" ? "guild_id" : k;
-		out[reversed] = v;
-	}
+	for (const [k, v] of Object.entries(obj)) out[camelToSnake(k)] = v;
 	return out;
 }
 
 function snakeToCamel(input: string): string {
 	return input.replace(/_([a-z])/g, (_match, ch: string) => ch.toUpperCase());
+}
+
+function camelToSnake(input: string): string {
+	return input.replace(/([A-Z])/g, (_match, ch: string) => `_${ch.toLowerCase()}`);
 }

--- a/packages/adapter-prisma/src/prisma-storage.test.ts
+++ b/packages/adapter-prisma/src/prisma-storage.test.ts
@@ -144,8 +144,9 @@ describe("prismaStorage (mocked)", () => {
 		expect(await storage.count(GuildPrefixModel, { guild_id: "g1" })).toBe(1);
 	});
 
-	test("unknown delegate on the client throws loud", () => {
-		expect(() => prismaStorage({})).toThrow(/no delegate for model "guild_prefix"/);
+	test("missing delegate on the client throws loud at first use (lazy)", async () => {
+		const storage = prismaStorage({});
+		await expect(async () => storage.findOne(GuildPrefixModel, { guild_id: "x" })).toThrow(/no delegate for "prisma\.guildPrefix"/);
 	});
 
 	test("GUILD_PREFIX_PRISMA_MODEL exports the schema fragment string", () => {

--- a/packages/adapter-prisma/src/schema.prisma.txt
+++ b/packages/adapter-prisma/src/schema.prisma.txt
@@ -1,10 +1,27 @@
-// @djs-commands/adapter-prisma — paste this model into your `schema.prisma`.
+// @djs-commands/adapter-prisma — paste these models into your `schema.prisma`.
 // Field names use camelCase on the Prisma side and are mapped to snake_case
-// columns so the underlying table matches the framework's API names.
+// columns so the underlying tables match the framework's API names.
 
 model GuildPrefix {
     guildId String @id @map("guild_id")
     prefix  String
 
     @@map("guild_prefix")
+}
+
+model DisabledCommand {
+    guildId     String @map("guild_id")
+    commandName String @map("command_name")
+
+    @@id([guildId, commandName])
+    @@map("disabled_commands")
+}
+
+model ChannelLock {
+    guildId     String @map("guild_id")
+    commandName String @map("command_name")
+    channelId   String @map("channel_id")
+
+    @@id([guildId, commandName, channelId])
+    @@map("channel_locks")
 }

--- a/packages/core/src/dispatcher.test.ts
+++ b/packages/core/src/dispatcher.test.ts
@@ -1,6 +1,7 @@
 import { expect, mock, test } from "bun:test";
 import type { ChatInputCommandInteraction } from "discord.js";
 import { Dispatcher } from "./dispatcher";
+import type { Storage, StorageFindOpts, StorageWhere } from "./storage";
 
 const fakeInteraction = (commandName: string, optionValues: Record<string, unknown> = {}) =>
 	({
@@ -119,4 +120,148 @@ test("dispatch passes a unified ctx with reply/author/guild/channelId", async ()
 	expect(ctx?.type).toBe("slash");
 	expect(ctx?.channelId).toBe("channel-1");
 	expect(typeof ctx?.reply).toBe("function");
+});
+
+// ─── storage-backed runtime gates ─────────────────────────────────────────
+
+type FakeRow = Record<string, unknown>;
+
+const matches = (row: FakeRow, where: StorageWhere): boolean => {
+	for (const [k, v] of Object.entries(where)) {
+		if (row[k] !== v) return false;
+	}
+	return true;
+};
+
+const fakeStorage = (initial: Record<string, FakeRow[]> = {}): Storage => {
+	const tables = new Map<string, FakeRow[]>(Object.entries(initial));
+	const getTable = (model: string) => {
+		if (!tables.has(model)) tables.set(model, []);
+		const t = tables.get(model);
+		if (!t) throw new Error("unreachable");
+		return t;
+	};
+	return {
+		async create(model, data) {
+			getTable(model).push({ ...data });
+			return data;
+		},
+		async findOne(model, where) {
+			const row = getTable(model).find((r) => matches(r, where));
+			return (row ?? null) as never;
+		},
+		async findMany(model, opts: StorageFindOpts = {}) {
+			const where = opts.where;
+			let rows = getTable(model);
+			if (where) rows = rows.filter((r) => matches(r, where));
+			return [...rows] as never;
+		},
+		async update(model, where, data) {
+			const row = getTable(model).find((r) => matches(r, where));
+			if (!row) throw new Error("no match");
+			Object.assign(row, data);
+			return row as never;
+		},
+		async delete(model, where) {
+			const t = getTable(model);
+			for (let i = t.length - 1; i >= 0; i--) {
+				const row = t[i];
+				if (row && matches(row, where)) t.splice(i, 1);
+			}
+		},
+		async count(model, where) {
+			const t = getTable(model);
+			return where ? t.filter((r) => matches(r, where)).length : t.length;
+		},
+	};
+};
+
+const guildInteraction = (commandName: string, channelId = "channel-1", guildId = "guild-1") =>
+	({
+		commandName,
+		user: { id: "user-1" },
+		guild: { id: guildId },
+		guildId,
+		member: null,
+		channel: null,
+		channelId,
+		client: {} as unknown,
+		replied: false,
+		deferred: false,
+		reply: mock(async () => undefined),
+		options: {
+			getString: () => null,
+			getInteger: () => null,
+			getNumber: () => null,
+			getBoolean: () => null,
+			getUser: () => null,
+			getChannel: () => null,
+			getRole: () => null,
+			getMentionable: () => null,
+			getAttachment: () => null,
+		},
+	}) as unknown as ChatInputCommandInteraction;
+
+test("storage gate: blocks when DisabledCommands has a row for this guild+command", async () => {
+	const storage = fakeStorage({
+		disabled_commands: [{ guild_id: "guild-1", command_name: "ping" }],
+	});
+	const dispatcher = new Dispatcher({ storage });
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({ name: "ping", description: "ping", run });
+
+	await dispatcher.dispatch(guildInteraction("ping"));
+
+	expect(run).toHaveBeenCalledTimes(0);
+});
+
+test("storage gate: lets command through when not disabled", async () => {
+	const storage = fakeStorage();
+	const dispatcher = new Dispatcher({ storage });
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({ name: "ping", description: "ping", run });
+
+	await dispatcher.dispatch(guildInteraction("ping"));
+
+	expect(run).toHaveBeenCalledTimes(1);
+});
+
+test("storage gate: blocks when channel locks exist and current channel is not allowed", async () => {
+	const storage = fakeStorage({
+		channel_locks: [{ guild_id: "guild-1", command_name: "ping", channel_id: "allowed-channel" }],
+	});
+	const dispatcher = new Dispatcher({ storage });
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({ name: "ping", description: "ping", run });
+
+	await dispatcher.dispatch(guildInteraction("ping", "blocked-channel"));
+
+	expect(run).toHaveBeenCalledTimes(0);
+});
+
+test("storage gate: allows when current channel is in the lock list", async () => {
+	const storage = fakeStorage({
+		channel_locks: [{ guild_id: "guild-1", command_name: "ping", channel_id: "allowed-channel" }],
+	});
+	const dispatcher = new Dispatcher({ storage });
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({ name: "ping", description: "ping", run });
+
+	await dispatcher.dispatch(guildInteraction("ping", "allowed-channel"));
+
+	expect(run).toHaveBeenCalledTimes(1);
+});
+
+test("storage gate: no-op when invocation isn't in a guild (DMs)", async () => {
+	const storage = fakeStorage({
+		disabled_commands: [{ guild_id: "guild-1", command_name: "ping" }],
+	});
+	const dispatcher = new Dispatcher({ storage });
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({ name: "ping", description: "ping", run });
+
+	// guildId: null → DM context, gates skip and command runs
+	await dispatcher.dispatch(fakeInteraction("ping"));
+
+	expect(run).toHaveBeenCalledTimes(1);
 });

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -3,6 +3,7 @@ import { normalizeLegacyContext, normalizeSlashContext } from "./context";
 import { type CacheAdapter, CooldownEngine } from "./cooldowns";
 import { parseLegacyArgs } from "./legacy-parser";
 import { extractOptions } from "./options";
+import { getChannelLocks, isCommandDisabled, type Storage } from "./storage";
 import type { AnyCommand } from "./types";
 import { type CanRunCommand, runValidatorChain, type Validator, type ValidatorContext, type ValidatorSource } from "./validators";
 
@@ -11,6 +12,7 @@ interface DispatcherConfig {
 	globalValidators: readonly Validator[];
 	canRunCommand?: CanRunCommand;
 	cacheAdapter?: CacheAdapter;
+	storage?: Storage;
 }
 
 export class Dispatcher {
@@ -25,6 +27,7 @@ export class Dispatcher {
 			globalValidators: config.globalValidators ?? [],
 			canRunCommand: config.canRunCommand,
 			cacheAdapter: config.cacheAdapter,
+			storage: config.storage,
 		};
 		this.cooldowns = new CooldownEngine(this.config.cacheAdapter);
 	}
@@ -57,6 +60,12 @@ export class Dispatcher {
 
 		if (!validation.ok) {
 			await replyFailure(validatorCtx.source, validation.reason);
+			return;
+		}
+
+		const storageGate = await this.runStorageGates(command, interaction.guildId, interaction.channelId);
+		if (storageGate) {
+			await replyFailure(validatorCtx.source, storageGate);
 			return;
 		}
 
@@ -106,6 +115,12 @@ export class Dispatcher {
 			return;
 		}
 
+		const storageGate = await this.runStorageGates(command, message.guildId, message.channelId);
+		if (storageGate) {
+			await replyFailure(validatorCtx.source, storageGate);
+			return;
+		}
+
 		const actor = { userId: message.author.id, guildId: message.guildId };
 		const remaining = await this.cooldowns.check(command, actor);
 		if (remaining !== null) {
@@ -121,6 +136,30 @@ export class Dispatcher {
 
 		await this.cooldowns.start(command, actor);
 		await command.run(normalizeLegacyContext(message, parsed.options));
+	}
+
+	/**
+	 * Storage-backed runtime gates: per-guild kill switch (DisabledCommands) and
+	 * per-guild channel allow-list (ChannelLocks). Returns a failure reason if
+	 * the command should be blocked, or null if it can proceed. No-op when no
+	 * storage is configured or the invocation is outside a guild.
+	 */
+	private async runStorageGates(command: AnyCommand, guildId: string | null, channelId: string): Promise<string | null> {
+		const storage = this.config.storage;
+		if (!storage || !guildId) return null;
+
+		try {
+			if (await isCommandDisabled(storage, guildId, command.name)) {
+				return "This command is currently disabled in this server.";
+			}
+			const locks = await getChannelLocks(storage, guildId, command.name);
+			if (locks.length > 0 && !locks.includes(channelId)) {
+				return "This command is locked to a different channel.";
+			}
+		} catch (err) {
+			console.error("[djs-commands] Storage gate check failed:", err);
+		}
+		return null;
 	}
 }
 

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -20,6 +20,7 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		globalValidators: options.validators ?? [],
 		canRunCommand: options.canRunCommand,
 		cacheAdapter: options.cacheAdapter,
+		storage: options.storage,
 	});
 
 	for (const command of allCommands) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,7 +54,26 @@ export type {
 	UserOption,
 } from "./options";
 export type { PluginManifest, PluginSetupContext } from "./plugin";
-export { clearGuildPrefix, GuildPrefixModel, type GuildPrefixRow, getGuildPrefix, type Storage, type StorageFindOpts, type StorageWhere, setGuildPrefix } from "./storage";
+export {
+	type ChannelLockRow,
+	ChannelLocksModel,
+	clearGuildPrefix,
+	type DisabledCommandRow,
+	DisabledCommandsModel,
+	disableCommand,
+	enableCommand,
+	GuildPrefixModel,
+	type GuildPrefixRow,
+	getChannelLocks,
+	getGuildPrefix,
+	isCommandDisabled,
+	lockCommandToChannel,
+	type Storage,
+	type StorageFindOpts,
+	type StorageWhere,
+	setGuildPrefix,
+	unlockCommandFromChannel,
+} from "./storage";
 export { runStorageConformance } from "./storage-conformance";
 export type {
 	AnyCommand,

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -52,3 +52,84 @@ export async function setGuildPrefix(storage: Storage, guildId: string, prefix: 
 export async function clearGuildPrefix(storage: Storage, guildId: string): Promise<void> {
 	await storage.delete(GuildPrefixModel, { guild_id: guildId });
 }
+
+// ─── DisabledCommands model ────────────────────────────────────────────────
+
+export const DisabledCommandsModel = "disabled_commands" as const;
+
+export interface DisabledCommandRow extends Record<string, unknown> {
+	guild_id: string;
+	command_name: string;
+}
+
+/** Returns true if the named command is disabled for the given guild. */
+export async function isCommandDisabled(storage: Storage, guildId: string, commandName: string): Promise<boolean> {
+	const row = await storage.findOne<DisabledCommandRow>(DisabledCommandsModel, {
+		guild_id: guildId,
+		command_name: commandName,
+	});
+	return row !== null;
+}
+
+export async function disableCommand(storage: Storage, guildId: string, commandName: string): Promise<void> {
+	const existing = await storage.findOne<DisabledCommandRow>(DisabledCommandsModel, {
+		guild_id: guildId,
+		command_name: commandName,
+	});
+	if (existing) return;
+	await storage.create<DisabledCommandRow>(DisabledCommandsModel, {
+		guild_id: guildId,
+		command_name: commandName,
+	});
+}
+
+export async function enableCommand(storage: Storage, guildId: string, commandName: string): Promise<void> {
+	await storage.delete(DisabledCommandsModel, {
+		guild_id: guildId,
+		command_name: commandName,
+	});
+}
+
+// ─── ChannelLocks model ────────────────────────────────────────────────────
+
+export const ChannelLocksModel = "channel_locks" as const;
+
+export interface ChannelLockRow extends Record<string, unknown> {
+	guild_id: string;
+	command_name: string;
+	channel_id: string;
+}
+
+/**
+ * Returns the list of channel IDs the named command is locked to in the given
+ * guild. An empty array means no lock — the command runs anywhere (subject to
+ * other validators). Non-empty means the command ONLY runs in those channels.
+ */
+export async function getChannelLocks(storage: Storage, guildId: string, commandName: string): Promise<string[]> {
+	const rows = await storage.findMany<ChannelLockRow>(ChannelLocksModel, {
+		where: { guild_id: guildId, command_name: commandName },
+	});
+	return rows.map((r) => r.channel_id);
+}
+
+export async function lockCommandToChannel(storage: Storage, guildId: string, commandName: string, channelId: string): Promise<void> {
+	const existing = await storage.findOne<ChannelLockRow>(ChannelLocksModel, {
+		guild_id: guildId,
+		command_name: commandName,
+		channel_id: channelId,
+	});
+	if (existing) return;
+	await storage.create<ChannelLockRow>(ChannelLocksModel, {
+		guild_id: guildId,
+		command_name: commandName,
+		channel_id: channelId,
+	});
+}
+
+export async function unlockCommandFromChannel(storage: Storage, guildId: string, commandName: string, channelId: string): Promise<void> {
+	await storage.delete(ChannelLocksModel, {
+		guild_id: guildId,
+		command_name: commandName,
+		channel_id: channelId,
+	});
+}


### PR DESCRIPTION
## Summary

Two new framework-defined storage models — `DisabledCommands` (per-guild kill switch) and `ChannelLocks` (per-guild allow-list of channels). Adapters only needed to extend their model dispatch; the contract didn't change. Dispatcher consults storage between validators and cooldown when an adapter is provided.

Closes #62.

## What changed

### Core
- `storage.ts` — two new models + helpers (`isCommandDisabled` / `disableCommand` / `enableCommand` and `getChannelLocks` / `lockCommandToChannel` / `unlockCommandFromChannel`)
- `dispatcher.ts` — `storage` in `DispatcherConfig`. New `runStorageGates()` runs **after** the validator chain and **before** cooldown. Catches storage errors so a transient DB hiccup can't take down command execution. No-op in DM contexts (gates only apply per-guild).
- `index.ts` — exports the new model constants, row types, and helpers
- 5 new dispatcher tests using a fake in-memory Storage covering both gates' allow + block paths and the DM no-op

### Drizzle adapter
- `schema.ts` — `disabledCommands` + `channelLocks` pgTables with composite PKs
- `index.ts` — extends `ModelTables` to all 3 models. snake/camel mapping generalized via regex helpers so `guild_id` / `command_name` / `channel_id` all map uniformly to camelCase columns.

### Prisma adapter
- `schema.prisma.txt` + new `DISABLED_COMMANDS_PRISMA_MODEL` + `CHANNEL_LOCKS_PRISMA_MODEL` constants
- `index.ts` — **lazy delegate resolution** (was eager). Only looks up a Prisma delegate when the model is actually used at runtime. Avoids requiring every client to have all 3 models generated; users who only want `GuildPrefix` don't pay for delegate-existence checks at construction time.

### Mongoose adapter
- `models.ts` — `createDisabledCommandModel` + `createChannelLockModel` with composite-key indexes
- `index.ts` — extends `ModelMap` to all 3 models with overridable factories

## Local verification

```
$ rm -rf apps/docs/.source && bun run ci
$ biome check                  ✓ 114 files
$ tsc (typecheck)              ✓ all packages
$ knip                         ✓ clean
$ bun test                     ✓ 73 core + 14 prisma + 10 jsx + adapter tests
```

## Test plan
- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer eyeballs the lazy-delegate refactor in adapter-prisma (was eager — change is what makes the slice land cleanly without forcing all 3 models on every Prisma client)
- [ ] Reviewer skims the gate ordering in dispatcher (validators → storage gates → cooldown → run); locks the surface for #62

## Future
- A `Storage`-aware `runStorageConformance` could exercise the new models against each adapter (currently the conformance tests only cover GuildPrefix). Could land alongside #67/#68 cleanup.