### PR TITLE
docs(#101): sidebar icons + Cmd+K search

### DIFF
--- a/apps/docs/content/pages/adapter-cookbook/meta.json
+++ b/apps/docs/content/pages/adapter-cookbook/meta.json
@@ -1,4 +1,5 @@
 {
 	"title": "Adapter Cookbook",
+	"icon": "Database",
 	"pages": ["index"]
 }

--- a/apps/docs/content/pages/api-reference/meta.json
+++ b/apps/docs/content/pages/api-reference/meta.json
@@ -1,4 +1,5 @@
 {
 	"title": "API Reference",
+	"icon": "Code",
 	"pages": ["index"]
 }

--- a/apps/docs/content/pages/components-v2/meta.json
+++ b/apps/docs/content/pages/components-v2/meta.json
@@ -1,4 +1,5 @@
 {
 	"title": "Components V2",
+	"icon": "Layers",
 	"pages": ["index"]
 }

--- a/apps/docs/content/pages/concepts/meta.json
+++ b/apps/docs/content/pages/concepts/meta.json
@@ -1,4 +1,5 @@
 {
 	"title": "Concepts",
+	"icon": "Lightbulb",
 	"pages": ["index", "commands", "validators", "cooldowns", "plugins", "storage", "components-v2"]
 }

--- a/apps/docs/content/pages/getting-started/meta.json
+++ b/apps/docs/content/pages/getting-started/meta.json
@@ -1,4 +1,5 @@
 {
 	"title": "Getting Started",
+	"icon": "Rocket",
 	"pages": ["index", "installation", "your-first-command"]
 }

--- a/apps/docs/content/pages/migration-from-v1/meta.json
+++ b/apps/docs/content/pages/migration-from-v1/meta.json
@@ -1,4 +1,5 @@
 {
 	"title": "Migration from v1",
+	"icon": "ArrowRightLeft",
 	"pages": ["index", "handler", "commands", "validators", "persistence", "events-and-plugins", "dropped-features"]
 }

--- a/apps/docs/content/pages/recipes/meta.json
+++ b/apps/docs/content/pages/recipes/meta.json
@@ -1,4 +1,5 @@
 {
 	"title": "Recipes",
+	"icon": "ChefHat",
 	"pages": ["index"]
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,6 +18,7 @@
 		"fumadocs-core": "^16.6.17",
 		"fumadocs-mdx": "^14.2.10",
 		"fumadocs-ui": "^16.6.17",
+		"lucide-react": "^1.14.0",
 		"nitro": "3.0.260311-beta",
 		"react": "catalog:",
 		"react-dom": "catalog:",

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,7 +1,21 @@
 import { loader } from "fumadocs-core/source";
+import * as Icons from "lucide-react";
+import { createElement } from "react";
 import { docs } from "../../.source/server";
 
+/*
+ * meta.json files set `icon: "Rocket"` (a lucide-react export name). The loader
+ * resolves the string to a real React component here so the sidebar renders an
+ * icon next to each section. Unknown names fall back to undefined (no icon).
+ */
 export const source = loader({
 	source: docs.toFumadocsSource(),
 	baseUrl: "/",
+	icon(icon) {
+		if (!icon) return undefined;
+		const Icon = (Icons as unknown as Record<string, unknown>)[icon];
+		if (!Icon) return undefined;
+		// biome-ignore lint/suspicious/noExplicitAny: lucide icons all share the same prop shape
+		return createElement(Icon as any);
+	},
 });

--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -10,33 +10,43 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SplatRouteImport } from './routes/$'
+import { Route as ApiSearchRouteImport } from './routes/api/search'
 
 const SplatRoute = SplatRouteImport.update({
   id: '/$',
   path: '/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiSearchRoute = ApiSearchRouteImport.update({
+  id: '/api/search',
+  path: '/api/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/$': typeof SplatRoute
+  '/api/search': typeof ApiSearchRoute
 }
 export interface FileRoutesByTo {
   '/$': typeof SplatRoute
+  '/api/search': typeof ApiSearchRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/$': typeof SplatRoute
+  '/api/search': typeof ApiSearchRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/$'
+  fullPaths: '/$' | '/api/search'
   fileRoutesByTo: FileRoutesByTo
-  to: '/$'
-  id: '__root__' | '/$'
+  to: '/$' | '/api/search'
+  id: '__root__' | '/$' | '/api/search'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   SplatRoute: typeof SplatRoute
+  ApiSearchRoute: typeof ApiSearchRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -48,11 +58,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/search': {
+      id: '/api/search'
+      path: '/api/search'
+      fullPath: '/api/search'
+      preLoaderRoute: typeof ApiSearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   SplatRoute: SplatRoute,
+  ApiSearchRoute: ApiSearchRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/docs/src/routes/__root.tsx
+++ b/apps/docs/src/routes/__root.tsx
@@ -29,7 +29,15 @@ function RootComponent() {
 				<HeadContent />
 			</head>
 			<body>
-				<RootProvider theme={{ defaultTheme: "dark" }}>
+				<RootProvider
+					theme={{ defaultTheme: "dark" }}
+					search={{
+						options: {
+							type: "fetch",
+							api: "/api/search",
+						},
+					}}
+				>
 					<Outlet />
 				</RootProvider>
 				<Scripts />

--- a/apps/docs/src/routes/api/search.ts
+++ b/apps/docs/src/routes/api/search.ts
@@ -1,0 +1,22 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { createSearchAPI } from "fumadocs-core/search/server";
+import { source } from "@/lib/source";
+
+const server = createSearchAPI("advanced", {
+	language: "english",
+	indexes: source.getPages().map((page) => ({
+		title: page.data.title,
+		description: page.data.description,
+		url: page.url,
+		id: page.url,
+		structuredData: page.data.structuredData,
+	})),
+});
+
+export const Route = createFileRoute("/api/search")({
+	server: {
+		handlers: {
+			GET: async ({ request }) => server.GET(request),
+		},
+	},
+});

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "fumadocs-core": "^16.6.17",
         "fumadocs-mdx": "^14.2.10",
         "fumadocs-ui": "^16.6.17",
+        "lucide-react": "^1.14.0",
         "nitro": "3.0.260311-beta",
         "react": "catalog:",
         "react-dom": "catalog:",
@@ -87,7 +88,7 @@
     },
     "packages/adapter-drizzle": {
       "name": "@djs-commands/adapter-drizzle",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@djs-commands/core": "workspace:*",
         "@djs-commands/tsconfig": "workspace:*",
@@ -105,7 +106,7 @@
     },
     "packages/adapter-mongoose": {
       "name": "@djs-commands/adapter-mongoose",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@djs-commands/core": "workspace:*",
         "@djs-commands/tsconfig": "workspace:*",
@@ -121,7 +122,7 @@
     },
     "packages/adapter-prisma": {
       "name": "@djs-commands/adapter-prisma",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@djs-commands/core": "workspace:*",
         "@djs-commands/tsconfig": "workspace:*",
@@ -138,7 +139,7 @@
     },
     "packages/adapter-redis": {
       "name": "@djs-commands/adapter-redis",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@djs-commands/core": "workspace:*",
         "@djs-commands/tsconfig": "workspace:*",
@@ -155,7 +156,7 @@
     },
     "packages/core": {
       "name": "@djs-commands/core",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@djs-commands/tsconfig": "workspace:*",
         "@types/bun": "catalog:",
@@ -170,7 +171,7 @@
     },
     "packages/create-djs-commands": {
       "name": "create-djs-commands",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "bin": {
         "create-djs-commands": "dist/cli.js",
       },
@@ -187,7 +188,7 @@
     },
     "packages/jsx": {
       "name": "@djs-commands/jsx",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@djs-commands/tsconfig": "workspace:*",
         "@types/bun": "catalog:",


### PR DESCRIPTION
Closes #101.

## What

- Lucide icons in every top-level section's `meta.json` (Rocket / Lightbulb / ChefHat / Code / Database / Layers / ArrowRightLeft)
- `source.ts` resolves icon strings → `lucide-react` components for the page tree
- New `/api/search` TanStack file-route using fumadocs `createSearchAPI('advanced', ...)` — indexes every page incl. `structuredData`
- `RootProvider` wired up with `search.options = { type: 'fetch', api: '/api/search' }` so Cmd+K opens the default fumadocs `SearchDialog`

## Verified

- `GET /api/search?query=cooldown` returns relevant hits across pages
- Sidebar HTML contains all expected lucide icon classes (`lucide-rocket`, `lucide-database`, etc.)
- `bun run typecheck` clean
- `bun run check` clean