### PR TITLE
Slice 16: v1 → v2 migration guide (content)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,32 @@
 
 > Modern command handler for Discord.js — TypeScript-first, Components V2 native, with pluggable persistence.
 
-**v2 is in active development.** v1 (`@d3oxy/djs-commands`) is preserved at the [`v1-final-commit` tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit).
+## Coming from v1 (`@d3oxy/djs-commands`)?
+
+The v1 package is preserved at the [`v1-final-commit` tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and stays on npm under `@d3oxy/djs-commands@1.4.x`. To upgrade to v2, follow the [Migration from v1](https://djscommands.deoxy.dev/migration-from-v1) guide — every v1 API has a v2 equivalent (with side-by-side examples).
 
 ## Quick start
 
 ```bash
-git clone https://github.com/D3OXY/djs-commands
-cd djs-commands
-bun install
-cp examples/minimal/.env.example examples/minimal/.env  # add DISCORD_TOKEN
-bun run --cwd examples/minimal dev
+npx create-djs-commands my-bot
+cd my-bot
+cp .env.example .env  # add DISCORD_TOKEN
+bun run dev
 ```
+
+Or scaffold by hand from the [Getting Started guide](https://djscommands.deoxy.dev/getting-started).
 
 ## Packages
 
-| Package | Description | Status |
-|---|---|---|
-| [`@djs-commands/core`](./packages/core) | Command dispatcher and core API | early bootstrap |
-
-More packages coming — see [PRD #51](https://github.com/D3OXY/djs-commands/issues/51) and the [v2 roadmap](https://github.com/D3OXY/djs-commands/issues?q=is%3Aopen+label%3Aneeds-triage).
+| Package | Description |
+|---|---|
+| [`@djs-commands/core`](./packages/core) | Command dispatcher, definitions, validators, plugins, fs-autoloader |
+| [`@djs-commands/jsx`](./packages/jsx) | Components V2 JSX runtime (opt-in) |
+| [`@djs-commands/cli`](./packages/cli) | `create-djs-commands` scaffolding tool |
+| [`@djs-commands/adapter-drizzle`](./packages/adapter-drizzle) | Drizzle/Postgres `Storage` adapter |
+| [`@djs-commands/adapter-prisma`](./packages/adapter-prisma) | Prisma `Storage` adapter |
+| [`@djs-commands/adapter-mongoose`](./packages/adapter-mongoose) | Mongoose `Storage` adapter (v1 continuity path) |
+| [`@djs-commands/adapter-redis`](./packages/adapter-redis) | Redis `CacheAdapter` for distributed cooldowns |
 
 ## Development
 

--- a/apps/docs/content/pages/index.mdx
+++ b/apps/docs/content/pages/index.mdx
@@ -25,6 +25,10 @@ v2 is in active development. The legacy v1 package (`@d3oxy/djs-commands`) is pr
 	<Card title="Recipes" href="/recipes" description="Copy-paste solutions for common bot patterns: pagination, modals, role gates, and more." />
 </Cards>
 
+## Coming from v1?
+
+If you have a bot built on `@d3oxy/djs-commands`, the [Migration from v1](/migration-from-v1) guide walks you through every API that moved or was dropped, with side-by-side examples.
+
 ## Useful links
 
 - [GitHub](https://github.com/D3OXY/djs-commands) — source, issues, discussions

--- a/apps/docs/content/pages/meta.json
+++ b/apps/docs/content/pages/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Documentation",
-	"pages": ["index", "getting-started", "concepts", "recipes", "api-reference", "adapter-cookbook", "components-v2"]
+	"pages": ["index", "getting-started", "concepts", "recipes", "api-reference", "adapter-cookbook", "components-v2", "migration-from-v1"]
 }

--- a/apps/docs/content/pages/migration-from-v1/commands.mdx
+++ b/apps/docs/content/pages/migration-from-v1/commands.mdx
@@ -1,0 +1,142 @@
+---
+title: Command files
+description: CommandType.SLASH/LEGACY/BOTH and callback(usage) become defineCommand(ctx)
+---
+
+# Command files
+
+v1 used `CommandType.SLASH | LEGACY | BOTH` and a `callback(usage)` shape. v2 unifies everything under `defineCommand`. The same `defineCommand` serves slash invocations, prefix invocations, or both.
+
+## Slash command
+
+```ts
+// v1 — commands/ping.js
+const { CommandType } = require("@d3oxy/djs-commands");
+
+module.exports = {
+    type: CommandType.SLASH,
+    description: "Replies with pong",
+    callback: ({ interaction }) => {
+        interaction.reply("pong");
+    },
+};
+```
+
+```ts
+// v2 — commands/ping.ts
+import { defineCommand } from "@djs-commands/core";
+
+export default defineCommand({
+    name: "ping",
+    description: "Replies with pong",
+    run: async (ctx) => {
+        await ctx.reply("pong");
+    },
+});
+```
+
+The big shifts:
+
+- `module.exports = { … }` → `export default defineCommand({ … })`. The wrapper is just an identity function for type inference.
+- `callback(usage)` → `run(ctx)`. The `ctx` is normalized — `ctx.reply(...)` works for both slash and legacy invocations.
+- Slash is the default; you don't need a `type` flag.
+- Filename → command name in v1 was implicit; v2 is explicit (`name: "ping"`).
+
+## Slash + legacy from one definition
+
+v1's `CommandType.BOTH` is now `legacy: { enabled: true }` on the same command:
+
+```ts
+// v1 — commands/ping.js
+module.exports = {
+    type: CommandType.BOTH,
+    description: "Replies with pong",
+    callback: ({ interaction, message }) => {
+        const target = interaction ?? message;
+        target.reply("pong");
+    },
+};
+```
+
+```ts
+// v2 — commands/ping.ts
+export default defineCommand({
+    name: "ping",
+    description: "Replies with pong",
+    legacy: { enabled: true, aliases: ["p"] },
+    run: async (ctx) => {
+        await ctx.reply("pong");
+    },
+});
+```
+
+Use `ctx.type === "slash"` or `ctx.type === "legacy"` if you need to access the raw `interaction` or `message`:
+
+```ts
+run: async (ctx) => {
+    if (ctx.type === "slash") {
+        await ctx.interaction.deferReply();
+    }
+    // …
+};
+```
+
+## Typed options
+
+v1 didn't infer types for command arguments. v2 does — `options.user` is typed as `User`, `options.message` is typed as `string`, choices narrow to literal unions.
+
+```ts
+// v1 — manually pulled args from `usage.args` (string[])
+module.exports = {
+    type: CommandType.SLASH,
+    description: "Echo a message",
+    options: [{ name: "message", description: "What to echo", type: 3, required: true }],
+    callback: ({ interaction }) => {
+        const message = interaction.options.getString("message", true);
+        interaction.reply(message);
+    },
+};
+```
+
+```ts
+// v2 — schema is the source of truth, run handler args inferred
+export default defineCommand({
+    name: "echo",
+    description: "Echo a message",
+    options: {
+        message: { type: "string", description: "What to echo", required: true },
+    },
+    run: async (ctx) => {
+        // ctx.options.message is statically typed as `string`
+        await ctx.reply(ctx.options.message);
+    },
+});
+```
+
+In legacy mode, arguments are auto-parsed from the message text using the same schema (the last `string` option consumes all remaining tokens, so `!echo hello world` works out of the box).
+
+## Cooldowns
+
+v1 had a global `cooldownConfig` plus per-command cooldown declarations. v2 is per-command only:
+
+```ts
+// v1
+module.exports = {
+    type: CommandType.SLASH,
+    description: "…",
+    cooldowns: { perUser: "5s" },
+    callback: () => {…},
+};
+```
+
+```ts
+// v2
+export default defineCommand({
+    name: "ping",
+    description: "…",
+    cooldown: { type: "perUser", duration: 5_000 }, // ms
+    run: async (ctx) => {…},
+});
+```
+
+Cooldown types are the same: `perUser`, `perGuild`, `perUserPerGuild`, `global`.

--- a/apps/docs/content/pages/migration-from-v1/dropped-features.mdx
+++ b/apps/docs/content/pages/migration-from-v1/dropped-features.mdx
@@ -1,0 +1,82 @@
+---
+title: Dropped features
+description: What didn't make the cut and why
+---
+
+# Dropped features
+
+These features existed in v1 and intentionally don't ship in v2. Each section explains the rationale and the recommended replacement.
+
+## Custom commands (user-defined runtime slash commands)
+
+v1 had a `custom-command-schema` and built-in `/customcommand` admin command that let server admins create new slash commands from inside Discord, persisted to MongoDB.
+
+**Why dropped**: it's a whole feature inside a feature. It complicates persistence (every adapter would have to support it), it's a moderate fraction of v1's surface area, and most users either built their own version with richer behavior or never used it at all.
+
+**Replacement**: build it yourself on top of v2 if you need it. Define an admin command (`/define`) that writes to your own table and dynamically registers handlers via your application logic. Your data shape, your UI.
+
+## Built-in default admin commands
+
+v1 shipped 8 commands automatically: `prefix`, `slashcommand list/delete`, `togglecommand`, `embed`, `channelonly`, `requiredPermissions`, `requiredroles`, etc.
+
+**Why dropped**: every bot has different opinions about how admin UI should look. Shipping these as defaults forced users to either accept them or fight to disable them.
+
+**Replacement**: each helper is now a one-liner you can call from your own admin command. See [Persistence](./persistence) — `setGuildPrefix`, `disableCommand`, `lockCommandToChannel`, etc.
+
+## FeaturesHandler
+
+v1's `featuresDir` walked a directory and called `require(file)(commandHandler, client)` for each entry. It worked but was bundle-hostile (uses dynamic `require()`) and listener leaks were common.
+
+**Why dropped**: the [plugin system](./events-and-plugins#plugins-replacing-featureshandler) is a strict superset — same dynamic-loading capability, plus lifecycle hooks, type safety, and cleaner unmounting on `destroy()`.
+
+**Replacement**: factory functions returning `PluginManifest`, registered via the `plugins: [...]` option.
+
+## Anti-crash mode
+
+v1 had `antiCrash: true` that registered an `uncaughtException` handler keeping the process alive after errors.
+
+**Why dropped**: this hides bugs. Production deployments should let the process crash and restart via PM2 / systemd / Docker — that way crash loops show up in monitoring and the bug actually gets noticed.
+
+**Replacement**: handle it at the process level if you really want it:
+
+```ts
+process.on("uncaughtException", (err) => {
+    console.error("Uncaught exception:", err);
+});
+process.on("unhandledRejection", (err) => {
+    console.error("Unhandled rejection:", err);
+});
+```
+
+Or better: don't add it at all. Let your supervisor restart the bot on crash and pipe logs to a place you'll actually see them.
+
+## `testServers` (deploy-only-on-startup gate)
+
+v1 had a `testServers` option that registered new commands against a list of guild IDs first, then promoted to global on success.
+
+**Why dropped**: the deploy story for slash commands varies a lot (you might use `discord.js`'s REST helpers directly, run a separate deploy script, gate on environment, etc.). Forcing one model in the framework limited flexibility.
+
+**Replacement**: handle it yourself in the `clientReady` event:
+
+```ts
+client.once("clientReady", async (c) => {
+    if (process.env.NODE_ENV === "production") {
+        await c.application.commands.set(commands);
+    } else {
+        for (const guildId of TEST_GUILDS) {
+            const guild = await c.guilds.fetch(guildId);
+            await guild.commands.set(commands);
+        }
+    }
+});
+```
+
+The framework's default `clientReady` listener registers globally. If you want test-server gating, override it with your own listener BEFORE calling `createCommandHandler` (or pass `commands: []` to skip the framework's auto-register).
+
+## `cooldownConfig.dbRequired` (5-minute DB persistence threshold)
+
+v1 had a magic 300-second threshold above which cooldowns were persisted to MongoDB and below which they were in-memory.
+
+**Why dropped**: it was a heuristic that pleased no one. v2 makes it explicit: in-memory by default; provide `cacheAdapter` (e.g. `@djs-commands/adapter-redis`) if you want distributed cooldowns regardless of duration.
+
+**Replacement**: `cacheAdapter: redisCacheAdapter(redis)` from `@djs-commands/adapter-redis`.

--- a/apps/docs/content/pages/migration-from-v1/events-and-plugins.mdx
+++ b/apps/docs/content/pages/migration-from-v1/events-and-plugins.mdx
@@ -1,0 +1,95 @@
+---
+title: Events and plugins
+description: events.dir → eventDir, FeaturesHandler → plugins
+---
+
+# Events and plugins
+
+## Events
+
+v1's `events.dir` becomes `eventDir`. Each event file changes to use `defineEvent`:
+
+```ts
+// v1 — events/ready/log.js
+module.exports = (client) => {
+    console.log(`Logged in as ${client.user.tag}`);
+};
+// (the directory name was the event name)
+```
+
+```ts
+// v2 — events/ready.ts
+import { defineEvent } from "@djs-commands/core";
+
+export default defineEvent({
+    event: "clientReady",
+    once: true,
+    handler: (client) => {
+        console.log(`Logged in as ${client.user.tag}`);
+    },
+});
+```
+
+A single file with an explicit `event` name replaces the v1 convention of "directory name = event name". `handler`'s argument types are inferred from `event` against `keyof ClientEvents`.
+
+## Plugins (replacing FeaturesHandler)
+
+v1's `featuresDir` loaded files that called `client.on(...)` directly. The pattern is replaced by **plugins**: a factory function returning a manifest of commands, events, and lifecycle hooks.
+
+```ts
+// v1 — features/leveling.js
+const mongoose = require("mongoose");
+const xpSchema = new mongoose.Schema({ … });
+const Xp = mongoose.model("Xp", xpSchema);
+
+module.exports = (commandHandler, client) => {
+    client.on("messageCreate", async (msg) => {
+        await Xp.findOneAndUpdate(
+            { user: msg.author.id },
+            { $inc: { xp: 10 } },
+            { upsert: true },
+        );
+    });
+};
+```
+
+```ts
+// v2 — plugins/leveling.ts
+import { defineCommand, type PluginManifest } from "@djs-commands/core";
+
+interface LevelingOptions {
+    storage: Storage;
+}
+
+export function levelingPlugin(opts: LevelingOptions): PluginManifest {
+    return {
+        name: "@example/leveling",
+        commands: [levelCommand],
+        setup: async ({ client }) => {
+            client.on("messageCreate", async (msg) => {
+                // …award XP via opts.storage…
+            });
+        },
+        teardown: async () => {
+            // close connections, etc.
+        },
+    };
+}
+
+// app entry
+createCommandHandler({
+    client,
+    plugins: [levelingPlugin({ storage })],
+});
+```
+
+Why this is better:
+
+- Plugins return manifests; the framework owns lifecycle ordering. v1's `client.on(...)` from a feature file leaked listeners that were hard to remove.
+- `setup` and `teardown` hooks are awaited in registration order. `handler.destroy()` cleanly unwinds everything.
+- Plugins can register commands, events, and validators in one manifest.
+- Errors from `setup` are surfaced via `handler.ready` — boot fails fast with the plugin name in the message.
+
+## Hot reload
+
+v2's fs-autoloader watches `commandDir` and re-imports files on change in dev mode (`NODE_ENV !== "production"`). v1 required a full restart on every command change. No code changes needed to opt in — it just works.

--- a/apps/docs/content/pages/migration-from-v1/handler.mdx
+++ b/apps/docs/content/pages/migration-from-v1/handler.mdx
@@ -1,0 +1,90 @@
+---
+title: Handler options
+description: Mapping every v1 CommandHandler option to v2
+---
+
+# Handler options
+
+Every option you passed to `new CommandHandler({ … })` in v1 has a mapping in v2.
+
+| v1 option | v2 equivalent |
+|---|---|
+| `client` | `client` (unchanged) |
+| `mongoUri` | `storage: mongooseStorage(connection)` from `@djs-commands/adapter-mongoose` |
+| `commandDir` | `commandDir` (unchanged — fs-autoloader is still the default) |
+| `featuresDir` | `plugins: [...]` — see [Events and plugins](./events-and-plugins) |
+| `events.dir` | `eventDir` |
+| `defaultPrefix` | `legacy: { enabled: true, defaultPrefix: "!" }` |
+| `botOwners` | `botOwners` (unchanged) |
+| `cooldownConfig` | per-command `cooldown: { type, duration }` (no global config) |
+| `testServers` | dropped — handle via your own deploy logic per guild |
+| `defaultCommand` | dropped — built-in admin commands removed; build your own |
+| `antiCrash` | dropped — use process-level `unhandledRejection` / `uncaughtException` |
+
+## Worked example
+
+```ts
+// v1
+import CommandHandler from "@d3oxy/djs-commands";
+import { Client, IntentsBitField } from "discord.js";
+
+const client = new Client({
+    intents: [
+        IntentsBitField.Flags.Guilds,
+        IntentsBitField.Flags.GuildMessages,
+        IntentsBitField.Flags.MessageContent,
+    ],
+});
+
+client.on("ready", () => {
+    new CommandHandler({
+        client,
+        mongoUri: process.env.MONGO_URI,
+        commandDir: path.join(__dirname, "commands"),
+        featuresDir: path.join(__dirname, "features"),
+        defaultPrefix: "!",
+        botOwners: ["123…"],
+        events: { dir: path.join(__dirname, "events") },
+        cooldownConfig: { dbRequired: 300 },
+    });
+});
+
+client.login(process.env.TOKEN);
+```
+
+```ts
+// v2
+import { createCommandHandler } from "@djs-commands/core";
+import { mongooseStorage } from "@djs-commands/adapter-mongoose";
+import { Client, GatewayIntentBits } from "discord.js";
+import { fileURLToPath } from "node:url";
+import mongoose from "mongoose";
+
+const client = new Client({
+    intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+    ],
+});
+
+const connection = mongoose.createConnection(process.env.MONGO_URI!);
+
+createCommandHandler({
+    client,
+    storage: mongooseStorage(connection),
+    commandDir: fileURLToPath(new URL("./commands", import.meta.url)),
+    eventDir: fileURLToPath(new URL("./events", import.meta.url)),
+    legacy: { enabled: true, defaultPrefix: "!" },
+    botOwners: ["123…"],
+    // cooldowns are per-command in v2 — no global config
+});
+
+await client.login(process.env.TOKEN!);
+```
+
+Notes:
+
+- v2 doesn't wait for `ready` to wire up — you call `createCommandHandler` synchronously after constructing the `Client`.
+- v2's `commandDir` accepts a path string. We use `fileURLToPath(new URL(...))` so it works under both Bun and Node + tsx; v1's `path.join(__dirname, ...)` worked because v1 was CJS — v2 is ESM.
+- `cooldownConfig.dbRequired` (v1's "use DB if duration ≥ 5min") doesn't exist. Cooldowns default to in-memory; provide a `cacheAdapter` (e.g. `@djs-commands/adapter-redis`) for distributed cooldowns.

--- a/apps/docs/content/pages/migration-from-v1/index.mdx
+++ b/apps/docs/content/pages/migration-from-v1/index.mdx
@@ -1,0 +1,71 @@
+---
+title: Migrating from v1
+description: A guide for upgrading bots from @d3oxy/djs-commands to @djs-commands/core
+---
+
+# Migrating from v1
+
+If you're coming from `@d3oxy/djs-commands` (v1), this guide walks you through every API that moved, renamed, or was dropped in v2.
+
+## TL;DR
+
+```bash
+# 1. Remove the old package
+bun remove @d3oxy/djs-commands
+
+# 2. Install v2 packages
+bun add @djs-commands/core discord.js
+# Optional based on your stack:
+bun add @djs-commands/adapter-mongoose mongoose  # if you used mongoUri in v1
+bun add @djs-commands/jsx                        # for Components V2
+```
+
+The big change: a single `CommandHandler` class became a function-based API with composable storage adapters. Mongoose is no longer baked in — pick `@djs-commands/adapter-drizzle`, `@djs-commands/adapter-prisma`, or `@djs-commands/adapter-mongoose` (the v1 continuity path).
+
+## Side-by-side
+
+```ts
+// v1
+import CommandHandler from "@d3oxy/djs-commands";
+new CommandHandler({
+    client,
+    mongoUri: process.env.MONGO_URI,
+    commandDir: path.join(__dirname, "commands"),
+    featuresDir: path.join(__dirname, "features"),
+    defaultPrefix: "!",
+    botOwners: ["123456789012345678"],
+    events: { dir: path.join(__dirname, "events") },
+});
+```
+
+```ts
+// v2
+import { createCommandHandler } from "@djs-commands/core";
+import { mongooseStorage } from "@djs-commands/adapter-mongoose";
+import { fileURLToPath } from "node:url";
+import mongoose from "mongoose";
+
+const connection = mongoose.createConnection(process.env.MONGO_URI!);
+
+createCommandHandler({
+    client,
+    storage: mongooseStorage(connection),
+    commandDir: fileURLToPath(new URL("./commands", import.meta.url)),
+    eventDir: fileURLToPath(new URL("./events", import.meta.url)),
+    legacy: { enabled: true, defaultPrefix: "!" },
+    botOwners: ["123456789012345678"],
+});
+```
+
+## What's in this section
+
+- [Handler options](./handler) — every `CommandHandler` option mapped to v2
+- [Command files](./commands) — `CommandType`, `callback(usage)` → unified `defineCommand`
+- [Validators](./validators) — `requiredPermissions` / `requiredRoles` / `ownerOnly` / `guildOnly` / `channelOnly`
+- [Persistence](./persistence) — Mongoose schemas → Storage adapters
+- [Events and plugins](./events-and-plugins) — `events.dir` and FeaturesHandler → `eventDir` + `plugins`
+- [Dropped features](./dropped-features) — what didn't make the cut
+
+## Why the rewrite
+
+v1 was unmaintained since late 2023. Discord shipped Components V2, polls, voice messages, user-installable apps, and ~18 months of API surface that v1 couldn't reach. v2 is built on `discord.js@^14.26`, ships first-class Components V2 via `@djs-commands/jsx`, drops the Mongoose lock-in, and is structured for the upcoming discord.js v15. v1 stays on npm at `@d3oxy/djs-commands@1.4.x` for bots that aren't ready to upgrade — it just won't get new features.

--- a/apps/docs/content/pages/migration-from-v1/meta.json
+++ b/apps/docs/content/pages/migration-from-v1/meta.json
@@ -1,0 +1,4 @@
+{
+	"title": "Migration from v1",
+	"pages": ["index", "handler", "commands", "validators", "persistence", "events-and-plugins", "dropped-features"]
+}

--- a/apps/docs/content/pages/migration-from-v1/persistence.mdx
+++ b/apps/docs/content/pages/migration-from-v1/persistence.mdx
@@ -1,0 +1,82 @@
+---
+title: Persistence
+description: Mongoose schemas → Storage adapters
+---
+
+# Persistence
+
+v1 baked Mongoose into the framework with 7 hardcoded schemas. v2 splits storage out behind a generic `Storage` contract — pick `@djs-commands/adapter-drizzle`, `@djs-commands/adapter-prisma`, or `@djs-commands/adapter-mongoose` (the v1 continuity path).
+
+## Mongoose continuity
+
+If you want to keep using Mongoose:
+
+```bash
+bun add @djs-commands/adapter-mongoose mongoose
+```
+
+```ts
+import { mongooseStorage } from "@djs-commands/adapter-mongoose";
+import mongoose from "mongoose";
+
+const connection = mongoose.createConnection(process.env.MONGO_URI!);
+
+createCommandHandler({
+    client,
+    storage: mongooseStorage(connection),
+    // …
+});
+```
+
+The collections (`guild_prefix`, `disabled_commands`, `channel_locks`) are auto-created by Mongoose when first written. You can swap to Drizzle/Postgres or Prisma later just by changing the adapter import — your bot code doesn't move.
+
+## Schema mapping
+
+| v1 collection | v2 model | What changed |
+|---|---|---|
+| `cooldowns` | (in-memory + optional `CacheAdapter`) | Cooldowns no longer hit the DB by default. Use `@djs-commands/adapter-redis` for sharded bots. |
+| `guild-prefix-schema` | `GuildPrefix` model | Resolved automatically when `legacy.enabled` + `storage` are set. |
+| `disabled-commands-schema` | `DisabledCommands` model | Same shape, now part of the framework's gate chain. |
+| `channel-commands-schema` | `ChannelLocks` model | Same shape. |
+| `custom-command-schema` | dropped | The custom-commands feature is gone. |
+| `required-permissions-schema` | dropped | Use the `permissions` property on `defineCommand` (static) or `canRunCommand` for runtime gating. |
+| `required-roles-schema` | dropped | Use the `roles` property on `defineCommand` (static) or `canRunCommand`. |
+
+## Programmatic prefix / disabled / locks
+
+v1 commands like `/prefix`, `/togglecommand`, `/channelonly` were built into the framework. v2 ships them as helpers so you can build admin commands of your own:
+
+```ts
+import {
+    setGuildPrefix,
+    disableCommand,
+    enableCommand,
+    lockCommandToChannel,
+    unlockCommandFromChannel,
+} from "@djs-commands/core";
+
+await setGuildPrefix(storage, guildId, "?");
+await disableCommand(storage, guildId, "ban");
+await lockCommandToChannel(storage, guildId, "ban", channelId);
+```
+
+## Switching adapters later
+
+Because the `Storage` contract is the same across adapters, moving from Mongo to Postgres later means changing two lines:
+
+```diff
+- import { mongooseStorage } from "@djs-commands/adapter-mongoose";
+- const connection = mongoose.createConnection(process.env.MONGO_URI!);
++ import { drizzleStorage } from "@djs-commands/adapter-drizzle";
++ import { drizzle } from "drizzle-orm/node-postgres";
++ import pg from "pg";
++ const db = drizzle(new pg.Pool({ connectionString: process.env.DATABASE_URL }));
+
+  createCommandHandler({
+      client,
+-     storage: mongooseStorage(connection),
++     storage: drizzleStorage(db),
+  });
+```
+
+Plus, of course, copying the framework's tables into your new schema (each adapter's README has the schema fragment).

--- a/apps/docs/content/pages/migration-from-v1/validators.mdx
+++ b/apps/docs/content/pages/migration-from-v1/validators.mdx
@@ -1,0 +1,113 @@
+---
+title: Validators
+description: requiredPermissions / requiredRoles / ownerOnly / guildOnly / channelOnly map cleanly
+---
+
+# Validators
+
+v1's command-level validation flags map 1:1 to v2 properties on `defineCommand`.
+
+| v1 | v2 |
+|---|---|
+| `requiredPermissions: ["BanMembers"]` | `permissions: ["BanMembers"]` |
+| `requiredRoles: ["role-id-1"]` | `roles: ["role-id-1"]` |
+| `ownerOnly: true` | `ownerOnly: true` |
+| `guildOnly: true` | `guildOnly: true` |
+| `testOnly: true` | dropped — handle deploy gating yourself |
+
+```ts
+// v1
+module.exports = {
+    type: CommandType.SLASH,
+    description: "Ban a user",
+    requiredPermissions: ["BanMembers"],
+    guildOnly: true,
+    callback: ({ interaction }) => {…},
+};
+```
+
+```ts
+// v2
+export default defineCommand({
+    name: "ban",
+    description: "Ban a user",
+    permissions: ["BanMembers"],
+    guildOnly: true,
+    options: { user: { type: "user", description: "Who", required: true } },
+    run: async (ctx) => {…},
+});
+```
+
+## Channel locks: static vs dynamic
+
+v1 had a `channels` array on the command (static) and a separate `channel-commands-schema` for runtime channel locks. In v2:
+
+- **Static**: `channels: ["channel-id"]` on `defineCommand` (declared once, in code)
+- **Dynamic**: `ChannelLocks` storage model (per-guild ops control)
+
+```ts
+// Static — applies in every guild
+export default defineCommand({
+    name: "admin",
+    channels: ["channel-id"],
+    // …
+});
+
+// Dynamic — per-guild, set at runtime
+import { lockCommandToChannel } from "@djs-commands/core";
+await lockCommandToChannel(storage, guildId, "admin", channelId);
+```
+
+The framework runs both: a command must satisfy static `channels` AND any `ChannelLocks` entries for the guild.
+
+## Custom validators
+
+```ts
+// v1 — registered through `customValidations`
+new CommandHandler({
+    client,
+    customValidations: [
+        ({ command, interaction }) => {
+            if (command.beta && !isBetaUser(interaction.user.id)) {
+                interaction.reply({ content: "Beta only", ephemeral: true });
+                return false;
+            }
+            return true;
+        },
+    ],
+});
+```
+
+```ts
+// v2 — global `validators` or per-command
+import type { Validator } from "@djs-commands/core";
+
+const betaOnly: Validator = ({ command, user }) => {
+    if (!command.beta || isBetaUser(user.id)) return { ok: true };
+    return { ok: false, reason: "Beta only" };
+};
+
+createCommandHandler({
+    client,
+    validators: [betaOnly],
+    // …
+});
+```
+
+Custom validators return `{ ok: true } | { ok: false, reason: string }`. The framework auto-replies ephemerally with the reason; you no longer call `.reply()` from the validator yourself.
+
+## Dynamic per-invocation gates
+
+v1 didn't have a hook for runtime gating (you'd build one through `customValidations`). v2 has `canRunCommand`:
+
+```ts
+createCommandHandler({
+    client,
+    canRunCommand: async ({ user }) => {
+        const limited = await rateLimiter.check(user.id);
+        return limited ? "You're rate-limited." : true;
+    },
+});
+```
+
+Returns `boolean | string | Promise<…>`. A string becomes the user-visible reason.


### PR DESCRIPTION
## Summary

Comprehensive migration guide section in apps/docs for users coming from `@d3oxy/djs-commands` (v1). Side-by-side examples for every API mapping. Surfaced from the docs landing page and the root README. Closes the **content** half of #67. The npm/GitHub-side manual steps (final 1.4.x publish, `npm deprecate`, repo description, pinned announcement issue) are listed at the bottom of this PR — they need maintainer-side auth and are best run alongside slice #68's release.

## What changed

- **`apps/docs/content/pages/migration-from-v1/`** (new section):
  - `index.mdx` — TL;DR + side-by-side handler example + section overview
  - `handler.mdx` — every `CommandHandler` option mapped (mongoUri → storage adapter, defaultPrefix → legacy config, etc.)
  - `commands.mdx` — `CommandType.SLASH/LEGACY/BOTH` → unified `defineCommand` with optional `legacy: { enabled, aliases }`. Typed options inference. Cooldown migration.
  - `validators.mdx` — required-* flags → 1:1 mappings. Custom validators using `{ ok, reason }`. `canRunCommand` hook.
  - `persistence.mdx` — 7 v1 Mongoose schemas mapped to v2 Storage models. Mongoose continuity path (keep Mongo, just swap adapters). Programmatic helpers (`setGuildPrefix`, `disableCommand`, …). Diff-style "switching adapters later" demo.
  - `events-and-plugins.mdx` — `events.dir` → `eventDir + defineEvent`. FeaturesHandler → plugin factory functions. Hot reload note.
  - `dropped-features.mdx` — custom commands, default admin commands, FeaturesHandler, anti-crash, `testServers`, `cooldownConfig.dbRequired` — each with rationale + replacement guidance.
- `apps/docs/content/pages/meta.json` — nav now includes `migration-from-v1`
- `apps/docs/content/pages/index.mdx` — "Coming from v1?" section after the cards grid
- `README.md` — top-of-readme migration callout, plus `create-djs-commands` quick-start replaces the manual clone snippet

## Local verification

```
$ rm -rf apps/docs/.source && bun run ci
$ biome check                  ✓ 115 files
$ tsc (typecheck)              ✓ 14 tasks
$ knip                         ✓ clean
$ bun test                     ✓ all tests pass
```

## Test plan
- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer reads through the migration guide pages — primary deliverable, locks the v1→v2 communication. Spot-check the side-by-side examples for accuracy.
- [ ] Optional: `bun run --cwd apps/docs dev:docs` and walk through the rendered nav

## Manual follow-ups for #67 (deferred to release)

These need maintainer-side npm/GitHub auth and are best run when slice #68 (Release 2.0.0) ships:

1. **Final 1.4.x maintenance release** of `@d3oxy/djs-commands`:
   - `git checkout v1-final-commit && git switch -c v1-maintenance`
   - Replace v1 README with deprecation notice pointing here
   - Bump to `1.4.11` (or whatever the next patch is)
   - `npm publish --access public` from that branch
2. **`npm deprecate @d3oxy/djs-commands@"<2" "@d3oxy/djs-commands is unmaintained. Migrate to @djs-commands/core — see https://djscommands.deoxy.dev/migration-from-v1"`**
3. Update the GitHub repo description to mention the new package name and link the migration guide
4. Open + pin a GitHub issue announcing v2

These are intentionally NOT in this PR — they're one-way actions that should fire alongside the v2 release, not before it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README highlighting v2 as current focus with quick start guide using `npx create-djs-commands`, `.env` setup, and expanded package descriptions
  * Added comprehensive migration guide from v1 covering handler configuration, command definitions, validators, persistence adapters, events, plugins, and dropped features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->