### PR TITLE
docs(#102): SEO pack — head metadata + sitemap.xml + robots.txt

### DIFF
--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -9,9 +9,21 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
+import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 
+const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
+  id: '/sitemap.xml',
+  path: '/sitemap.xml',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
+  id: '/robots.txt',
+  path: '/robots.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SplatRoute = SplatRouteImport.update({
   id: '/$',
   path: '/$',
@@ -25,32 +37,54 @@ const ApiSearchRoute = ApiSearchRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/$': typeof SplatRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
 }
 export interface FileRoutesByTo {
   '/$': typeof SplatRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/$': typeof SplatRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/$' | '/api/search'
+  fullPaths: '/$' | '/robots.txt' | '/sitemap.xml' | '/api/search'
   fileRoutesByTo: FileRoutesByTo
-  to: '/$' | '/api/search'
-  id: '__root__' | '/$' | '/api/search'
+  to: '/$' | '/robots.txt' | '/sitemap.xml' | '/api/search'
+  id: '__root__' | '/$' | '/robots.txt' | '/sitemap.xml' | '/api/search'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   SplatRoute: typeof SplatRoute
+  RobotsDottxtRoute: typeof RobotsDottxtRoute
+  SitemapDotxmlRoute: typeof SitemapDotxmlRoute
   ApiSearchRoute: typeof ApiSearchRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/sitemap.xml': {
+      id: '/sitemap.xml'
+      path: '/sitemap.xml'
+      fullPath: '/sitemap.xml'
+      preLoaderRoute: typeof SitemapDotxmlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/robots.txt': {
+      id: '/robots.txt'
+      path: '/robots.txt'
+      fullPath: '/robots.txt'
+      preLoaderRoute: typeof RobotsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/$': {
       id: '/$'
       path: '/$'
@@ -70,6 +104,8 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   SplatRoute: SplatRoute,
+  RobotsDottxtRoute: RobotsDottxtRoute,
+  SitemapDotxmlRoute: SitemapDotxmlRoute,
   ApiSearchRoute: ApiSearchRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -7,6 +7,7 @@ import type React from "react";
 import { mdxComponents } from "@/lib/mdx-components";
 import browserCollections from "../../.source/browser";
 
+const SITE_URL = "https://djscommands.deoxy.dev";
 const REPO = "D3OXY/djs-commands";
 const REPO_BRANCH = "main";
 const CONTENT_PATH = "apps/docs/content/pages";
@@ -18,6 +19,32 @@ export const Route = createFileRoute("/$")({
 		const [data, tree] = await Promise.all([getPageData({ data: slugs }), getPageTree()]);
 		await clientLoader.preload(data.path);
 		return { ...data, tree };
+	},
+	head: ({ loaderData }) => {
+		if (!loaderData) return {};
+		const fullTitle = `${loaderData.title} · djs-commands`;
+		const description = loaderData.description ?? "Modern Discord.js command handler — TypeScript-first, Components V2 native, with pluggable persistence.";
+		const canonical = `${SITE_URL}${loaderData.url}`;
+		const ogImage = `${SITE_URL}/og-default.png`;
+		return {
+			meta: [
+				{ title: fullTitle },
+				{ name: "description", content: description },
+				// Open Graph
+				{ property: "og:title", content: fullTitle },
+				{ property: "og:description", content: description },
+				{ property: "og:url", content: canonical },
+				{ property: "og:type", content: "article" },
+				{ property: "og:site_name", content: "djs-commands" },
+				{ property: "og:image", content: ogImage },
+				// Twitter / X
+				{ name: "twitter:card", content: "summary_large_image" },
+				{ name: "twitter:title", content: fullTitle },
+				{ name: "twitter:description", content: description },
+				{ name: "twitter:image", content: ogImage },
+			],
+			links: [{ rel: "canonical", href: canonical }],
+		};
 	},
 });
 

--- a/apps/docs/src/routes/robots[.]txt.ts
+++ b/apps/docs/src/routes/robots[.]txt.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+const SITE_URL = "https://djscommands.deoxy.dev";
+
+export const Route = createFileRoute("/robots.txt")({
+	server: {
+		handlers: {
+			GET: () => {
+				const body = `User-agent: *\nAllow: /\n\nSitemap: ${SITE_URL}/sitemap.xml\n`;
+				return new Response(body, {
+					status: 200,
+					headers: {
+						"content-type": "text/plain; charset=utf-8",
+						"cache-control": "public, max-age=3600, s-maxage=3600",
+					},
+				});
+			},
+		},
+	},
+});

--- a/apps/docs/src/routes/sitemap[.]xml.ts
+++ b/apps/docs/src/routes/sitemap[.]xml.ts
@@ -1,0 +1,28 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+const SITE_URL = "https://djscommands.deoxy.dev";
+
+export const Route = createFileRoute("/sitemap.xml")({
+	server: {
+		handlers: {
+			GET: async () => {
+				const { source } = await import("@/lib/source");
+				const pages = source.getPages();
+				const urls = pages
+					.map(
+						(p) =>
+							`  <url>\n    <loc>${SITE_URL}${p.url}</loc>\n    <changefreq>weekly</changefreq>\n    <priority>${p.url === "/" ? "1.0" : "0.7"}</priority>\n  </url>`
+					)
+					.join("\n");
+				const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+				return new Response(xml, {
+					status: 200,
+					headers: {
+						"content-type": "application/xml; charset=utf-8",
+						"cache-control": "public, max-age=3600, s-maxage=3600",
+					},
+				});
+			},
+		},
+	},
+});


### PR DESCRIPTION
Closes #102.

## What

- **`routes/$.tsx`** — adds a `head()` function piping loader data (title, description, url) into a full `<head>` with `canonical`, `og:title`, `og:description`, `og:url`, `og:type`, `og:site_name`, `og:image`, `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`.
- **`/sitemap.xml`** — new file route that emits a valid sitemap from `source.getPages()` at request time, with `changefreq` + `priority`.
- **`/robots.txt`** — new file route that allows all UAs and references the sitemap.

## ⚠️ One follow-up needed

The OG image URL points at `/og-default.png`. That asset still needs to be dropped into `apps/docs/public/` (1200x630 recommended). The metadata is otherwise complete — once the file is in place, Discord/Slack/Twitter will all unfurl docs links with a rich preview.

## Verified locally

```
$ curl http://localhost:3002/robots.txt
User-agent: *
Allow: /

Sitemap: https://djscommands.deoxy.dev/sitemap.xml

$ curl http://localhost:3002/sitemap.xml | head
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>https://djscommands.deoxy.dev/adapter-cookbook</loc>
    <changefreq>weekly</changefreq>
    <priority>0.7</priority>
  </url>
  …

$ curl http://localhost:3002/concepts/cooldowns | grep -oE '<meta [^>]+>'
<meta property="og:title" content="Cooldowns · djs-commands"/>
<meta property="og:description" content="Per-user, per-guild, per-command rate limiting…"/>
<meta property="og:url" content="https://djscommands.deoxy.dev/concepts/cooldowns"/>
…
<link rel="canonical" href="https://djscommands.deoxy.dev/concepts/cooldowns"/>
```

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run check` clean
- [ ] After merge: drop a real PNG at `apps/docs/public/og-default.png`
- [ ] After merge: paste a docs link into Discord, see rich unfurl
- [ ] After merge: submit `/sitemap.xml` to Google Search Console