### PR TITLE
docs: refresh package READMEs with shipped-state content

### DIFF
--- a/.changeset/refresh-package-readmes.md
+++ b/.changeset/refresh-package-readmes.md
@@ -1,0 +1,17 @@
+---
+"@djs-commands/core": patch
+"@djs-commands/jsx": patch
+"create-djs-commands": patch
+"@djs-commands/adapter-drizzle": patch
+"@djs-commands/adapter-prisma": patch
+"@djs-commands/adapter-mongoose": patch
+"@djs-commands/adapter-redis": patch
+---
+
+docs: refresh package READMEs
+
+- Drop pre-2.0 placeholder copy ("bootstrap-stage skeleton", "more models in slice #62", etc.) — every framework model ships today.
+- Link prominently to https://djscommands.deoxy.dev for concepts, recipes, and the adapter cookbook.
+- Fix `adapter-redis` README using `cache:` (handler option is `cacheAdapter`).
+- Document all three framework models (`guild_prefix`, `disabled_commands`, `channel_locks`) on every storage adapter README.
+- Add migration-guide and companion-package links throughout.

--- a/packages/adapter-drizzle/README.md
+++ b/packages/adapter-drizzle/README.md
@@ -1,58 +1,64 @@
 # @djs-commands/adapter-drizzle
 
-Drizzle/Postgres `Storage` adapter for djs-commands. Persists framework state (currently per-guild legacy prefix overrides; more models in slice #62).
+Drizzle/Postgres `Storage` adapter for [`@djs-commands/core`](https://www.npmjs.com/package/@djs-commands/core).
+
+Persists the framework's three built-in models — **guild prefixes**, **disabled commands**, and **channel locks** — and any custom models you reach for via the generic `Storage` interface.
+
+📘 **Full walk-through: https://djscommands.deoxy.dev/adapter-cookbook#drizzle-postgres**
 
 ## Install
 
 ```bash
 bun add @djs-commands/core @djs-commands/adapter-drizzle drizzle-orm pg
+bun add -d drizzle-kit
 ```
 
 ## Usage
 
-1. Add the framework's schema to your Drizzle schema file:
+1. Re-export the framework's tables from your Drizzle schema:
 
-```ts
-// src/db/schema.ts
-export { guildPrefix } from "@djs-commands/adapter-drizzle/schema";
-// ...your own tables alongside
-```
+   ```ts
+   // src/db/schema.ts
+   export { channelLocks, disabledCommands, guildPrefix } from "@djs-commands/adapter-drizzle/schema";
+   // ...your own tables alongside
+   ```
 
-2. Run a migration so the table exists:
+2. Run a migration so the tables exist:
 
-```bash
-bunx drizzle-kit push
-```
+   ```bash
+   bunx drizzle-kit push
+   ```
 
 3. Wire it up:
 
+   ```ts
+   import { drizzleStorage } from "@djs-commands/adapter-drizzle";
+   import { drizzle } from "drizzle-orm/node-postgres";
+   import { Pool } from "pg";
+
+   const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+   const db = drizzle(pool);
+
+   createCommandHandler({
+     client,
+     commands: [/* ... */],
+     storage: drizzleStorage(db),
+   });
+   ```
+
+The dispatcher reads/writes `guild_prefix`, `disabled_commands`, and `channel_locks` automatically — you don't write any code for the framework models.
+
+## Bring-your-own-tables
+
+Override any of the table objects (rename columns, add fields, share with your app's schema):
+
 ```ts
 import { drizzleStorage } from "@djs-commands/adapter-drizzle";
-import { drizzle } from "drizzle-orm/node-postgres";
-import { Pool } from "pg";
+import { myGuildPrefixTable } from "./schema";
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-const db = drizzle(pool);
-
-createCommandHandler({
-  client,
-  storage: drizzleStorage(db),
-  legacy: { enabled: true, defaultPrefix: "!" },
-  // ...
+drizzleStorage(db, {
+  tables: { guildPrefix: myGuildPrefixTable },
 });
-```
-
-## Bring-your-own-table
-
-If you want a custom table name or share the table with other code, pass it explicitly:
-
-```ts
-import { GuildPrefixModel } from "@djs-commands/core";
-import { drizzleStorage, guildPrefix as defaultGuildPrefix } from "@djs-commands/adapter-drizzle";
-
-const myGuildPrefix = pgTable("my_prefix_table", { guildId: text("guild_id").primaryKey(), prefix: text("prefix").notNull() });
-
-drizzleStorage(db, { tables: { [GuildPrefixModel]: myGuildPrefix } });
 ```
 
 ## Local development
@@ -64,4 +70,8 @@ docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres bun test
 ```
 
-The integration test suite skips cleanly if `DATABASE_URL` is unset or unreachable.
+The integration test suite skips cleanly if `DATABASE_URL` is unset or unreachable — CI without Postgres will not fail.
+
+## License
+
+[MIT](https://github.com/D3OXY/djs-commands/blob/main/LICENSE) · Issues + discussions on [GitHub](https://github.com/D3OXY/djs-commands).

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -1,12 +1,12 @@
 # @djs-commands/adapter-mongoose
 
-Mongoose/MongoDB `Storage` adapter for djs-commands. Persists framework state
-(currently per-guild legacy prefix overrides; more models in slice #62).
+Mongoose/MongoDB `Storage` adapter for [`@djs-commands/core`](https://www.npmjs.com/package/@djs-commands/core).
 
-This is the continuity path for v1 (`@d3oxy/djs-commands`) users — v1 was
-Mongo-first. The adapter targets `mongoose@^8` (v1 used `mongoose@^7`); the
-breaking changes between the two are documented in
-[Mongoose's migrating-to-8 guide](https://mongoosejs.com/docs/migrating_to_8.html).
+Persists the framework's three built-in models — **guild prefixes**, **disabled commands**, and **channel locks**. This is the v1 (`@d3oxy/djs-commands`) continuity path — v1 was Mongo-first.
+
+📘 **Full walk-through: https://djscommands.deoxy.dev/adapter-cookbook#mongoose-mongodb**
+
+The adapter targets `mongoose@^8`. v1 was on `mongoose@^7`; the breaking changes between the two are documented in [Mongoose's migrating-to-8 guide](https://mongoosejs.com/docs/migrating_to_8.html).
 
 ## Install
 
@@ -14,14 +14,11 @@ breaking changes between the two are documented in
 bun add @djs-commands/core @djs-commands/adapter-mongoose mongoose
 ```
 
-`mongoose` and `@djs-commands/core` are peer dependencies — install them in
-your app.
+`mongoose` and `@djs-commands/core` are peer dependencies — install them in your app.
 
 ## Usage
 
-Pass a Mongoose `Connection` (created with `mongoose.createConnection(url)`)
-into `mongooseStorage`, then hand the returned `Storage` to your command
-handler.
+Pass a Mongoose `Connection` (created with `mongoose.createConnection(url)`) into `mongooseStorage`, then hand the returned `Storage` to your command handler.
 
 ```ts
 import { Client, GatewayIntentBits } from "discord.js";
@@ -36,37 +33,39 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 createCommandHandler({
   client,
+  commands: [/* ... */],
   storage: mongooseStorage(connection),
-  legacy: { enabled: true, defaultPrefix: "!" },
-  // ...
 });
 
 await client.login(process.env.DISCORD_TOKEN);
 ```
 
-The adapter lazy-creates the GuildPrefix model on the connection the first
-time it's needed. Mongoose caches models by name on the connection, so
-re-instantiating the storage with the same connection is cheap.
+The adapter lazy-creates the framework models on the connection the first time each is needed. Mongoose caches models by name on the connection, so re-instantiating the storage with the same connection is cheap.
 
-## Bring-your-own-model
+## Bring-your-own-models
 
-If you've already registered a compatible model on the connection (e.g. to
-share with other code), pass it explicitly:
+If you've already registered compatible models on the connection (e.g. to share with other code), pass them explicitly:
 
 ```ts
-import { createGuildPrefixModel, mongooseStorage } from "@djs-commands/adapter-mongoose";
+import {
+  createGuildPrefixModel,
+  createDisabledCommandModel,
+  createChannelLockModel,
+  mongooseStorage,
+} from "@djs-commands/adapter-mongoose";
 
-const guildPrefix = createGuildPrefixModel(connection);
-
-mongooseStorage(connection, { models: { guildPrefix } });
+mongooseStorage(connection, {
+  models: {
+    guildPrefix: createGuildPrefixModel(connection),
+    disabledCommand: createDisabledCommandModel(connection),
+    channelLock: createChannelLockModel(connection),
+  },
+});
 ```
 
-`createGuildPrefixModel` is also exported as a named entry point for
-Mongoose-discovery tooling:
+## Coming from v1?
 
-```ts
-import { createGuildPrefixModel } from "@djs-commands/adapter-mongoose/models";
-```
+`@d3oxy/djs-commands@1.4.x` is preserved at the [`v1-final-commit` git tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and is no longer maintained. Your existing Mongoose connection works as-is — see the [v1 → v2 migration guide](https://djscommands.deoxy.dev/migration-from-v1) for the rest.
 
 ## Local development
 
@@ -77,5 +76,8 @@ docker run --rm -p 27017:27017 mongo:7
 MONGO_URL=mongodb://localhost:27017/djs-commands-test bun test
 ```
 
-The integration test suite skips cleanly if `MONGO_URL` is unset or
-unreachable — CI without Mongo will not fail.
+The integration test suite skips cleanly if `MONGO_URL` is unset or unreachable — CI without Mongo will not fail.
+
+## License
+
+[MIT](https://github.com/D3OXY/djs-commands/blob/main/LICENSE) · Issues + discussions on [GitHub](https://github.com/D3OXY/djs-commands).

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -1,38 +1,62 @@
 # @djs-commands/adapter-prisma
 
-Prisma `Storage` adapter for djs-commands. Persists framework state (currently per-guild legacy prefix overrides; more models in slice #62) using a Prisma Client you've already generated for your own app.
+Prisma `Storage` adapter for [`@djs-commands/core`](https://www.npmjs.com/package/@djs-commands/core).
+
+Persists the framework's three built-in models — **guild prefixes**, **disabled commands**, and **channel locks** — using a Prisma Client you've already generated for your own app.
+
+📘 **Full walk-through: https://djscommands.deoxy.dev/adapter-cookbook#prisma**
 
 ## Install
 
 ```bash
 bun add @djs-commands/core @djs-commands/adapter-prisma @prisma/client
-bun add -D prisma
+bun add -d prisma
 ```
 
 ## Usage
 
-1. Add the framework's model to your `schema.prisma`. You can either copy-paste the fragment below or import the string from the package:
+1. Add the framework's models to your `schema.prisma`. Copy the fragment below, or import the schema strings:
 
    ```prisma
    model GuildPrefix {
-       guildId String @id @map("guild_id")
-       prefix  String
+     guildId String @id @map("guild_id")
+     prefix  String
 
-       @@map("guild_prefix")
+     @@map("guild_prefix")
+   }
+
+   model DisabledCommand {
+     guildId     String @map("guild_id")
+     commandName String @map("command_name")
+
+     @@id([guildId, commandName])
+     @@map("disabled_commands")
+   }
+
+   model ChannelLock {
+     guildId     String @map("guild_id")
+     commandName String @map("command_name")
+     channelId   String @map("channel_id")
+
+     @@id([guildId, commandName, channelId])
+     @@map("channel_locks")
    }
    ```
 
    Programmatic option (e.g. for codegen / docs):
 
    ```ts
-   import { GUILD_PREFIX_PRISMA_MODEL } from "@djs-commands/adapter-prisma";
-   console.log(GUILD_PREFIX_PRISMA_MODEL);
+   import {
+     GUILD_PREFIX_PRISMA_MODEL,
+     DISABLED_COMMANDS_PRISMA_MODEL,
+     CHANNEL_LOCKS_PRISMA_MODEL,
+   } from "@djs-commands/adapter-prisma";
    ```
 
-2. Run a migration so the table exists:
+2. Run a migration so the tables exist:
 
    ```bash
-   bunx prisma migrate dev --name add_djs_commands_guild_prefix
+   bunx prisma migrate dev --name add_djs_commands
    bunx prisma generate
    ```
 
@@ -45,22 +69,24 @@ bun add -D prisma
    const prisma = new PrismaClient();
 
    createCommandHandler({
-       client,
-       storage: prismaStorage(prisma),
-       legacy: { enabled: true, defaultPrefix: "!" },
-       // ...
+     client,
+     commands: [/* ... */],
+     storage: prismaStorage(prisma),
    });
    ```
 
-## Bring-your-own-delegate
+The dispatcher reads/writes `guild_prefix`, `disabled_commands`, and `channel_locks` automatically — you don't write any code for the framework models.
 
-If you've renamed the model in your schema, or want to share a delegate with other code, pass it explicitly:
+## Bring-your-own-delegates
+
+If you've renamed the models in your schema, pass the delegates explicitly:
 
 ```ts
-import { GuildPrefixModel } from "@djs-commands/core";
 import { prismaStorage } from "@djs-commands/adapter-prisma";
 
-prismaStorage(prisma, { delegates: { [GuildPrefixModel]: prisma.myCustomModel } });
+prismaStorage(prisma, {
+  delegates: { guildPrefix: prisma.myCustomModel },
+});
 ```
 
 ## Local development
@@ -73,4 +99,8 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres bunx prisma mi
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres bun test
 ```
 
-The integration test suite skips cleanly if `DATABASE_URL` is unset, `@prisma/client` hasn't been generated, or Postgres is unreachable.
+The integration test suite skips cleanly if `DATABASE_URL` is unset, `@prisma/client` hasn't been generated, or Postgres is unreachable — CI without Postgres will not fail.
+
+## License
+
+[MIT](https://github.com/D3OXY/djs-commands/blob/main/LICENSE) · Issues + discussions on [GitHub](https://github.com/D3OXY/djs-commands).

--- a/packages/adapter-redis/README.md
+++ b/packages/adapter-redis/README.md
@@ -1,27 +1,22 @@
 # @djs-commands/adapter-redis
 
-Redis-backed [`CacheAdapter`](https://github.com/D3OXY/djs-commands) for
-[`@djs-commands/core`](https://github.com/D3OXY/djs-commands) cooldowns.
+Redis-backed `CacheAdapter` for [`@djs-commands/core`](https://www.npmjs.com/package/@djs-commands/core) cooldowns.
 
-> Distributed, TTL-native cooldown storage so sharded bots have consistent
-> cooldowns across processes. Uses `SET ... PX <ms>` for atomic
-> set-with-TTL — Redis stores the absolute expiry timestamp as the value
-> AND auto-evicts the key when the TTL elapses.
+Distributed, TTL-native cooldown storage so sharded bots have consistent cooldowns across processes. Uses `SET key value PX <ms>` for atomic set-with-TTL — Redis stores the absolute expiry timestamp as the value AND auto-evicts the key when the TTL elapses, so you never accumulate dead entries.
+
+📘 **Full walk-through: https://djscommands.deoxy.dev/adapter-cookbook#redis-cache-adapter-not-storage**
 
 ## Install
 
 ```bash
-bun add @djs-commands/adapter-redis @djs-commands/core ioredis
+bun add @djs-commands/core @djs-commands/adapter-redis ioredis
 ```
 
-`ioredis` and `@djs-commands/core` are peer dependencies — install them in
-your app.
+`ioredis` and `@djs-commands/core` are peer dependencies — install them in your app.
 
 ## Usage
 
-Pass an `ioredis` instance (constructed however you like — connection URL,
-config object, sentinel, cluster) into `redisCacheAdapter`, then hand the
-returned adapter to your command handler.
+Pass an `ioredis` instance (URL, config, sentinel, cluster — whatever you like) into `redisCacheAdapter`, then hand the returned adapter to your command handler via the `cacheAdapter` option.
 
 ```ts
 import { Client, GatewayIntentBits } from "discord.js";
@@ -30,26 +25,29 @@ import { redisCacheAdapter } from "@djs-commands/adapter-redis";
 import Redis from "ioredis";
 
 const redis = new Redis(process.env.REDIS_URL!);
-const cache = redisCacheAdapter(redis);
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-createCommandHandler({ client, commands: [/* ... */], cache });
+createCommandHandler({
+  client,
+  commands: [/* ... */],
+  cacheAdapter: redisCacheAdapter(redis),
+});
 
 await client.login(process.env.DISCORD_TOKEN);
 ```
 
-### Multi-bot deployments: `keyPrefix`
+Pair this with one of the storage adapters ([drizzle](https://www.npmjs.com/package/@djs-commands/adapter-drizzle) / [prisma](https://www.npmjs.com/package/@djs-commands/adapter-prisma) / [mongoose](https://www.npmjs.com/package/@djs-commands/adapter-mongoose)) for full persistence — `Storage` covers prefixes/locks (durable, low-traffic), `CacheAdapter` covers cooldowns (hot path, ephemeral).
 
-When several bots share a single Redis instance, give each one a distinct
-prefix to avoid collisions:
+## Multi-bot deployments: `keyPrefix`
+
+When several bots share a single Redis instance, give each one a distinct prefix to avoid collisions:
 
 ```ts
-const cache = redisCacheAdapter(redis, { keyPrefix: "moderation-bot:" });
+const cacheAdapter = redisCacheAdapter(redis, { keyPrefix: "moderation-bot:" });
 ```
 
-Every key the adapter reads or writes is prepended with this prefix. The
-default is `"djs-commands:"`.
+Every key the adapter reads or writes is prepended with this prefix. The default is `"djs-commands:"`.
 
 ## How it works
 
@@ -61,8 +59,7 @@ The adapter implements three methods from the `CacheAdapter` interface:
 | `get`    | `GET <prefix><key>` then parse to number   |
 | `delete` | `DEL <prefix><key>`                        |
 
-`get` returns `null` for missing keys, non-numeric values, or timestamps in
-the past — defensive against clock skew.
+`get` returns `null` for missing keys, non-numeric values, or timestamps in the past — defensive against clock skew.
 
 ## Testing
 
@@ -74,9 +71,12 @@ Integration tests run against a real Redis when `REDIS_URL` is set:
 REDIS_URL=redis://localhost:6379 bun test
 ```
 
-If `REDIS_URL` isn't set, the integration suite skips cleanly — CI without
-Redis will not fail. Locally you can spin one up with:
+If `REDIS_URL` isn't set, the integration suite skips cleanly. Spin one up locally with:
 
 ```bash
 docker run --rm -p 6379:6379 redis:7-alpine
 ```
+
+## License
+
+[MIT](https://github.com/D3OXY/djs-commands/blob/main/LICENSE) · Issues + discussions on [GitHub](https://github.com/D3OXY/djs-commands).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,16 +1,19 @@
 # @djs-commands/core
 
-Command dispatcher and core API for djs-commands v2.
+Modern Discord.js command handler — TypeScript-first, Components V2 native, with pluggable persistence.
 
-> Bootstrap-stage skeleton. Public API is unstable until 2.0.0.
+📘 **Full documentation: https://djscommands.deoxy.dev**
 
 ## Install
 
 ```bash
 bun add @djs-commands/core discord.js
+# or: pnpm / npm / yarn
 ```
 
-## Usage
+`discord.js@^14.26` is a peer dependency.
+
+## Quick start
 
 ```ts
 import { Client, GatewayIntentBits } from "discord.js";
@@ -19,18 +22,46 @@ import { createCommandHandler, defineCommand } from "@djs-commands/core";
 const ping = defineCommand({
 	name: "ping",
 	description: "Replies with pong",
-	run: async ({ interaction }) => {
-		await interaction.reply("pong");
+	run: async ({ reply }) => {
+		await reply("pong");
 	},
 });
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-createCommandHandler({ client, commands: [ping] });
+const handler = createCommandHandler({ client, commands: [ping] });
+await handler.ready;
 
 await client.login(process.env.DISCORD_TOKEN);
 ```
 
-## Roadmap
+Prefer scaffolding? Run `npx create-djs-commands my-bot` and you're online in under a minute.
 
-This package is being built out incrementally. See the [v2 PRD](https://github.com/D3OXY/djs-commands/issues/51).
+## What's in the box
+
+- **`defineCommand`** — typed slash + legacy prefix commands with shared `CommandRunContext`. [Docs →](https://djscommands.deoxy.dev/concepts/commands)
+- **Validators** — built-in `ownerOnly` / `guildOnly` / `channels` / `permissions` / `roles`, plus custom `Validator` functions. [Docs →](https://djscommands.deoxy.dev/concepts/validators)
+- **Cooldowns** — four scopes (`perUser` / `perGuild` / `perUserPerGuild` / `global`); pluggable `CacheAdapter` for distributed setups. [Docs →](https://djscommands.deoxy.dev/concepts/cooldowns)
+- **Plugins** — bundle commands and lifecycle hooks; `setup`/`teardown` awaited at boot. [Docs →](https://djscommands.deoxy.dev/concepts/plugins)
+- **Storage** — generic `Storage` adapter contract drives `guild_prefix`, `disabled_commands`, `channel_locks` framework models, plus your own. [Docs →](https://djscommands.deoxy.dev/concepts/storage)
+- **Components V2** — function-form builders (`button`, `container`, `section`, `modal`, …); pair with [`@djs-commands/jsx`](https://www.npmjs.com/package/@djs-commands/jsx) for JSX. [Docs →](https://djscommands.deoxy.dev/components-v2)
+- **fs-autoloader** — `commandDir` autoloads files; hot reloads in dev.
+
+## Companion packages
+
+| Package | Purpose |
+|---|---|
+| [`@djs-commands/jsx`](https://www.npmjs.com/package/@djs-commands/jsx) | Components V2 JSX runtime |
+| [`@djs-commands/adapter-drizzle`](https://www.npmjs.com/package/@djs-commands/adapter-drizzle) | Drizzle/Postgres `Storage` |
+| [`@djs-commands/adapter-prisma`](https://www.npmjs.com/package/@djs-commands/adapter-prisma) | Prisma `Storage` |
+| [`@djs-commands/adapter-mongoose`](https://www.npmjs.com/package/@djs-commands/adapter-mongoose) | Mongoose `Storage` (v1 continuity path) |
+| [`@djs-commands/adapter-redis`](https://www.npmjs.com/package/@djs-commands/adapter-redis) | Redis `CacheAdapter` for distributed cooldowns |
+| [`create-djs-commands`](https://www.npmjs.com/package/create-djs-commands) | `npx create-djs-commands` scaffolding tool |
+
+## Migrating from v1?
+
+`@d3oxy/djs-commands@1.4.x` is preserved at the [`v1-final-commit` git tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and is no longer maintained. Every v1 API has a v2 equivalent — see the [v1 → v2 migration guide](https://djscommands.deoxy.dev/migration-from-v1).
+
+## License
+
+[MIT](https://github.com/D3OXY/djs-commands/blob/main/LICENSE) · Issues + discussions on [GitHub](https://github.com/D3OXY/djs-commands).

--- a/packages/create-djs-commands/README.md
+++ b/packages/create-djs-commands/README.md
@@ -1,8 +1,6 @@
 # create-djs-commands
 
-Scaffolding CLI for djs-commands v2.
-
-## Quick start
+Scaffolding CLI for [djs-commands](https://djscommands.deoxy.dev) — pick a template, answer a few prompts, get a working Discord bot.
 
 ```bash
 npx create-djs-commands my-bot
@@ -12,27 +10,7 @@ bunx create-djs-commands my-bot
 pnpm dlx create-djs-commands my-bot
 ```
 
-Runs an interactive wizard. Pass flags to skip prompts:
-
-```bash
-npx create-djs-commands my-bot \
-  --adapter drizzle \
-  --legacy \
-  --components-v2 \
-  --package-manager bun
-```
-
-## Flags
-
-| Flag | Values | Default |
-|---|---|---|
-| `--adapter` | `drizzle` / `prisma` / `mongoose` / `none` | wizard |
-| `--legacy` | (boolean) | `false` |
-| `--components-v2` | (boolean) | `false` |
-| `--package-manager`, `--pm` | `bun` / `pnpm` / `npm` | `bun` |
-| `--no-git` | (boolean) | `false` |
-| `--skip-install` | (boolean) | `false` |
-| `-h`, `--help` | | |
+📘 **Full documentation: https://djscommands.deoxy.dev/getting-started**
 
 ## What gets scaffolded
 
@@ -43,3 +21,44 @@ npx create-djs-commands my-bot \
 - `.env.example`, `.gitignore`, `README.md`
 
 The bot uses fs-autoloader (`commandDir`), so any new file under `src/commands/` auto-registers on save in dev mode.
+
+## Non-interactive mode
+
+Pass flags to skip prompts:
+
+```bash
+npx create-djs-commands my-bot \
+  --adapter drizzle \
+  --legacy \
+  --components-v2 \
+  --package-manager bun
+```
+
+| Flag | Values | Default |
+|---|---|---|
+| `--adapter` | `drizzle` / `prisma` / `mongoose` / `none` | wizard |
+| `--legacy` | (boolean — enable prefix commands) | `false` |
+| `--components-v2` | (boolean — install `@djs-commands/jsx`) | `false` |
+| `--package-manager`, `--pm` | `bun` / `pnpm` / `npm` | `bun` |
+| `--no-git` | (boolean — skip `git init`) | `false` |
+| `--skip-install` | (boolean — skip dependency install) | `false` |
+| `-h`, `--help` | | |
+
+## Next steps
+
+Once your bot is scaffolded:
+
+```bash
+cd my-bot
+cp .env.example .env  # add your DISCORD_TOKEN
+bun run dev
+```
+
+Then read:
+- [Concepts](https://djscommands.deoxy.dev/concepts) — the mental model.
+- [Recipes](https://djscommands.deoxy.dev/recipes) — copy-paste patterns.
+- [Adapter Cookbook](https://djscommands.deoxy.dev/adapter-cookbook) — wiring up your DB.
+
+## License
+
+[MIT](https://github.com/D3OXY/djs-commands/blob/main/LICENSE) · Issues + discussions on [GitHub](https://github.com/D3OXY/djs-commands).

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -1,50 +1,65 @@
 # @djs-commands/jsx
 
-JSX runtime + Components V2 components for [`@djs-commands/core`](https://github.com/D3OXY/djs-commands).
+JSX runtime + Components V2 component set for [`@djs-commands/core`](https://www.npmjs.com/package/@djs-commands/core).
 
-Write Discord Components V2 messages as JSX:
+📘 **Full documentation: https://djscommands.deoxy.dev/components-v2**
+
+Write Discord Components V2 messages as JSX, compile to discord.js builders:
 
 ```tsx
 import { Container, Section, TextDisplay, Button, render } from "@djs-commands/jsx";
 import { MessageFlags } from "discord.js";
 
 await interaction.reply({
-    flags: MessageFlags.IsComponentsV2,
-    components: render(
-        <Container accentColor={0x5865f2}>
-            <TextDisplay># Welcome</TextDisplay>
-            <Section accessory={<Button style="primary" customId="ok" label="OK" />}>
-                Click the button to continue.
-            </Section>
-        </Container>
-    ),
+	flags: MessageFlags.IsComponentsV2,
+	components: render(
+		<Container accentColor={0x5865f2}>
+			<TextDisplay># Welcome</TextDisplay>
+			<Section accessory={<Button style="primary" customId="ok" label="OK" />}>
+				Click the button to continue.
+			</Section>
+		</Container>
+	),
 });
 ```
 
-## Setup
+## Install
+
+```bash
+bun add @djs-commands/jsx
+```
 
 In your `tsconfig.json`:
 
 ```json
 {
-    "compilerOptions": {
-        "jsx": "react-jsx",
-        "jsxImportSource": "@djs-commands/jsx"
-    }
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "@djs-commands/jsx"
+	}
 }
 ```
 
-That's it — no Babel, no SWC. The TypeScript compiler (and Bun's transpiler) emits `import { jsx } from "@djs-commands/jsx/jsx-runtime"` automatically.
+That's it — no Babel, no SWC, no React. The TypeScript compiler (and Bun's transpiler) emits `import { jsx } from "@djs-commands/jsx/jsx-runtime"` automatically.
 
 ## Components
 
-Display: `<Container>`, `<Section>`, `<TextDisplay>`, `<MediaGallery>`, `<Separator>`, `<File>`, `<Thumbnail>`.
+**Display:** `<Container>`, `<Section>`, `<TextDisplay>`, `<MediaGallery>`, `<Separator>`, `<File>`, `<Thumbnail>`
 
-Forms: `<ActionRow>`, `<Button>`, `<Modal>`, `<TextInput>`, `<RadioGroup>`, `<CheckboxGroup>`.
+**Forms:** `<ActionRow>`, `<Button>` (`primary`/`secondary`/`success`/`danger`/`link`/`premium`), `<Modal>`, `<TextInput>`, `<RadioGroup>`, `<CheckboxGroup>`
+
+**Renderers:** `render(tree)` for messages, `renderModal(tree)` for `interaction.showModal`.
+
+The full surface — every component, side-by-side JSX vs. function examples, modal forms — is on the [Components V2 docs page](https://djscommands.deoxy.dev/components-v2).
 
 ## No JSX? Use the function fallback
 
-If you can't enable JSX in your project, every component has a function-form
-sibling re-exported from `@djs-commands/core` (e.g. `container`, `section`,
-`textDisplay`, `button`). They return the same discord.js builders, so you can
-mix the two freely.
+If you can't (or won't) enable JSX in your project, every component has a function-form sibling re-exported from `@djs-commands/core` (e.g. `container`, `section`, `textDisplay`, `button`). They return the same discord.js builders, so you can mix the two freely.
+
+```ts
+import { button, container, section, textDisplay } from "@djs-commands/core";
+```
+
+## License
+
+[MIT](https://github.com/D3OXY/djs-commands/blob/main/LICENSE) · Issues + discussions on [GitHub](https://github.com/D3OXY/djs-commands).


### PR DESCRIPTION
## Summary

All 7 package READMEs were carrying pre-2.0 placeholder copy ("bootstrap-stage skeleton", "more models in slice #62", "public API is unstable until 2.0.0"). Replaced with current shape now that v2.0 has shipped.

## Changes per package

- **`@djs-commands/core`** — full rewrite: install + quick-start + feature surface (validators, cooldowns, plugins, storage, components-v2, fs-autoloader) with deep-links into the docs; companion-packages table; v1 migration link.
- **`@djs-commands/jsx`** — link to `/components-v2` reference; clarify function-fallback path.
- **`create-djs-commands`** — link to `/getting-started`; "next steps" pointing at concepts/recipes/cookbook.
- **`@djs-commands/adapter-{drizzle,prisma,mongoose}`** — document all three framework models (was only `guild_prefix`); deep-link to `/adapter-cookbook` walk-through; mongoose README links the v1 migration guide.
- **`@djs-commands/adapter-redis`** — fix `cache:` → `cacheAdapter:` (the actual handler option name); cross-link the storage adapters.

Standardized layout across all of them: install → quick start → docs link → footer.

## Changeset

A patch changeset for all 7 publishable packages is included — they'll lockstep-bump on the next release.

## Test plan

- [x] `bun run check` (biome) — clean
- [x] `bun run typecheck` — clean across the workspace
- [x] Eyeballed each README on GitHub diff view
- [x] After merge: verify the new content appears on the npm package pages (npm picks up README from the published tarball, so it'll update on the next release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed package READMEs with updated examples and clearer setup guidance.
  * Added prominent links to official documentation site across all packages.
  * Enhanced storage adapter documentation with complete configuration examples.
  * Improved installation instructions and quick start tutorials.
  * Added companion packages and migration guide references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->