### PR TITLE
fix(docs): declare correct turbo outputs (.vercel/output, .source)

### DIFF
--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": [".vercel/output/**", ".source/**"]
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Vercel deploys started failing with \`Error: No Output Directory named \"dist\" found\` (see [failed deploy](https://vercel.com/d3o/djs-commands/CaQHHEhuvsy8K3JjYT3zActCFmFe)). The build itself succeeded — but as a Turbo \`>>> FULL TURBO\` cache hit in 417ms, and Turbo only restored the logs, not the actual output directory.

## Root cause

Root \`turbo.json\` declares \`"outputs": ["dist/**"]\`, but \`apps/docs\` builds to \`.vercel/output/**\` (Vercel Build Output API v3) via \`nitro({ preset: "vercel" })\` — never \`dist/\`.

On the first build of the day, Turbo populated the cache (with no actual artifacts). On the next deploy, the cache hit replayed the build as a no-op, \`.vercel/output/\` never appeared, and Vercel fell back to looking for \`dist/\` and 404'd.

## Fix

Per-package \`apps/docs/turbo.json\` overrides outputs to the dirs the docs build actually produces:

\`\`\`json
{
  "extends": ["//"],
  "tasks": {
    "build": {
      "outputs": [".vercel/output/**", ".source/**"]
    }
  }
}
\`\`\`

(\`.source/\` is fumadocs-mdx's generated source — also needed on cache replay since the second \`build\` step in \`fumadocs-mdx && vite build\` consumes it.)

## Verification

\`\`\`
$ bun run build:docs              # populates cache (14.5s)
$ rm -rf apps/docs/.vercel apps/docs/.source
$ bun run build:docs              # cache hit (78ms)
$ ls apps/docs/.vercel/output/    # config.json functions nitro.json static  ✓
$ ls apps/docs/.source/           # browser.ts dynamic.ts server.ts source.config.mjs  ✓
\`\`\`

## Test plan

- [x] Local: clean build populates cache, cache replay restores \`.vercel/output/\` + \`.source/\`
- [ ] Vercel preview deploy on this PR succeeds