### PR TITLE
Slice 17: Release 2.0.0 + provenance

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,9 +3,19 @@
 	"changelog": "@changesets/cli/changelog",
 	"commit": false,
 	"fixed": [],
-	"linked": [],
+	"linked": [
+		[
+			"@djs-commands/core",
+			"@djs-commands/jsx",
+			"@djs-commands/cli",
+			"@djs-commands/adapter-drizzle",
+			"@djs-commands/adapter-prisma",
+			"@djs-commands/adapter-mongoose",
+			"@djs-commands/adapter-redis"
+		]
+	],
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": []
+	"ignore": ["minimal", "components-v2-showcase", "moderation-drizzle", "docs"]
 }

--- a/.changeset/v2-launch.md
+++ b/.changeset/v2-launch.md
@@ -1,0 +1,28 @@
+---
+"@djs-commands/core": major
+"@djs-commands/jsx": major
+"@djs-commands/cli": major
+"@djs-commands/adapter-drizzle": major
+"@djs-commands/adapter-prisma": major
+"@djs-commands/adapter-mongoose": major
+"@djs-commands/adapter-redis": major
+---
+
+🎉 Initial v2.0.0 release.
+
+A complete rewrite under the new `@djs-commands/*` npm org. v1 (`@d3oxy/djs-commands`) is preserved at the [`v1-final-commit` tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and stays on npm under `@d3oxy/djs-commands@1.4.x` — see the [migration guide](https://djscommands.deoxy.dev/migration-from-v1) to upgrade.
+
+What's new:
+
+- **Modern API surface** — function-based `defineCommand` with full TypeScript inference of run-handler arguments from the option schema
+- **Pluggable persistence** — `Storage` contract with first-party adapters for [Drizzle](https://www.npmjs.com/package/@djs-commands/adapter-drizzle), [Prisma](https://www.npmjs.com/package/@djs-commands/adapter-prisma), and [Mongoose](https://www.npmjs.com/package/@djs-commands/adapter-mongoose) (the v1 continuity path)
+- **Components V2** — first-class JSX runtime in [`@djs-commands/jsx`](https://www.npmjs.com/package/@djs-commands/jsx) plus a function-API fallback in core
+- **Plugin system** — factory functions returning manifests with `setup`/`teardown` hooks; replaces v1's FeaturesHandler
+- **Cooldowns** — 4 types in-memory by default; plug [`@djs-commands/adapter-redis`](https://www.npmjs.com/package/@djs-commands/adapter-redis) for distributed/sharded bots
+- **Legacy prefix mode** — opt-in via `legacy: { enabled, defaultPrefix }`; one `defineCommand` definition serves slash + prefix
+- **fs-autoloader + hot reload** — `commandDir` / `eventDir` walk recursively; dev mode hot-reloads files on save
+- **Storage gates** — per-guild kill switches (`DisabledCommands`) and per-command channel allow-lists (`ChannelLocks`) flow through any adapter
+- **CLI** — `npx create-djs-commands my-bot` scaffolds a working baseline with adapter / legacy / Components V2 / package-manager flags
+- **discord.js** — peer dep `^14.26.0`, structured for v15 readiness
+
+Built on Bun + Turbo + Biome + Knip; tested across `{node-22, node-24, bun-latest} × {ubuntu, macos}` matrix in CI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+    push:
+        branches: [main]
+
+concurrency:
+    group: release-${{ github.ref }}
+
+jobs:
+    release:
+        name: Release
+        runs-on: ubuntu-latest
+        permissions:
+            # GITHUB_TOKEN: changesets/action commits version-bump PRs and pushes tags
+            contents: write
+            pull-requests: write
+            # OIDC token for npm provenance attestation
+            id-token: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  # Changesets needs full history to detect changeset files
+                  fetch-depth: 0
+
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  registry-url: "https://registry.npmjs.org"
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Create Release Pull Request or Publish to npm
+              id: changesets
+              uses: changesets/action@v1
+              with:
+                  # When changesets exist on main: opens a "Version Packages" PR
+                  # bumping versions + writing CHANGELOGs. Merging that PR
+                  # triggers this workflow again, hits the publish branch below.
+                  version: bun run version-packages
+                  # When versions in package.json are ahead of npm: publish.
+                  publish: bun run release
+                  # Friendlier commit messages on the auto-PR.
+                  commit: "chore: release"
+                  title: "chore: release"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  # Tells `npm publish` (called via `changeset publish`) to attach
+                  # an SLSA provenance attestation. Requires id-token: write above.
+                  NPM_CONFIG_PROVENANCE: "true"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,66 @@
+# Releasing
+
+This repo ships v2.x of `@djs-commands/*` packages via [Changesets](https://github.com/changesets/changesets) + GitHub Actions.
+
+## Day-to-day flow
+
+1. Land a feature PR.
+2. As part of the PR (or in a follow-up), run `bun changeset` and pick the bump kind (`patch` / `minor` / `major`) for each affected package. Commit the generated `.changeset/<random>.md`.
+3. After the PR merges to `main`, the **Release** workflow opens (or updates) a `chore: release` pull request that:
+   - Bumps versions in every affected `package.json`
+   - Writes/updates `CHANGELOG.md` for each package
+   - Removes the consumed changesets
+4. Merging that release PR triggers the workflow again. This time it sees package versions are ahead of npm and runs `bun run release` — `turbo build` followed by `changeset publish` with `NPM_CONFIG_PROVENANCE=true` for SLSA attestation.
+
+## Initial v2.0.0 launch
+
+The first release is bootstrapped:
+
+- All `@djs-commands/*` package.jsons are pinned at `2.0.0` in this branch
+- A single `v2-launch.md` changeset declares it `major` for every package
+- Once this PR merges, the Release workflow opens the version PR which consumes that changeset and prepares CHANGELOGs
+- Merging the version PR publishes 2.0.0 to npm
+
+### One-time setup before the first publish
+
+The maintainer needs to configure two repository secrets:
+
+| Secret | Description |
+|---|---|
+| `NPM_TOKEN` | An npm "Automation" token with publish access to the `@djs-commands` org. Generate at <https://www.npmjs.com/settings/~/tokens>. |
+| (built-in) `GITHUB_TOKEN` | Provided by Actions. The release job needs `contents: write`, `pull-requests: write`, `id-token: write` — already declared in `.github/workflows/release.yml`. |
+
+For provenance to work, the npm package owners must have 2FA enabled and the npm org must allow OIDC publishing from GitHub Actions (default for new orgs).
+
+## Manual publish (escape hatch)
+
+If GitHub Actions is unavailable or the workflow needs to be bypassed:
+
+```bash
+bun install --frozen-lockfile
+bun run build --filter='@djs-commands/*'
+NPM_CONFIG_PROVENANCE=true bun changeset publish
+```
+
+You'll need to be logged in via `npm login` and have publish access to `@djs-commands`. Note that provenance only attaches when run from CI with OIDC — local publishes will succeed but without the attestation.
+
+## v1 sunset
+
+After v2.0.0 publishes successfully, the maintainer also handles the v1 deprecation (these are one-way actions, not automated):
+
+```bash
+# Final v1 maintenance release (replaces README with deprecation notice)
+git checkout v1-final-commit
+git switch -c v1-maintenance
+# … edit packages/v1's README.md to point at v2 …
+npm version patch       # bumps to 1.4.11 or similar
+npm publish --access public
+
+# Mark all v1 versions as deprecated on npm
+npm deprecate '@d3oxy/djs-commands@<2' '@d3oxy/djs-commands is unmaintained. Migrate to @djs-commands/core — see https://djscommands.deoxy.dev/migration-from-v1'
+
+# Update the GitHub repo description to mention the new package name
+# Open and pin a GitHub issue announcing v2
+```
+
+These steps are spelled out in [slice #67](https://github.com/D3OXY/djs-commands/issues/67).

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
 		"knip": "knip",
 		"test": "turbo test",
 		"ci": "bun run check && bun run typecheck && bun run knip && bun run test",
+		"changeset": "changeset",
+		"version-packages": "changeset version",
+		"release": "turbo build --filter='@djs-commands/*' && changeset publish",
 		"prepare": "husky"
 	},
 	"devDependencies": {

--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@djs-commands/adapter-drizzle",
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"description": "Drizzle Storage adapter for djs-commands — Postgres-backed persistent state",
 	"author": "D3OXY <hello@deoxy.dev>",
 	"license": "MIT",

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@djs-commands/adapter-mongoose",
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"description": "Mongoose Storage adapter for djs-commands — MongoDB-backed persistent state",
 	"author": "D3OXY <hello@deoxy.dev>",
 	"license": "MIT",

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@djs-commands/adapter-prisma",
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"description": "Prisma Storage adapter for djs-commands — persistent state via Prisma Client",
 	"author": "D3OXY <hello@deoxy.dev>",
 	"license": "MIT",

--- a/packages/adapter-redis/package.json
+++ b/packages/adapter-redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@djs-commands/adapter-redis",
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"description": "Redis CacheAdapter for djs-commands cooldowns — distributed, TTL-native cooldown storage",
 	"author": "D3OXY <hello@deoxy.dev>",
 	"license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@djs-commands/cli",
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"description": "Scaffolding CLI for djs-commands — `npx create-djs-commands`",
 	"author": "D3OXY <hello@deoxy.dev>",
 	"license": "MIT",

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -6,11 +6,11 @@ interface FileContent {
 }
 
 const DEPS = {
-	core: "^0.0.0",
-	jsx: "^0.0.0",
-	adapterDrizzle: "^0.0.0",
-	adapterPrisma: "^0.0.0",
-	adapterMongoose: "^0.0.0",
+	core: "^2.0.0",
+	jsx: "^2.0.0",
+	adapterDrizzle: "^2.0.0",
+	adapterPrisma: "^2.0.0",
+	adapterMongoose: "^2.0.0",
 	discordJs: "^14.26.0",
 	drizzleOrm: "^0.36.4",
 	pg: "^8.13.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@djs-commands/core",
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"description": "Modern Discord.js command handler — dispatcher, definitions, validators, plugins",
 	"author": "D3OXY <hello@deoxy.dev>",
 	"license": "MIT",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@djs-commands/jsx",
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"description": "JSX runtime + components for djs-commands — Components V2 expressed as JSX",
 	"author": "D3OXY <hello@deoxy.dev>",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Final slice. Wires Changesets + a Release GitHub Actions workflow with `--provenance`, stages the v2.0.0 launch changeset, and pins all 7 publishable packages at `2.0.0` so the maintainer can ship the moment this lands on main.

Closes #68.

## What changed

- **All 7 publishable packages pinned at `2.0.0`**: `@djs-commands/core`, `/jsx`, `/cli`, `/adapter-drizzle`, `/adapter-prisma`, `/adapter-mongoose`, `/adapter-redis`. `examples/*` and `apps/docs` stay private.
- **CLI templates** — `packages/cli/src/templates.ts` `DEPS` map bumped from `^0.0.0` to `^2.0.0`. `npx create-djs-commands` now scaffolds projects pinned to v2 majors.
- **Changesets config** — `.changeset/config.json` links all 7 publishable packages so future bumps move in lockstep. `access: public`. Ignores examples/docs.
- **Launch changeset** — `.changeset/v2-launch.md` is a single major bump across all 7 packages with a long-form changelog summarizing what shipped in v2.
- **Release script + workflow**:
  - Root scripts: `changeset`, `version-packages`, `release` (`turbo build --filter='@djs-commands/*' && changeset publish`).
  - `.github/workflows/release.yml` triggers on push to main. Two modes:
    - **Changesets exist** → opens/updates a `chore: release` PR that consumes them, bumps versions, writes CHANGELOGs.
    - **Versions ahead of npm** → publishes via `bun run release`. `NPM_CONFIG_PROVENANCE=true` + `id-token: write` = SLSA provenance on every tarball.
- **`RELEASING.md`** — day-to-day flow, the v2.0.0 bootstrap, one-time setup (`NPM_TOKEN` secret), manual escape hatch, and the v1 sunset checklist (`npm deprecate` + repo description + pinned announcement issue) carried over from #67.

## Local verification

```
$ rm -rf apps/docs/.source && bun run ci
$ biome check                  ✓ 115 files
$ tsc (typecheck)              ✓ 14 tasks
$ knip                         ✓ clean
$ bun test                     ✓ all tests pass
```

## Manual steps before merging

Configure `NPM_TOKEN` repository secret with an [npm Automation token](https://docs.npmjs.com/creating-and-viewing-access-tokens) that has publish access to the `@djs-commands` org. The `GITHUB_TOKEN` permissions are declared in the workflow itself.

## What happens after merge

1. Push to main triggers the Release workflow
2. Workflow sees the `v2-launch.md` changeset → opens a `chore: release` PR
3. That PR bumps all 7 package.jsons (already at 2.0.0 → no diff in versions, but writes CHANGELOGs and removes the changeset)
4. Merging the release PR triggers the workflow again → publishes 2.0.0 to npm with SLSA provenance

Then the maintainer handles the v1 sunset (one-way actions, listed in `RELEASING.md`):

```bash
npm deprecate '@d3oxy/djs-commands@<2' '@d3oxy/djs-commands is unmaintained. Migrate to @djs-commands/core — see https://djscommands.deoxy.dev/migration-from-v1'
```

Plus updating the GitHub repo description and pinning a v2 announcement issue.

## Test plan

- [ ] CI matrix passes (6 jobs)
- [ ] Reviewer reads through `RELEASING.md` — locks the publish workflow
- [ ] Reviewer eyeballs `.github/workflows/release.yml` — `id-token: write` is the key permission for provenance
- [ ] Reviewer verifies all 7 publishable packages are at `2.0.0` in `package.json`
- [ ] Reviewer ensures `NPM_TOKEN` secret is configured before merging (this PR can't verify it from inside the workflow without leaking)