### PR TITLE
fix(docs): Tailwind v4 @source + MDX components, refresh stale pages

### DIFF
--- a/apps/docs/content/pages/adapter-cookbook/index.mdx
+++ b/apps/docs/content/pages/adapter-cookbook/index.mdx
@@ -4,18 +4,249 @@ description: End-to-end recipes for plugging djs-commands into a real database.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
-<Callout type="warn">
-**Coming with [Slice #59 — Adapter Cookbook](https://github.com/D3OXY/djs-commands/issues/59).** This section is currently a placeholder.
+Each entry walks through wiring a specific backing store to djs-commands' `Storage` adapter interface, soup-to-nuts. All four first-party adapters implement the same contract, so the **only** thing that changes between them is the constructor call and the schema/migration step.
+
+```ts
+const handler = createCommandHandler({
+	client,
+	commands: [...],
+	storage, // ← swap this line
+});
+```
+
+<Callout type="info">
+The framework's three built-in models — `guild_prefix`, `disabled_commands`, `channel_locks` — are read/written automatically by the dispatcher. You don't write any code for them; you just need the table/collection to exist.
 </Callout>
 
-Each entry walks through wiring a specific backing store to djs-commands' storage adapter interface, soup-to-nuts:
+## Drizzle (Postgres)
 
-- **Postgres** with Prisma
-- **Postgres** with Drizzle
-- **Redis** (Upstash, ioredis)
-- **MongoDB** (Mongoose)
-- **Cloudflare KV / Durable Objects**
-- **In-memory** (the default — for dev and tests)
+The Drizzle adapter is recommended for new projects. It ships a ready-made schema you import directly.
 
-Want to contribute an adapter recipe? Open a PR against [`apps/docs/content/pages/adapter-cookbook/`](https://github.com/D3OXY/djs-commands/tree/main/apps/docs/content/pages/adapter-cookbook). Track issue [#59](https://github.com/D3OXY/djs-commands/issues/59) for progress on the cookbook structure.
+```bash
+bun add @djs-commands/adapter-drizzle drizzle-orm pg
+bun add -d drizzle-kit
+```
+
+```ts title="src/db.ts"
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const db = drizzle(pool);
+```
+
+```ts title="drizzle.config.ts"
+import type { Config } from "drizzle-kit";
+
+export default {
+	schema: ["./node_modules/@djs-commands/adapter-drizzle/dist/schema.js"],
+	out: "./drizzle",
+	dialect: "postgresql",
+	dbCredentials: { url: process.env.DATABASE_URL! },
+} satisfies Config;
+```
+
+Generate and apply migrations:
+
+```bash
+bunx drizzle-kit generate
+bunx drizzle-kit migrate
+```
+
+Wire into the handler:
+
+```ts title="src/index.ts"
+import { drizzleStorage } from "@djs-commands/adapter-drizzle";
+import { db } from "./db";
+
+createCommandHandler({
+	client,
+	commands: [...],
+	storage: drizzleStorage(db),
+});
+```
+
+To use your own table objects (renamed columns, extra fields), pass them via `tables`:
+
+```ts
+import { drizzleStorage, schema } from "@djs-commands/adapter-drizzle";
+import { myGuildPrefixTable } from "./schema";
+
+drizzleStorage(db, {
+	tables: { guildPrefix: myGuildPrefixTable },
+});
+```
+
+## Prisma
+
+```bash
+bun add @djs-commands/adapter-prisma @prisma/client
+bun add -d prisma
+```
+
+The adapter ships schema fragments as exported template strings. Copy them into your `schema.prisma`:
+
+```ts
+import {
+	GUILD_PREFIX_PRISMA_MODEL,
+	DISABLED_COMMANDS_PRISMA_MODEL,
+	CHANNEL_LOCKS_PRISMA_MODEL,
+} from "@djs-commands/adapter-prisma/schema";
+
+console.log(GUILD_PREFIX_PRISMA_MODEL);
+// model GuildPrefix { ... }
+```
+
+Or copy the models manually:
+
+```prisma title="prisma/schema.prisma"
+model GuildPrefix {
+	guildId String @id @map("guild_id")
+	prefix  String
+	@@map("guild_prefix")
+}
+
+model DisabledCommand {
+	guildId      String @map("guild_id")
+	commandName  String @map("command_name")
+	@@id([guildId, commandName])
+	@@map("disabled_commands")
+}
+
+model ChannelLock {
+	guildId      String @map("guild_id")
+	commandName  String @map("command_name")
+	channelId    String @map("channel_id")
+	@@id([guildId, commandName, channelId])
+	@@map("channel_locks")
+}
+```
+
+Then:
+
+```bash
+bunx prisma migrate dev --name add-djs-commands
+```
+
+```ts title="src/index.ts"
+import { PrismaClient } from "@prisma/client";
+import { prismaStorage } from "@djs-commands/adapter-prisma";
+
+const prisma = new PrismaClient();
+
+createCommandHandler({
+	client,
+	commands: [...],
+	storage: prismaStorage(prisma),
+});
+```
+
+If you renamed the Prisma models in your schema (e.g. you have a different naming convention), pass the delegates explicitly:
+
+```ts
+prismaStorage(prisma, {
+	delegates: { guildPrefix: prisma.myGuildPrefix },
+});
+```
+
+## Mongoose (MongoDB)
+
+The Mongoose adapter is the v1 continuity path — your existing v1 connection works as-is.
+
+```bash
+bun add @djs-commands/adapter-mongoose mongoose
+```
+
+```ts title="src/index.ts"
+import mongoose from "mongoose";
+import { mongooseStorage } from "@djs-commands/adapter-mongoose";
+
+await mongoose.connect(process.env.MONGODB_URI!);
+
+createCommandHandler({
+	client,
+	commands: [...],
+	storage: mongooseStorage(mongoose.connection),
+});
+```
+
+The adapter creates the three framework models automatically (`guildPrefix`, `disabledCommand`, `channelLock`). To reuse models from your own application — e.g. you already have a `Guild` collection — pass them via `models`:
+
+```ts
+import { createGuildPrefixModel } from "@djs-commands/adapter-mongoose";
+
+mongooseStorage(connection, {
+	models: {
+		guildPrefix: createGuildPrefixModel(connection, "MyGuildPrefix"),
+	},
+});
+```
+
+## Redis (cache adapter, not storage)
+
+Redis isn't a `Storage` adapter — it's a `CacheAdapter` for cooldowns. Use it **alongside** one of the storage adapters above.
+
+```bash
+bun add @djs-commands/adapter-redis ioredis
+```
+
+```ts title="src/index.ts"
+import Redis from "ioredis";
+import { redisCacheAdapter } from "@djs-commands/adapter-redis";
+import { drizzleStorage } from "@djs-commands/adapter-drizzle";
+import { db } from "./db";
+
+const redis = new Redis(process.env.REDIS_URL!);
+
+createCommandHandler({
+	client,
+	commands: [...],
+	storage: drizzleStorage(db),       // persistent state (prefixes, locks)
+	cacheAdapter: redisCacheAdapter(redis), // hot state (cooldowns)
+});
+```
+
+The Redis adapter uses `SET key expiresAt PX ttl` so Redis handles expiration server-side — you never accumulate dead keys.
+
+To prefix Redis keys (e.g. multi-tenant Redis), pass `keyPrefix`:
+
+```ts
+redisCacheAdapter(redis, { keyPrefix: "bot:prod:" });
+```
+
+Default prefix is `djs-commands:`.
+
+## In-memory (the default)
+
+If you don't pass a `storage`, only **non-persistent** features work — slash commands run, validators run, but `guild_prefix`, `disabled_commands`, and `channel_locks` lookups are skipped.
+
+If you don't pass a `cacheAdapter`, cooldowns are stored in a process-local `Map`. That's fine for development and single-process bots.
+
+For production, register **both** a storage adapter (persistent, durable) and a cache adapter (fast, ephemeral).
+
+## Writing your own adapter
+
+`Storage` is six methods. Implement them, run the conformance suite, ship.
+
+```ts
+import type { Storage } from "@djs-commands/core";
+import { runStorageConformance } from "@djs-commands/core";
+
+export function myStorage(): Storage {
+	return {
+		async create(model, data) { /* ... */ },
+		async findOne(model, where) { /* ... */ },
+		async findMany(model, opts) { /* ... */ },
+		async update(model, where, data) { /* ... */ },
+		async delete(model, where) { /* ... */ },
+		async count(model, where) { /* ... */ },
+	};
+}
+
+// Validate against the framework's contract:
+runStorageConformance("my-adapter", () => myStorage());
+```
+
+The conformance suite covers every code path the framework relies on — pass it and your adapter will work for every shipped feature.

--- a/apps/docs/content/pages/api-reference/index.mdx
+++ b/apps/docs/content/pages/api-reference/index.mdx
@@ -1,20 +1,158 @@
 ---
 title: API Reference
-description: The full surface area of the @djs-commands/* packages.
+description: Public surface area of the @djs-commands/* packages.
 ---
 
-import { Callout } from "fumadocs-ui/components/callout";
+import { Cards, Card } from "fumadocs-ui/components/card";
 
-<Callout type="warn">
-**Coming with [Slice #63 — API Reference generation](https://github.com/D3OXY/djs-commands/issues/63).** This section is currently a placeholder.
-</Callout>
+This page lists every public symbol the framework exports. Each link jumps to the concept page that explains it in context — start there for examples and trade-offs.
 
-The API reference will be generated directly from the source — TypeDoc-driven, with every public symbol from every `@djs-commands/*` package documented in one place. Until it's automated, the [Concepts](/concepts) section is the most up-to-date documentation of the public API.
+<Cards>
+	<Card title="Concepts" href="/concepts" description="The narrative documentation. Start here if you're new." />
+	<Card title="Components V2" href="/components-v2" description="Full JSX + function reference for the layout/form primitives." />
+	<Card title="Adapter Cookbook" href="/adapter-cookbook" description="Soup-to-nuts guides for each first-party adapter." />
+</Cards>
 
-For the current shape of `@djs-commands/core`, see:
+## `@djs-commands/core`
 
-- [`defineCommand`](/concepts/commands#definecommand)
-- [`createCommandHandler`](/concepts/commands#registering-commands)
-- [`CommandRunContext`](/concepts/commands#commandruncontext)
+### Commands
 
-Track issue [#63](https://github.com/D3OXY/djs-commands/issues/63) for progress on the generated reference.
+| Export | Kind | Page |
+| --- | --- | --- |
+| `defineCommand` | function | [Commands](/concepts/commands#definecommand) |
+| `Command` | type | [Commands](/concepts/commands#definecommand) |
+| `AnyCommand` | type | [Commands](/concepts/commands#definecommand) |
+| `CommandRunContext` | type | [Commands](/concepts/commands#commandruncontext) |
+| `SlashRunContext` | type | [Commands](/concepts/commands#commandruncontext) |
+| `LegacyRunContext` | type | [Commands](/concepts/commands#commandruncontext) |
+| `CommandRun` | type | [Commands](/concepts/commands#commandruncontext) |
+| `CommandLegacyConfig` | type | [Commands](/concepts/commands) |
+
+### Options
+
+| Export | Kind | Page |
+| --- | --- | --- |
+| `CommandOption` / `CommandOptions` | type | [Commands → Options](/concepts/commands#options) |
+| `StringOption`, `IntegerOption`, `NumberOption`, `BooleanOption`, `UserOption`, `ChannelOption`, `RoleOption`, `MentionableOption`, `AttachmentOption` | type | [Commands → Options](/concepts/commands#options) |
+| `ResolveOption` / `ResolveOptions` | type | [Commands → Options](/concepts/commands#options) |
+
+### Handler
+
+| Export | Kind | Page |
+| --- | --- | --- |
+| `createCommandHandler` | function | [Commands → Registering](/concepts/commands#registering-commands) |
+| `CommandHandler` | type | [Commands](/concepts/commands#registering-commands) |
+| `CommandHandlerOptions` | type | [Commands](/concepts/commands#registering-commands) |
+| `HandlerLegacyConfig` | type | [Commands](/concepts/commands) |
+
+### Validators
+
+| Export | Kind | Page |
+| --- | --- | --- |
+| `Validator` | type | [Validators](/concepts/validators#custom-validators) |
+| `ValidatorContext` | type | [Validators](/concepts/validators#validatorcontext) |
+| `ValidationResult` | type | [Validators](/concepts/validators#validationresult) |
+| `ValidatorSource` | type | [Validators](/concepts/validators#validatorcontext) |
+| `CanRunCommand` | type | [Validators](/concepts/validators#canruncommand-shorthand) |
+
+### Cooldowns
+
+| Export | Kind | Page |
+| --- | --- | --- |
+| `CooldownConfig` | type | [Cooldowns](/concepts/cooldowns#configuring-a-cooldown) |
+| `CooldownType` | type | [Cooldowns → Types](/concepts/cooldowns#cooldown-types) |
+| `CooldownActor` | type | [Cooldowns](/concepts/cooldowns#cooldownengine-directly) |
+| `CacheAdapter` | type | [Cooldowns](/concepts/cooldowns#writing-a-custom-cacheadapter) |
+
+### Plugins
+
+| Export | Kind | Page |
+| --- | --- | --- |
+| `PluginManifest` | type | [Plugins](/concepts/plugins#plugin-manifest) |
+| `PluginSetupContext` | type | [Plugins](/concepts/plugins#manifest-fields) |
+
+### Storage
+
+| Export | Kind | Page |
+| --- | --- | --- |
+| `Storage` | type | [Storage](/concepts/storage#the-storage-interface) |
+| `StorageWhere` / `StorageFindOpts` | type | [Storage](/concepts/storage#the-storage-interface) |
+| `runStorageConformance` | function | [Storage → Custom adapter](/concepts/storage#writing-a-custom-adapter) |
+| `GuildPrefixModel` / `GuildPrefixRow` | const / type | [Storage → Helpers](/concepts/storage#guild-prefix) |
+| `getGuildPrefix` / `setGuildPrefix` / `clearGuildPrefix` | function | [Storage → Helpers](/concepts/storage#guild-prefix) |
+| `DisabledCommandsModel` / `DisabledCommandRow` | const / type | [Storage → Helpers](/concepts/storage#disabled-commands) |
+| `isCommandDisabled` / `disableCommand` / `enableCommand` | function | [Storage → Helpers](/concepts/storage#disabled-commands) |
+| `ChannelLocksModel` / `ChannelLockRow` | const / type | [Storage → Helpers](/concepts/storage#channel-locks) |
+| `getChannelLocks` / `lockCommandToChannel` / `unlockCommandFromChannel` | function | [Storage → Helpers](/concepts/storage#channel-locks) |
+
+### Filesystem loader
+
+| Export | Kind | Page |
+| --- | --- | --- |
+| `loadCommandsFromDir` | function | [Commands → Loading](/concepts/commands#loading-commands-from-a-directory) |
+| `loadEventsFromDir` | function | [Commands → Loading](/concepts/commands#loading-commands-from-a-directory) |
+| `watchCommandsDir` | function | [Commands → Loading](/concepts/commands#loading-commands-from-a-directory) |
+
+### Events
+
+| Export | Kind | Description |
+| --- | --- | --- |
+| `defineEvent` | function | Define a discord.js event handler with full type-safety. |
+| `EventDefinition` | type | The shape `defineEvent` returns. |
+
+### Components V2 (function API)
+
+| Export | Returns |
+| --- | --- |
+| `container` | `ContainerBuilder` |
+| `section` | `SectionBuilder` |
+| `textDisplay` | `TextDisplayBuilder` |
+| `mediaGallery` | `MediaGalleryBuilder` |
+| `separator` | `SeparatorBuilder` |
+| `file` | `FileBuilder` |
+| `thumbnail` | `ThumbnailBuilder` |
+| `button` | `ButtonBuilder` |
+| `actionRow` | `ActionRowBuilder` |
+| `modal` | `ModalBuilder` |
+| `textInput` | `TextInputBuilder` |
+| `radioGroup` / `checkboxGroup` | `LabelBuilder` |
+
+Each takes an `*Options` object — see [Components V2](/components-v2) for full signatures and examples.
+
+### Legacy parser
+
+| Export | Description |
+| --- | --- |
+| `parseLegacyArgs` | Parse a legacy message into a typed argument object using a command's `options` schema. |
+| `LegacyParseResult` | Discriminated union of `{ ok: true; values }` / `{ ok: false; reason }`. |
+
+### Context normalizers
+
+| Export | Description |
+| --- | --- |
+| `normalizeSlashContext` | Build a `SlashRunContext` from a discord.js interaction. |
+| `normalizeLegacyContext` | Build a `LegacyRunContext` from a discord.js message. |
+
+## `@djs-commands/jsx`
+
+| Export | Kind | Description |
+| --- | --- | --- |
+| `render` | function | Compile a JSX tree into discord.js component builders. |
+| `renderModal` | function | Compile a `<Modal>` JSX tree into a `ModalBuilder`. |
+| `Container`, `Section`, `TextDisplay`, `MediaGallery`, `Separator`, `File`, `Thumbnail` | component | Display primitives. |
+| `ActionRow`, `Button`, `TextInput`, `RadioGroup`, `CheckboxGroup`, `Modal` | component | Form primitives. |
+| `Fragment` | component | Group children without nesting. |
+| `*Props`, `ButtonStyleName`, `TextInputStyleName`, `DjsxNode` | type | TypeScript helpers. |
+
+JSX runtime entry points: `@djs-commands/jsx/jsx-runtime` and `@djs-commands/jsx/jsx-dev-runtime` — set `jsxImportSource: "@djs-commands/jsx"` in your tsconfig.
+
+## Adapters
+
+| Package | Factory | Notes |
+| --- | --- | --- |
+| `@djs-commands/adapter-drizzle` | `drizzleStorage(db, options?)` | Postgres via Drizzle. Schema exported from `./schema`. |
+| `@djs-commands/adapter-prisma` | `prismaStorage(prisma, options?)` | Generic Prisma client; ships schema fragments to copy in. |
+| `@djs-commands/adapter-mongoose` | `mongooseStorage(connection, options?)` | Auto-creates Mongoose models if you don't pass your own. |
+| `@djs-commands/adapter-redis` | `redisCacheAdapter(redis, options?)` | TTL-native `CacheAdapter` for distributed cooldowns. |
+
+See [Adapter Cookbook](/adapter-cookbook) for a walk-through per adapter.

--- a/apps/docs/content/pages/concepts/commands.mdx
+++ b/apps/docs/content/pages/concepts/commands.mdx
@@ -1,6 +1,6 @@
 ---
 title: Commands
-description: Define, register, and dispatch slash commands with @djs-commands/core.
+description: Define, register, and dispatch slash and prefix commands with @djs-commands/core.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -17,8 +17,8 @@ import { defineCommand } from "@djs-commands/core";
 const ping = defineCommand({
 	name: "ping",
 	description: "Replies with pong",
-	run: async ({ interaction }) => {
-		await interaction.reply("pong");
+	run: async ({ reply }) => {
+		await reply("pong");
 	},
 });
 ```
@@ -31,33 +31,87 @@ const ping = defineCommand({
 | `description` | `string` | The 1–100-character description shown in the Discord client. |
 | `run` | `(ctx) => void \| Promise<void>` | The handler. Receives a [`CommandRunContext`](#commandruncontext). |
 
-<Callout type="warn">
-The current core slice (#52) ships only those three fields. Options, subcommands, validators, and cooldowns land in upcoming slices — track them via the [v2 roadmap](https://github.com/D3OXY/djs-commands/issues/51).
-</Callout>
+### Optional fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `options` | `CommandOptions` | Typed schema for slash-command options — see [Options](#options). |
+| `validators` | `Validator[]` | Custom pre-handler checks. See [Validators](/concepts/validators). |
+| `cooldown` | `CooldownConfig` | Rate limit. See [Cooldowns](/concepts/cooldowns). |
+| `ownerOnly` | `boolean` | When `true`, only IDs in `botOwners` (passed to the handler) can run it. |
+| `guildOnly` | `boolean` | When `true`, blocks DM invocations. |
+| `channels` | `string[]` | Allow-list of channel IDs the command can run in. |
+| `permissions` | `PermissionsString[]` | Discord member permissions required (e.g. `["BanMembers"]`). |
+| `roles` | `string[]` | Role IDs the invoking member must have. |
+| `legacy` | `CommandLegacyConfig` | Opt this command into legacy prefix invocation; supports aliases. |
 
 ## `CommandRunContext`
 
+`CommandRunContext` is a discriminated union over the invocation source. Both branches share a unified surface so most handlers don't need to care whether they were invoked via slash or prefix:
+
 ```ts
-interface CommandRunContext {
-	interaction: ChatInputCommandInteraction;
+type CommandRunContext = SlashRunContext | LegacyRunContext;
+
+interface BaseRunContext {
+	client: Client;
+	author: User;
+	guild: Guild | null;
+	member: GuildMember | null;
+	channel: TextBasedChannel | null;
+	channelId: string | null;
+	options: ResolveOptions<S>; // typed from your `options` schema
+	reply: (content: string | { content?: string; ephemeral?: boolean }) => Promise<unknown>;
+}
+
+type SlashRunContext = BaseRunContext & { type: "slash"; interaction: ChatInputCommandInteraction };
+type LegacyRunContext = BaseRunContext & { type: "legacy"; message: Message };
+```
+
+When you need source-specific behavior, narrow on `ctx.type`:
+
+```ts
+run: async (ctx) => {
+	if (ctx.type === "slash") {
+		await ctx.interaction.deferReply({ ephemeral: true });
+	}
+	await ctx.reply("hi");
 }
 ```
 
-Today, the context exposes the raw discord.js interaction. Future slices wrap it with:
+## Options
 
-- `validators` — pre-handler outcomes
-- `storage` — the adapter you registered for cooldowns, prefixes, etc.
-- `plugins` — extra fields contributed by plugins (typed via module augmentation)
-- helpers like `t()` for i18n, `defer()` shortcuts, and Components V2 builders
+Define typed slash-command options with the `options` field. The handler context's `options` is fully inferred from your schema — required options resolve to their type, optional ones to `T | undefined`.
 
-That augmentation surface is intentional: every concept page in this section adds something to the context.
+```ts
+defineCommand({
+	name: "ban",
+	description: "Ban a user",
+	options: {
+		target: { type: "user", description: "Who to ban", required: true },
+		reason: { type: "string", description: "Why", required: false },
+		days: {
+			type: "integer",
+			description: "Days of messages to delete",
+			choices: [0, 1, 7] as const,
+		},
+	},
+	run: async ({ options, reply }) => {
+		// options.target: User
+		// options.reason: string | undefined
+		// options.days:   0 | 1 | 7 | undefined
+		await reply(`Banning ${options.target.tag}`);
+	},
+});
+```
+
+Supported option types: `string`, `integer`, `number`, `boolean`, `user`, `channel`, `role`, `mentionable`, `attachment`. `string` and `integer` accept `choices` for enum-style narrowing.
 
 ## Registering commands
 
 `createCommandHandler` accepts a `client` and an array of commands. It does two things on your behalf:
 
-1. **Subscribes** to `interactionCreate`. When a chat-input interaction comes in, it looks up the command by `name` and calls `run`.
-2. **Registers** the command list with Discord on `clientReady`. This calls `client.application.commands.set(...)` with the names and descriptions of every command you passed in.
+1. **Subscribes** to `interactionCreate`. When a chat-input interaction comes in, it looks up the command by `name` and dispatches it through validators → cooldown gates → plugins → `run`.
+2. **Registers** the command list with Discord on `clientReady`. This calls `client.application.commands.set(...)` with the names, descriptions, and options of every command you passed in.
 
 ```ts
 import { createCommandHandler } from "@djs-commands/core";
@@ -70,34 +124,44 @@ const handler = createCommandHandler({
 	commands: [ping /*, more commands */],
 });
 
+await handler.ready;
 await client.login(process.env.DISCORD_TOKEN);
 ```
 
-The returned `handler` exposes a single method:
+The returned `handler` exposes:
 
 ```ts
-await handler.destroy();
+handler.ready;     // Promise<void> — resolves once all plugin setup hooks complete
+await handler.destroy();   // Removes listeners, awaits plugin teardown
 ```
 
-This unsubscribes the listeners. Use it in tests or when you want to swap out a handler without restarting the process. It does **not** delete the registered application commands from Discord — those persist until you explicitly clear them.
+`destroy()` does **not** delete the registered application commands from Discord — those persist until you explicitly clear them.
 
 ## Loading commands from a directory
 
-v2's core stays out of the file-system business. If you want a v1-style "drop a file in `commands/` and it just works" loader, build one yourself or wait for the official `@djs-commands/loader` plugin (slated for a later slice). A four-line loader using Bun's glob looks like:
+Pass a `commandDir` to the handler and every file's default export is registered automatically. In dev (`NODE_ENV !== "production"`) the directory is watched and edited files hot-reload without a restart.
 
 ```ts
-import { Glob } from "bun";
-
-const commands = await Promise.all(
-	Array.from(new Glob("./commands/*.ts").scanSync()).map(async (file) => (await import(file)).default)
-);
+createCommandHandler({
+	client,
+	commandDir: "./src/commands",
+});
 ```
 
-For Node, use `fs.glob` (Node 22+) or any directory-import library you like. The shape of `commands` is just `Command[]`, so anything that produces an array works.
+If you'd rather wire it up by hand, the loader functions are public:
+
+```ts
+import { loadCommandsFromDir, watchCommandsDir } from "@djs-commands/core";
+
+const commands = await loadCommandsFromDir("./src/commands");
+const watcher = watchCommandsDir("./src/commands", {
+	onCommandChange: () => { /* re-register */ },
+});
+```
 
 ## Best practices
 
-- **One command per file.** Export the `defineCommand` result as the default export so any loader can `import(file).default`.
+- **One command per file.** Export the `defineCommand` result as the default export so the autoloader can pick it up.
 - **Keep `run` thin.** Move business logic into ordinary functions you can unit-test without spinning up a Discord client.
-- **Don't share state via module scope.** When a feature wants memory across calls (cooldowns, per-guild config), reach for the Storage adapter — that's its job.
-- **Test handlers in isolation.** Construct a `ChatInputCommandInteraction` mock and call `command.run({ interaction: mock })` directly. The dispatcher is just a `Map.get` + function call.
+- **Prefer `ctx.reply`** over `ctx.interaction.reply` / `ctx.message.reply` — it works in both slash and legacy contexts.
+- **Don't share state via module scope.** When a feature wants memory across calls (cooldowns, per-guild config), reach for the [Storage adapter](/concepts/storage).

--- a/apps/docs/content/pages/concepts/components-v2.mdx
+++ b/apps/docs/content/pages/concepts/components-v2.mdx
@@ -1,12 +1,40 @@
 ---
 title: Components V2
-description: First-class JSX for Discord's new component model.
+description: First-class JSX (or function) builders for Discord's new component model.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-<Callout type="warn">
-**Coming with [Slice #61 — Components V2](https://github.com/D3OXY/djs-commands/issues/61).** This page is a placeholder; it will be filled in once that slice lands.
-</Callout>
+Discord's [Components V2](https://discord.com/developers/docs/components/reference) replaces the old "embeds + button rows" pattern with composable layout primitives. `djs-commands` ships **two ways** to build them — a JSX runtime in `@djs-commands/jsx`, and a plain-function fallback in `@djs-commands/core`. Both produce identical discord.js builder objects, so you can mix them freely.
 
-Components V2 is a first-class concern for djs-commands. The same package will ship both a JSX builder (for projects with a JSX-capable toolchain) and a function-call fallback (for plain JavaScript). Track the API design in issue [#61](https://github.com/D3OXY/djs-commands/issues/61) and the dedicated [Components V2 reference](/components-v2).
+```tsx
+import { defineCommand } from "@djs-commands/core";
+import { Button, Container, Section, TextDisplay, render } from "@djs-commands/jsx";
+import { MessageFlags } from "discord.js";
+
+export const welcome = defineCommand({
+	name: "welcome",
+	description: "Show a Components V2 welcome card",
+	run: async ({ interaction }) => {
+		await interaction.reply({
+			flags: MessageFlags.IsComponentsV2,
+			components: render(
+				<Container accentColor={0x5865f2}>
+					<TextDisplay># Welcome</TextDisplay>
+					<Section accessory={<Button style="primary" customId="welcome:next" label="Next" />}>
+						Components V2 lets you compose rich messages from layout primitives.
+					</Section>
+				</Container>
+			),
+		});
+	},
+});
+```
+
+For the full surface — every component, side-by-side JSX and function examples, modal forms, and a runnable example bot — see the dedicated reference:
+
+→ **[Components V2 reference](/components-v2)**
+
+<Callout type="info">
+The JSX runtime is opt-in. Set `jsxImportSource: "@djs-commands/jsx"` in your `tsconfig.json` and JSX in any `.tsx` file compiles to `discord.js` builders — no Babel, no SWC, no React. Plain-JS users skip JSX entirely and import `button()`, `container()`, `section()`, etc. from `@djs-commands/core`.
+</Callout>

--- a/apps/docs/content/pages/concepts/cooldowns.mdx
+++ b/apps/docs/content/pages/concepts/cooldowns.mdx
@@ -1,12 +1,93 @@
 ---
 title: Cooldowns
-description: Per-user, per-guild, per-command rate limiting.
+description: Per-user, per-guild, per-command rate limiting backed by your storage adapter.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-<Callout type="warn">
-**Coming with [Slice #56 — Cooldowns](https://github.com/D3OXY/djs-commands/issues/56).** This page is a placeholder; it will be filled in once that slice lands.
+Cooldowns rate-limit a command for an actor. The dispatcher checks the cooldown gate after validators pass — if the actor is on cooldown, the user sees a "try again in N seconds" reply and the handler is not invoked.
+
+## Configuring a cooldown
+
+Attach `cooldown` to the command. `duration` is in **milliseconds**.
+
+```ts
+defineCommand({
+	name: "vote",
+	description: "Vote on the current poll",
+	cooldown: { type: "perUser", duration: 30_000 },
+	run: async ({ reply }) => {
+		await reply("voted");
+	},
+});
+```
+
+## Cooldown types
+
+| Type | Key shape | When to use |
+| --- | --- | --- |
+| `perUser` | `cd:<cmd>:user:<userId>` | One invocation per user globally — e.g. daily reward. |
+| `perGuild` | `cd:<cmd>:guild:<guildId>` | One invocation per guild — e.g. server-wide announcement. |
+| `perUserPerGuild` | `cd:<cmd>:user:<userId>:guild:<guildId>` | One per user per server — the most common choice for moderation. |
+| `global` | `cd:<cmd>:global` | One invocation across all users and guilds — debug/owner commands. |
+
+In DMs, `guildId` falls back to the literal string `"dm"` so `perGuild` and `perUserPerGuild` keys remain stable.
+
+## Storage backends
+
+By default, cooldowns are stored **in-process** in a `Map`. That works for development and single-process bots, but loses state on restart and doesn't survive horizontal scale. Pass a `cacheAdapter` to the handler to use a shared store.
+
+```ts
+import { createCommandHandler } from "@djs-commands/core";
+import { redisCacheAdapter } from "@djs-commands/adapter-redis";
+import Redis from "ioredis";
+
+const redis = new Redis(process.env.REDIS_URL);
+
+createCommandHandler({
+	client,
+	commands: [...],
+	cacheAdapter: redisCacheAdapter(redis),
+});
+```
+
+## Writing a custom CacheAdapter
+
+The contract is three methods. `expiresAt` is an absolute UNIX millisecond timestamp; `ttlMs` is the same value expressed as a TTL hint for stores that prefer it (Redis `PX`, Memcached, etc).
+
+```ts
+interface CacheAdapter {
+	get(key: string): Promise<number | null>;
+	set(key: string, expiresAt: number, ttlMs: number): Promise<void>;
+	delete(key: string): Promise<void>;
+}
+```
+
+`get` should return `null` when the key is missing or already expired. The engine uses `expiresAt` to compute remaining time, so backends that auto-expire keys (Redis with `PX`) and backends that don't (a SQL `cooldowns` table) both work — the engine cleans up expired entries on read for the latter.
+
+<Callout type="info">
+The Redis adapter writes with `SET key expiresAt PX ttl` so Redis handles expiry server-side and you never accumulate dead keys.
 </Callout>
 
-Cooldowns will plug into the storage adapter you register, so the same code works for in-memory dev and Redis/Postgres production. Track issue [#56](https://github.com/D3OXY/djs-commands/issues/56) for progress.
+## When cooldowns start
+
+The cooldown is **started after** `command.run` returns successfully. If `run` throws, no cooldown is applied — users won't be punished for a failed invocation.
+
+If you need pre-handler cooldowns (e.g. expensive permission lookups should rate-limit even on failure), use a custom validator that records the timestamp itself.
+
+## `CooldownEngine` directly
+
+The engine is exposed for advanced use — you can construct one yourself to gate non-command flows (autocomplete handlers, button clicks, modal submits) using the same shared cache.
+
+```ts
+import { CooldownEngine } from "@djs-commands/core";
+
+const engine = new CooldownEngine(redisCacheAdapter(redis));
+
+const remaining = await engine.check(myCommand, { userId, guildId });
+if (remaining !== null) {
+	// on cooldown — `remaining` ms left
+}
+
+await engine.start(myCommand, { userId, guildId });
+```

--- a/apps/docs/content/pages/concepts/index.mdx
+++ b/apps/docs/content/pages/concepts/index.mdx
@@ -35,5 +35,3 @@ Components V2 reply (optional)
 ```
 
 Storage sits orthogonal to that pipeline — anything that needs to remember state across calls (cooldowns, per-guild prefixes, user preferences) reads and writes through the adapter you provide.
-
-Only the **Commands** page is fully written today; the other concept pages stub out the shape and link to the slice that lands them. See the [v2 roadmap](https://github.com/D3OXY/djs-commands/issues/51).

--- a/apps/docs/content/pages/concepts/plugins.mdx
+++ b/apps/docs/content/pages/concepts/plugins.mdx
@@ -1,12 +1,114 @@
 ---
 title: Plugins
-description: Cross-cutting hooks and lifecycle wrappers.
+description: Cross-cutting hooks, command bundles, and lifecycle wrappers.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-<Callout type="warn">
-**Coming with [Slice #57 — Plugins](https://github.com/D3OXY/djs-commands/issues/57).** This page is a placeholder; it will be filled in once that slice lands.
+Plugins let third-party packages — and your own internal bundles — ship commands and side-effects that hook into the handler's lifecycle. The plugin system is intentionally small: a manifest with three optional hooks (`commands`, `setup`, `teardown`).
+
+## Plugin manifest
+
+A plugin is a plain object you pass to `createCommandHandler`. The convention is to expose it as a factory function that returns a `PluginManifest`.
+
+```ts
+import type { PluginManifest } from "@djs-commands/core";
+
+export function loggingPlugin(opts: { level?: "info" | "debug" } = {}): PluginManifest {
+	return {
+		name: "logging",
+		setup({ client }) {
+			client.on("interactionCreate", (i) => {
+				if (i.isChatInputCommand()) {
+					console.log(`[${opts.level ?? "info"}]`, i.commandName, "by", i.user.tag);
+				}
+			});
+		},
+		teardown() {
+			// optional cleanup — runs on handler.destroy()
+		},
+	};
+}
+```
+
+Register at boot:
+
+```ts
+createCommandHandler({
+	client,
+	commands: [...],
+	plugins: [loggingPlugin({ level: "debug" })],
+});
+```
+
+### Manifest fields
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `name` | `string` | Human-readable identifier; surfaces in error messages. |
+| `commands` | `Command[]` | Commands merged into the dispatcher at boot — same shape as the top-level `commands`. |
+| `setup` | `(ctx) => void \| Promise<void>` | Awaited at boot in registration order. **Throwing aborts handler boot.** |
+| `teardown` | `() => void \| Promise<void>` | Awaited on `handler.destroy()`. Errors are logged but don't block other teardowns. |
+
+## Bundling commands
+
+The most common pattern: a plugin ships a related set of commands plus the listeners they need.
+
+```ts
+import { defineCommand, type PluginManifest } from "@djs-commands/core";
+
+const start = defineCommand({
+	name: "music-play",
+	description: "Start playback",
+	run: async ({ reply }) => { await reply("started"); },
+});
+
+const stop = defineCommand({
+	name: "music-stop",
+	description: "Stop playback",
+	run: async ({ reply }) => { await reply("stopped"); },
+});
+
+export function musicPlugin(): PluginManifest {
+	return {
+		name: "music",
+		commands: [start, stop],
+		setup({ client }) {
+			// connect to voice gateway, etc.
+		},
+	};
+}
+```
+
+Plugin commands and top-level commands share a single namespace — duplicates throw at boot.
+
+## Lifecycle and ordering
+
+Plugins boot in array order. Each plugin's `setup` is awaited before the next runs, so plugins later in the array can rely on earlier ones having initialized.
+
+`handler.ready` resolves once **all** setup hooks have completed. If any setup throws, `handler.ready` rejects with that error and the handler does not attach event listeners.
+
+```ts
+const handler = createCommandHandler({ client, plugins: [a, b, c] });
+await handler.ready; // resolves after a.setup → b.setup → c.setup
+```
+
+On `handler.destroy()`:
+
+1. The dispatcher detaches its listeners.
+2. Each plugin's `teardown` is awaited in reverse-registration order.
+3. A failing teardown is logged but does not stop other teardowns.
+
+<Callout type="info">
+Plugins do not currently expose pre/post-dispatch hooks (e.g. wrap-every-command middleware). Today, plugins use the discord.js client directly for that. A typed dispatch-middleware surface is on the roadmap.
 </Callout>
 
-Plugins will let you wrap every command call with logging, metrics, error handling, and feature flags. They will also be how community packages (e.g., legacy message-command support) extend core. Track issue [#57](https://github.com/D3OXY/djs-commands/issues/57).
+## Sharing state
+
+The setup context is intentionally minimal — just `{ client }`. Plugins that need to expose state to commands typically:
+
+- Attach to the client as a property: `client.myState = ...`. Type via module augmentation.
+- Close over their own values and inject them into the commands they ship.
+- Use the `Storage` adapter for persistent state.
+
+Avoid module-scoped singletons in plugin code — that breaks tests that want to construct multiple handlers in the same process.

--- a/apps/docs/content/pages/concepts/storage.mdx
+++ b/apps/docs/content/pages/concepts/storage.mdx
@@ -1,12 +1,135 @@
 ---
 title: Storage
-description: The pluggable persistence layer behind cooldowns, prefixes, and user state.
+description: The pluggable persistence layer behind framework features and your own commands.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import { Cards, Card } from "fumadocs-ui/components/card";
 
-<Callout type="warn">
-**Coming with [Slice #58 — Storage adapter interface](https://github.com/D3OXY/djs-commands/issues/58).** This page is a placeholder; it will be filled in once that slice lands.
+`@djs-commands/core` ships **without a database**. Anything that needs to remember state across restarts — guild prefixes, disabled-command lists, channel locks, your own bot's state — goes through the `Storage` adapter you register.
+
+The contract is a generic CRUD interface modeled on Better Auth's pattern: adapters implement six methods once, and the framework consumes them for every persistent feature. Adding a new model never requires changes to the adapter contract.
+
+## The `Storage` interface
+
+```ts
+interface Storage {
+	create<T>(model: string, data: T): Promise<T>;
+	findOne<T>(model: string, where: StorageWhere): Promise<T | null>;
+	findMany<T>(model: string, opts?: StorageFindOpts): Promise<T[]>;
+	update<T>(model: string, where: StorageWhere, data: Partial<T>): Promise<T>;
+	delete(model: string, where: StorageWhere): Promise<void>;
+	count(model: string, where?: StorageWhere): Promise<number>;
+}
+```
+
+Models are identified by **string names** (snake_case). The framework ships three model names you'll see in the type signatures: `guild_prefix`, `disabled_commands`, `channel_locks`.
+
+## Built-in adapters
+
+`@djs-commands/core` is database-agnostic. First-party adapters live in their own packages so you only depend on what you use.
+
+<Cards>
+	<Card title="Drizzle (Postgres)" href="https://www.npmjs.com/package/@djs-commands/adapter-drizzle" description="@djs-commands/adapter-drizzle — recommended for new projects. Schema is exported from the package." />
+	<Card title="Prisma" href="https://www.npmjs.com/package/@djs-commands/adapter-prisma" description="@djs-commands/adapter-prisma — works against any Prisma client; ships schema fragments to copy in." />
+	<Card title="Mongoose (MongoDB)" href="https://www.npmjs.com/package/@djs-commands/adapter-mongoose" description="@djs-commands/adapter-mongoose — the v1 continuity path. Mongoose models are auto-created if you don't pass your own." />
+</Cards>
+
+Walk-throughs for each are in the [Adapter Cookbook](/adapter-cookbook).
+
+## Using storage
+
+Pass an adapter at boot:
+
+```ts
+import { drizzleStorage } from "@djs-commands/adapter-drizzle";
+import { db } from "./db";
+
+createCommandHandler({
+	client,
+	commands: [...],
+	storage: drizzleStorage(db),
+});
+```
+
+The framework reads/writes its own models automatically. To use storage from your own commands, the adapter is exposed via the handler — most commands won't need it because they can use the **helper functions** below.
+
+## Framework models and helpers
+
+For each first-party model, `@djs-commands/core` exports typed read/write helpers. Use these instead of calling `storage.findOne(...)` directly — they keep the model name and column shape in one place.
+
+### Guild prefix
+
+Per-guild override for the legacy command prefix.
+
+```ts
+import { getGuildPrefix, setGuildPrefix, clearGuildPrefix } from "@djs-commands/core";
+
+const prefix = await getGuildPrefix(storage, guildId); // string | null
+await setGuildPrefix(storage, guildId, "?");
+await clearGuildPrefix(storage, guildId);
+```
+
+### Disabled commands
+
+Per-guild allow-list for commands. Useful for letting moderators turn individual commands off without redeploying.
+
+```ts
+import { isCommandDisabled, disableCommand, enableCommand } from "@djs-commands/core";
+
+if (await isCommandDisabled(storage, guildId, "music-play")) { /* ... */ }
+await disableCommand(storage, guildId, "music-play");
+await enableCommand(storage, guildId, "music-play");
+```
+
+The dispatcher consults `isCommandDisabled` automatically — you don't need to wire it into your validators.
+
+### Channel locks
+
+Restrict a command to specific channels in a guild. Empty list = no restriction.
+
+```ts
+import { getChannelLocks, lockCommandToChannel, unlockCommandFromChannel } from "@djs-commands/core";
+
+const locks = await getChannelLocks(storage, guildId, "music-play"); // string[]
+await lockCommandToChannel(storage, guildId, "music-play", channelId);
+await unlockCommandFromChannel(storage, guildId, "music-play", channelId);
+```
+
+## Using storage for your own state
+
+Storage is generic — you can register your own models with no framework changes. Pick a snake_case model name, define the row shape, and call the adapter methods directly.
+
+```ts
+const USER_SETTINGS = "user_settings";
+
+interface UserSettings {
+	user_id: string;
+	timezone: string;
+}
+
+await storage.create<UserSettings>(USER_SETTINGS, {
+	user_id: "123",
+	timezone: "America/New_York",
+});
+
+const row = await storage.findOne<UserSettings>(USER_SETTINGS, { user_id: "123" });
+```
+
+You're responsible for **migrations**: every adapter expects the underlying table/collection to exist. The Drizzle and Prisma adapters publish schema definitions you can extend.
+
+## Writing a custom adapter
+
+Implement `Storage`, then verify it against the framework's conformance suite:
+
+```ts
+import { runStorageConformance } from "@djs-commands/core";
+
+runStorageConformance("my-adapter", () => myStorageFactory());
+```
+
+The conformance suite is exported as a plain function so you can call it from any test runner. It exercises every CRUD path the framework relies on, including upserts, partial updates, and find-with-options.
+
+<Callout type="info">
+Adapter authors should **not** implement framework-specific logic. The shipped helpers (`getGuildPrefix`, etc.) call the generic CRUD methods — keep your adapter focused on the transport, and the helpers will compose on top.
 </Callout>
-
-The storage layer is a small, well-typed interface. djs-commands core ships an in-memory implementation for dev, and you bring your own for production — Postgres, Redis, MongoDB, Cloudflare KV, anything. Adapter recipes will live in the [Adapter Cookbook](/adapter-cookbook). Track issue [#58](https://github.com/D3OXY/djs-commands/issues/58).

--- a/apps/docs/content/pages/concepts/validators.mdx
+++ b/apps/docs/content/pages/concepts/validators.mdx
@@ -5,23 +5,127 @@ description: Pre-handler checks that gate command execution.
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-<Callout type="warn">
-**Coming with [Slice #54 — Validators](https://github.com/D3OXY/djs-commands/issues/54).** This page is a placeholder; it will be filled in once that slice lands.
-</Callout>
+Validators are async-friendly checks that run **before** `command.run`. They short-circuit the dispatch with a reason string when a check fails — the user sees the reason as an ephemeral reply.
 
-Validators are composable, async-friendly checks that run before `command.run`. Use them for role gates, channel restrictions, custom permission logic, and anything else that should short-circuit the call.
+## Built-in validators
 
-The shape will look roughly like:
+Several common gates live on the command object directly. The dispatcher runs them automatically; you don't have to write them as `Validator` functions.
 
 ```ts
 defineCommand({
-	name: "kick",
-	description: "Kicks a user",
-	validators: [hasRole("moderator"), inGuild()],
-	run: async ({ interaction }) => {
-		// only runs if every validator passed
+	name: "ban",
+	description: "Ban a user",
+	ownerOnly: false,
+	guildOnly: true,
+	channels: ["123456789012345678"],
+	permissions: ["BanMembers"],
+	roles: ["234567890123456789"],
+	run: async ({ reply }) => {
+		await reply("banned");
 	},
 });
 ```
 
-Subscribe to issue [#54](https://github.com/D3OXY/djs-commands/issues/54) for progress.
+| Field | Effect |
+| --- | --- |
+| `ownerOnly: true` | Only IDs in the handler's `botOwners` array can run it. |
+| `guildOnly: true` | Blocks DM invocations. |
+| `channels: string[]` | Allow-list of channel IDs (empty/unset = everywhere). |
+| `permissions: PermissionsString[]` | Required member permissions (e.g. `"BanMembers"`). |
+| `roles: string[]` | Role IDs the invoking member must have. |
+
+Each built-in returns a localized reason string if the check fails, so you don't have to write your own messaging for the common cases.
+
+## Custom validators
+
+For anything beyond the built-ins, attach a `validators` array to the command. A `Validator` is just a function that receives a `ValidatorContext` and returns a result.
+
+```ts
+import { defineCommand, type Validator } from "@djs-commands/core";
+
+const inVoiceChannel: Validator = async ({ member }) => {
+	if (member?.voice.channel) return { ok: true };
+	return { ok: false, reason: "Join a voice channel first." };
+};
+
+defineCommand({
+	name: "play",
+	description: "Play a track",
+	validators: [inVoiceChannel],
+	run: async ({ reply }) => {
+		await reply("playing");
+	},
+});
+```
+
+### `ValidatorContext`
+
+```ts
+interface ValidatorContext {
+	command: AnyCommand;          // the command being dispatched
+	botOwners: readonly string[]; // bot owners passed to createCommandHandler
+	user: User;                   // invoker
+	guild: Guild | null;          // null in DMs
+	member: GuildMember | null;
+	channelId: string;
+	source:
+		| { type: "slash"; interaction: ChatInputCommandInteraction }
+		| { type: "legacy"; message: Message };
+}
+```
+
+The context is **unified** across slash and legacy invocations — most validators don't need to look at `source`. When you do (e.g. ephemeral replies are slash-only), narrow on `source.type`.
+
+### `ValidationResult`
+
+```ts
+type ValidationResult = { ok: true } | { ok: false; reason: string };
+```
+
+`reason` is shown to the user. Keep it short and actionable.
+
+## Global validators
+
+Pass `validators` to `createCommandHandler` to run them on **every** command. Useful for cross-cutting policy like "block banned users":
+
+```ts
+createCommandHandler({
+	client,
+	commands: [...],
+	validators: [
+		async ({ user }) => banSet.has(user.id)
+			? { ok: false, reason: "You're not allowed to use this bot." }
+			: { ok: true },
+	],
+});
+```
+
+## `canRunCommand` shorthand
+
+For a single global gate, `canRunCommand` is a slimmer signature: return `true`, `false`, or a string reason.
+
+```ts
+createCommandHandler({
+	client,
+	commands: [...],
+	canRunCommand: ({ command, user }) => {
+		if (command.name === "admin" && !admins.has(user.id)) return "Admins only.";
+		return true;
+	},
+});
+```
+
+## Order of evaluation
+
+For each dispatch, the chain runs in this order — first failure wins:
+
+1. Built-in validators (in this order: `ownerOnly`, `guildOnly`, `channels`, `permissions`, `roles`)
+2. Handler-level `validators`
+3. Command-level `validators`
+4. Handler-level `canRunCommand`
+
+If every check returns `{ ok: true }` (or `canRunCommand` returns `true`), the dispatcher proceeds to the cooldown gate and then `command.run`.
+
+<Callout type="info">
+Validators run **before** cooldowns. A failing validator does not start a cooldown. This is intentional — you don't want a permission denial to also rate-limit the user.
+</Callout>

--- a/apps/docs/content/pages/getting-started/index.mdx
+++ b/apps/docs/content/pages/getting-started/index.mdx
@@ -8,12 +8,23 @@ import { Cards, Card } from "fumadocs-ui/components/card";
 
 This section walks you from a blank directory to a Discord bot that responds to a slash command. If you already have a Discord.js project, jump straight to [Your first command](/getting-started/your-first-command).
 
+## Fastest path: `create-djs-commands`
+
+```bash
+npx create-djs-commands my-bot
+cd my-bot
+cp .env.example .env  # then add your DISCORD_TOKEN
+bun run dev
+```
+
+The CLI scaffolds the directory layout, `tsconfig.json`, `.env.example`, and a working `/ping` command. Pick one of the templates (minimal, components-v2 showcase, or moderation with Drizzle) and you're online in under a minute.
+
 <Callout type="info">
 djs-commands v2 targets Discord.js v14.26+ and Node.js 22+. Bun 1.2+ is supported and is the development runtime used by the maintainers.
 </Callout>
 
 <Cards>
-	<Card title="Installation" href="/getting-started/installation" description="Add @djs-commands/core to a Discord.js project — npm, pnpm, bun." />
+	<Card title="Installation" href="/getting-started/installation" description="Add @djs-commands/core to an existing Discord.js project — npm, pnpm, bun, yarn." />
 	<Card title="Your first command" href="/getting-started/your-first-command" description="Define a slash command with defineCommand, wire it into a Client, and respond to interactions." />
 </Cards>
 

--- a/apps/docs/content/pages/getting-started/your-first-command.mdx
+++ b/apps/docs/content/pages/getting-started/your-first-command.mdx
@@ -6,6 +6,8 @@ description: Define, register, and run a slash command end-to-end.
 import { Callout } from "fumadocs-ui/components/callout";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 
+The fastest path to a running bot is `npx create-djs-commands` — it scaffolds the directory layout, `tsconfig.json`, and `.env.example` for you. This page walks through the same setup by hand so you understand each piece.
+
 <Steps>
 <Step>
 ### Define a command
@@ -15,27 +17,27 @@ A command is just a plain object you build with `defineCommand`. The function is
 ```ts title="src/commands/ping.ts"
 import { defineCommand } from "@djs-commands/core";
 
-export const ping = defineCommand({
+export default defineCommand({
 	name: "ping",
 	description: "Replies with pong",
-	run: async ({ interaction }) => {
-		await interaction.reply("pong");
+	run: async ({ reply }) => {
+		await reply("pong");
 	},
 });
 ```
 
-The handler receives a `CommandRunContext` — for now, that's just the underlying `ChatInputCommandInteraction` from discord.js. Future slices add validators, plugins, and storage to that context.
+The handler receives a [`CommandRunContext`](/concepts/commands#commandruncontext) with a unified `reply()` (works for both slash and legacy invocations), the invoking `author`, the `guild`, `member`, and typed `options`.
 </Step>
 
 <Step>
 ### Wire up a Client
 
-Pass your commands to `createCommandHandler` along with a discord.js `Client`. The handler subscribes to `interactionCreate` and dispatches matching slash commands to the right `run` function. On `clientReady`, it registers the command list with Discord.
+Pass your commands to `createCommandHandler` along with a discord.js `Client`. The handler subscribes to `interactionCreate` and dispatches matching slash commands. On `clientReady`, it registers the command list with Discord.
 
 ```ts title="src/index.ts"
 import { createCommandHandler } from "@djs-commands/core";
 import { Client, GatewayIntentBits } from "discord.js";
-import { ping } from "./commands/ping";
+import ping from "./commands/ping";
 
 const token = process.env.DISCORD_TOKEN;
 if (!token) {
@@ -45,10 +47,12 @@ if (!token) {
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-createCommandHandler({
+const handler = createCommandHandler({
 	client,
 	commands: [ping],
 });
+
+await handler.ready;
 
 client.once("clientReady", (c) => {
 	console.log(`Logged in as ${c.user.tag}`);
@@ -56,6 +60,17 @@ client.once("clientReady", (c) => {
 
 await client.login(token);
 ```
+
+Or skip the manual import and let the framework load the directory for you:
+
+```ts
+createCommandHandler({
+	client,
+	commandDir: "./src/commands",
+});
+```
+
+In dev (`NODE_ENV !== "production"`) the directory is watched and edited files hot-reload without a restart.
 </Step>
 
 <Step>
@@ -73,19 +88,15 @@ The first time you run a freshly registered command, Discord may take a minute t
 </Step>
 </Steps>
 
-## What changed from v1?
+## Next steps
 
-If you're coming from the legacy `@d3oxy/djs-commands` package, here's the short version:
+- **Add typed options** — see [Commands → Options](/concepts/commands#options).
+- **Gate execution** with role/permission/channel checks — see [Validators](/concepts/validators).
+- **Rate-limit** with built-in cooldowns — see [Cooldowns](/concepts/cooldowns).
+- **Persist state** (prefixes, disabled commands, your own data) — see [Storage](/concepts/storage).
+- **Build rich replies** with Components V2 — see [Components V2](/components-v2).
+- **Extend the handler** with a plugin — see [Plugins](/concepts/plugins).
 
-- **Commands are objects, not files.** v1 read a `commandDir` from disk; v2 takes an array. You bring your own loader (or skip it entirely and import directly).
-- **No more `legacyCommands` toggle.** v2 is slash-first. Message commands are coming back as an opt-in plugin in a later slice.
-- **No more global state.** The handler returned by `createCommandHandler` exposes `destroy()` so you can tear down cleanly in tests.
-- **MongoDB is gone from core.** Persistence (cooldowns, prefixes, user state) is now plugin-shaped — bring your own adapter. See [Concepts → storage](/concepts) once that slice ships.
+## Coming from v1?
 
-The v1 package will keep working at the [`v1-final-commit` tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit). It will not receive feature updates.
-
-## Next
-
-- Read [Concepts → commands](/concepts/commands) for the deep dive on `defineCommand`.
-- Browse [Recipes](/recipes) for ready-made patterns.
-- Join the [Discord support server](https://deoxy.dev/links?redirect=support).
+If you're upgrading from `@d3oxy/djs-commands`, the [Migration from v1](/migration-from-v1) guide walks through every API that moved or was dropped, with side-by-side examples.

--- a/apps/docs/content/pages/index.mdx
+++ b/apps/docs/content/pages/index.mdx
@@ -12,9 +12,20 @@ import { Cards, Card } from "fumadocs-ui/components/card";
 2. **Components V2 native.** First-class support for the new Discord component model, so building rich, interactive responses is the default path — not an afterthought.
 3. **Pluggable persistence.** Cooldowns, guild prefixes, and user state plug into adapters you control: in-memory for dev, your own database in production.
 
-<Callout type="warn">
-v2 is in active development. The legacy v1 package (`@d3oxy/djs-commands`) is preserved at the [`v1-final-commit` tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit). Track the v2 rollout on the [roadmap](https://github.com/D3OXY/djs-commands/issues/51).
+<Callout type="info">
+**v2.0 shipped.** Packages are live on npm under [`@djs-commands/*`](https://www.npmjs.com/org/djs-commands). The legacy v1 package (`@d3oxy/djs-commands`) is preserved at the [`v1-final-commit` tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and is no longer maintained — see the [v1 → v2 migration guide](/migration-from-v1) to upgrade.
 </Callout>
+
+## Quick start
+
+```bash
+npx create-djs-commands my-bot
+cd my-bot
+cp .env.example .env  # add DISCORD_TOKEN
+bun run dev
+```
+
+Or scaffold by hand from [Getting Started](/getting-started).
 
 ## Where to start
 

--- a/apps/docs/content/pages/recipes/index.mdx
+++ b/apps/docs/content/pages/recipes/index.mdx
@@ -4,19 +4,146 @@ description: Copy-paste solutions for common bot patterns.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import { Cards, Card } from "fumadocs-ui/components/card";
 
-<Callout type="warn">
-**Coming with [Slice #62 — Recipes](https://github.com/D3OXY/djs-commands/issues/62).** This section is currently a placeholder.
+Recipes are small, focused, copy-paste-friendly examples. They build on the [Concepts](/concepts) pages — read those first if a snippet's `import` doesn't ring a bell.
+
+<Callout type="info">
+The runnable [`examples/`](https://github.com/D3OXY/djs-commands/tree/main/examples) directory in the repo has full bots you can clone and run. The `minimal`, `components-v2-showcase`, and `moderation-drizzle` examples each ship a working `.env.example` and `package.json`.
 </Callout>
 
-Recipes are small, focused, copy-paste-friendly examples. Each one solves a single problem end-to-end:
+## Defer a long-running command
 
-- Pagination with select menus
-- Modal-based forms
-- Role gates via validators
-- Long-running tasks with deferred replies
-- i18n / localized command names
-- Logging every command call
-- Reloading commands without restarting the process
+If your handler does work that takes more than 3 seconds, defer the reply so Discord doesn't time out the interaction.
 
-Want a specific recipe? Open an issue with the [`recipes` label](https://github.com/D3OXY/djs-commands/issues?q=label%3Arecipes) or drop a request in the [Discord support server](https://deoxy.dev/links?redirect=support).
+```ts
+defineCommand({
+	name: "report",
+	description: "Generate the weekly report",
+	run: async ({ interaction, reply }) => {
+		if (interaction) await interaction.deferReply();
+		const report = await generateReport(); // takes 8 seconds
+		await reply(report);
+	},
+});
+```
+
+## Role-gated command
+
+Use the built-in `roles` field for the simple case, or a custom `Validator` if the rule is dynamic.
+
+```ts
+defineCommand({
+	name: "kick",
+	description: "Kick a user",
+	guildOnly: true,
+	permissions: ["KickMembers"],
+	roles: ["123456789012345678"], // moderator role
+	options: { target: { type: "user", description: "Who to kick", required: true } },
+	run: async ({ options, member, reply }) => {
+		const guildMember = await member?.guild.members.fetch(options.target.id);
+		await guildMember?.kick();
+		await reply(`Kicked ${options.target.tag}`);
+	},
+});
+```
+
+## Per-user cooldown
+
+```ts
+defineCommand({
+	name: "daily",
+	description: "Claim your daily reward",
+	cooldown: { type: "perUser", duration: 24 * 60 * 60 * 1000 },
+	run: async ({ author, reply }) => {
+		await reply(`Reward claimed for ${author.tag}.`);
+	},
+});
+```
+
+For distributed cooldowns across multiple bot processes, register the [Redis cache adapter](/concepts/cooldowns#storage-backends).
+
+## Modal-based form
+
+```tsx
+import { Modal, TextInput, renderModal } from "@djs-commands/jsx";
+
+defineCommand({
+	name: "feedback",
+	description: "Send feedback",
+	run: async ({ interaction }) => {
+		await interaction.showModal(
+			renderModal(
+				<Modal title="Send feedback" customId="feedback-modal">
+					<TextInput customId="subject" label="Subject" style="short" required={true} />
+					<TextInput customId="body" label="Tell us more" style="paragraph" />
+				</Modal>
+			)
+		);
+	},
+});
+
+// Wire submission handling on the discord.js client itself:
+client.on("interactionCreate", async (i) => {
+	if (!i.isModalSubmit() || i.customId !== "feedback-modal") return;
+	const subject = i.fields.getTextInputValue("subject");
+	const body = i.fields.getTextInputValue("body");
+	// store, log, post to a channel...
+	await i.reply({ content: "Thanks!", ephemeral: true });
+});
+```
+
+## Toggling commands per guild
+
+`disabledCommands` is a built-in storage model. The dispatcher consults it automatically — you only need to expose admin commands to flip the flag.
+
+```ts
+import { defineCommand, disableCommand, enableCommand } from "@djs-commands/core";
+
+defineCommand({
+	name: "toggle",
+	description: "Enable or disable a command in this guild",
+	guildOnly: true,
+	permissions: ["ManageGuild"],
+	options: {
+		command: { type: "string", description: "Command name", required: true },
+		state: { type: "string", description: "on or off", choices: ["on", "off"] as const, required: true },
+	},
+	run: async ({ options, guild, reply }) => {
+		if (!guild) return;
+		const fn = options.state === "off" ? disableCommand : enableCommand;
+		await fn(storage, guild.id, options.command);
+		await reply(`\`${options.command}\` is now ${options.state}`);
+	},
+});
+```
+
+## Channel-locked commands
+
+Use `channels` for a static allow-list, or the dynamic `channel_locks` storage model for per-guild moderator control.
+
+```ts
+import { lockCommandToChannel } from "@djs-commands/core";
+
+await lockCommandToChannel(storage, guildId, "music-play", musicChannelId);
+// `music-play` now only runs in `musicChannelId` for this guild
+```
+
+The dispatcher consults channel locks alongside the static `channels` field.
+
+## Hot-reload commands in development
+
+Pass a `commandDir` to the handler. In dev (`NODE_ENV !== "production"`) the directory is watched and edits hot-reload without a restart.
+
+```ts
+createCommandHandler({
+	client,
+	commandDir: "./src/commands",
+});
+```
+
+To opt out, pass `dev: false`.
+
+## Want a recipe that's not here?
+
+Open an issue with the [`recipes` label](https://github.com/D3OXY/djs-commands/issues?q=label%3Arecipes) or drop a request in the [Discord support server](https://deoxy.dev/links?redirect=support).

--- a/apps/docs/src/lib/mdx-components.tsx
+++ b/apps/docs/src/lib/mdx-components.tsx
@@ -1,0 +1,32 @@
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+import { Banner } from "fumadocs-ui/components/banner";
+import { Callout } from "fumadocs-ui/components/callout";
+import { Card, Cards } from "fumadocs-ui/components/card";
+import { File, Files, Folder } from "fumadocs-ui/components/files";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { TypeTable } from "fumadocs-ui/components/type-table";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+
+/*
+ * defaultMdxComponents provides the `pre` mapping that turns ``` fences into
+ * the styled CodeBlock + Pre pair — without it, code blocks render unstyled
+ * (one pill per line).
+ */
+export const mdxComponents = {
+	...defaultMdxComponents,
+	Tabs,
+	Tab,
+	Steps,
+	Step,
+	Files,
+	File,
+	Folder,
+	Callout,
+	Card,
+	Cards,
+	Accordion,
+	Accordions,
+	Banner,
+	TypeTable,
+};

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -2,8 +2,9 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import type { Root as PageTreeRoot } from "fumadocs-core/page-tree";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
-import { DocsBody, DocsPage } from "fumadocs-ui/page";
+import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/layouts/docs/page";
 import type React from "react";
+import { mdxComponents } from "@/lib/mdx-components";
 import browserCollections from "../../.source/browser";
 
 export const Route = createFileRoute("/$")({
@@ -47,11 +48,13 @@ const clientLoader = browserCollections.docs.createClientLoader({
 	component(doc) {
 		const MDX = doc.default;
 		return (
-			<DocsBody>
-				<h1 className="fd-heading">{doc.frontmatter.title}</h1>
-				{doc.frontmatter.description && <p className="fd-paragraph -mt-2 text-fd-muted-foreground text-lg">{doc.frontmatter.description}</p>}
-				<MDX />
-			</DocsBody>
+			<DocsPage toc={doc.toc} tableOfContent={{ style: "clerk" }}>
+				<DocsTitle>{doc.frontmatter.title}</DocsTitle>
+				{doc.frontmatter.description && <DocsDescription>{doc.frontmatter.description}</DocsDescription>}
+				<DocsBody>
+					<MDX components={mdxComponents} />
+				</DocsBody>
+			</DocsPage>
 		);
 	},
 });
@@ -101,9 +104,7 @@ function Page() {
 
 	return (
 		<DocsLayoutWrapper tree={data.tree}>
-			<DocsPage>
-				<Content />
-			</DocsPage>
+			<Content />
 		</DocsLayoutWrapper>
 	);
 }

--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -1,3 +1,11 @@
 @import "tailwindcss";
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
+
+/*
+ * Tailwind v4 needs an explicit @source for any package whose JS uses utility
+ * classes — fumadocs-ui ships compiled JS with Tailwind classes (incl. the
+ * code-block, tabs, callout, etc styles). Without this, those classes get
+ * tree-shaken away and code blocks render unstyled (one pill per line).
+ */
+@source "../../node_modules/fumadocs-ui/dist/**/*.js";

--- a/biome.json
+++ b/biome.json
@@ -42,6 +42,9 @@
 				"useNumberNamespace": "error",
 				"noInferrableTypes": "error",
 				"noUselessElse": "error"
+			},
+			"suspicious": {
+				"noUnknownAtRules": "off"
 			}
 		}
 	},


### PR DESCRIPTION
## Summary

Code blocks in the docs were rendering each line in its own \`pill\` (see screenshots). Two root causes:

1. **Tailwind v4 missing `@source`.** `fumadocs-ui` ships compiled JS with Tailwind utility classes. Without `@source ".../fumadocs-ui/dist/**/*.js"`, those class names never reached Tailwind's scanner, so the bundled CSS had no styles for the `<figure>`/`<pre>` wrappers — only the inline shiki spans got styled, hence the per-line look.

2. **MDX rendered without components.** Fumadocs maps `pre` → `<CodeBlock><Pre>` via `defaultMdxComponents`, but the route was rendering `<MDX />` with no `components` prop, so fenced fences stayed raw `<pre>`.

While in there, audited every page and refreshed the ones still saying "coming with slice X" — all 17 slices have shipped.

## Fix

- `apps/docs/src/styles/app.css` — added the `@source` directive.
- `apps/docs/src/lib/mdx-components.tsx` (new) — spreads `defaultMdxComponents` + Tabs/Steps/Files/Folder/Callout/Card/Cards/Accordion/Banner/TypeTable.
- `apps/docs/src/routes/$.tsx` — passes `components={mdxComponents}`, restructures into `DocsPage > DocsTitle > DocsDescription > DocsBody`, pipes `toc={doc.toc}` so the right-side TOC works.
- `biome.json` — turn off `noUnknownAtRules` so Tailwind v4 at-rules don't trip the CSS linter.

## Content audit (every page touched)

- `index.mdx` — replaced "v2 in active development" with "v2.0 shipped" + `npx create-djs-commands` quick-start.
- `concepts/{commands,validators,cooldowns,plugins,storage,components-v2}.mdx` — full rewrites from placeholders to real API content with examples (signatures pulled directly from `packages/core/src/`).
- `recipes/index.mdx` — 8 actual copy-paste recipes (deferred replies, role gates, cooldowns, modals, command toggles, channel locks, hot reload).
- `api-reference/index.mdx` — full table of every public export in `@djs-commands/{core,jsx}` + the four adapters, with deep-links into the concept pages.
- `adapter-cookbook/index.mdx` — soup-to-nuts walk-through for Drizzle, Prisma, Mongoose, Redis, plus a custom-adapter how-to.
- `getting-started/{index,your-first-command}.mdx` — added the CLI scaffold flow, removed stale "future slices" notes.

## Test plan

- [x] `bun run check` (biome) — 116 files, no errors
- [x] `bun run typecheck` — clean across the workspace
- [x] `bun run knip` — only configuration hints (pre-existing)
- [x] `cd apps/docs && bun run build` — exits 0; `.vercel/output/` produced; all routes prerender
- [x] Verified rendered HTML on `/getting-started/installation` now shows proper `<figure class="...bg-fd-card rounded-xl shiki...">` wrappers with copy buttons; Tabs render with `role="tablist"` ARIA.
- [ ] Spot-check on Vercel preview after merge (sidebar/TOC/code-block visuals).