### PR TITLE
docs(#103): API reference for @djs-commands/core (every public symbol)

### DIFF
--- a/apps/docs/content/pages/api-reference/core/command-handler.mdx
+++ b/apps/docs/content/pages/api-reference/core/command-handler.mdx
@@ -1,0 +1,101 @@
+---
+title: createCommandHandler
+description: Wire commands, validators, cooldowns, plugins, and storage into a discord.js client.
+---
+
+## `createCommandHandler(options)`
+
+```ts
+function createCommandHandler(options: CommandHandlerOptions): CommandHandler;
+```
+
+Subscribes the dispatcher to your discord.js `Client` and registers commands with Discord on `clientReady`. Returns a small handle for lifecycle management.
+
+```ts
+import { createCommandHandler } from "@djs-commands/core";
+import { Client, GatewayIntentBits } from "discord.js";
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+const handler = createCommandHandler({
+	client,
+	commands: [ping, help],
+	commandDir: "./src/commands",
+	storage: drizzleStorage(db),
+	cacheAdapter: redisCacheAdapter(redis),
+});
+
+await handler.ready;
+await client.login(process.env.DISCORD_TOKEN);
+```
+
+## `CommandHandlerOptions`
+
+```ts
+interface CommandHandlerOptions {
+	client: Client;
+	commands?: AnyCommand[];
+	commandDir?: string;
+	eventDir?: string;
+	dev?: boolean;
+	botOwners?: readonly string[];
+	validators?: readonly Validator[];
+	canRunCommand?: CanRunCommand;
+	plugins?: PluginManifest[];
+	cacheAdapter?: CacheAdapter;
+	legacy?: HandlerLegacyConfig;
+	storage?: Storage;
+}
+```
+
+| Field | Purpose |
+| --- | --- |
+| `client` | discord.js `Client` instance — required. |
+| `commands` | Inline list of commands to dispatch. |
+| `commandDir` | Directory to recursively load commands from. Default exports must look like `Command`s. |
+| `eventDir` | Directory to recursively load `EventDefinition`s from. |
+| `dev` | When `true` (or `NODE_ENV !== "production"`), the command dir is watched and edited files hot-reload. |
+| `botOwners` | IDs that pass the built-in `ownerOnly` check. |
+| `validators` | Global validators run on every command. |
+| `canRunCommand` | Slimmer single-callback gate — return `true` / `false` / a reason string. |
+| `plugins` | Plugin manifests merged at boot. |
+| `cacheAdapter` | TTL-native cache for cooldowns. Without it, cooldowns are in-memory. |
+| `legacy` | Master switch + default prefix for legacy invocation. |
+| `storage` | Persistence adapter for guild prefixes, disabled commands, channel locks, and your own models. |
+
+## `CommandHandler`
+
+```ts
+interface CommandHandler {
+	ready: Promise<void>;
+	destroy: () => Promise<void>;
+}
+```
+
+| Field | Notes |
+| --- | --- |
+| `ready` | Resolves once all plugin `setup` hooks complete. Rejects if any setup throws (the handler then doesn't attach listeners). |
+| `destroy` | Detaches all listeners, awaits each plugin's `teardown` in reverse-registration order, stops the fs watcher. Errors during teardown are logged but don't block other teardowns. Does **not** delete registered application commands from Discord. |
+
+```ts
+await handler.destroy();
+```
+
+## `HandlerLegacyConfig`
+
+```ts
+interface HandlerLegacyConfig {
+	enabled: boolean;
+	defaultPrefix: string;
+}
+```
+
+Master switch + fallback prefix for legacy mode. Per-guild prefix overrides come from the storage adapter (`guild_prefix` model — see [Storage](/api-reference/core/storage#guildprefix-helpers)).
+
+```ts
+createCommandHandler({
+	client,
+	commands: [...],
+	legacy: { enabled: true, defaultPrefix: "!" },
+});
+```

--- a/apps/docs/content/pages/api-reference/core/components-v2-functions.mdx
+++ b/apps/docs/content/pages/api-reference/core/components-v2-functions.mdx
@@ -1,0 +1,236 @@
+---
+title: Components V2 (function API)
+description: Function-form builders for Discord Components V2 — no JSX required.
+---
+
+The function API is a JSX-free way to build Components V2 messages. Every function returns a real discord.js builder, so the output is identical to [`@djs-commands/jsx`](/components-v2)'s `render()`. Mix the two freely.
+
+```ts
+import { actionRow, button, container, section, textDisplay } from "@djs-commands/core";
+
+const components = [
+	container({
+		accentColor: 0x5865f2,
+		children: [
+			textDisplay("# Welcome"),
+			section({
+				accessory: button({ style: "primary", customId: "next", label: "Next" }),
+				text: "Components V2 lets you compose rich messages from layout primitives.",
+			}),
+		],
+	}),
+];
+```
+
+## Display components
+
+### `container(options?)`
+
+```ts
+function container(options?: ContainerOptions): ContainerBuilder;
+
+interface ContainerOptions {
+	accentColor?: number | readonly [number, number, number];
+	spoiler?: boolean;
+	id?: number;
+	children?: readonly ContainerChild[];
+}
+
+type ContainerChild =
+	| TextDisplayBuilder
+	| SectionBuilder
+	| MediaGalleryBuilder
+	| SeparatorBuilder
+	| FileBuilder
+	| ActionRowBuilder<MessageActionRowComponentBuilder>;
+```
+
+Top-level layout primitive. Pass `accentColor` as a hex int or RGB tuple; optionally mark the container `spoiler`.
+
+### `section(options)`
+
+```ts
+function section(options: SectionOptions): SectionBuilder;
+
+interface SectionOptions {
+	text: string | readonly string[];
+	accessory: ButtonBuilder | ThumbnailBuilder;
+	id?: number;
+}
+```
+
+Text + accessory layout. The accessory renders to the right; pass a button or thumbnail.
+
+### `textDisplay(content, options?)`
+
+```ts
+function textDisplay(content: string, options?: { id?: number }): TextDisplayBuilder;
+```
+
+Markdown text. Supports headings, lists, links, code spans — anything Discord's V2 markdown allows.
+
+### `mediaGallery(options)`
+
+```ts
+function mediaGallery(options: MediaGalleryOptions): MediaGalleryBuilder;
+
+interface MediaGalleryOptions {
+	items: readonly APIMediaGalleryItem[];
+	id?: number;
+}
+```
+
+Image carousel. Each item is `{ media: { url }, description?, spoiler? }`.
+
+### `separator(options?)`
+
+```ts
+function separator(options?: SeparatorOptions): SeparatorBuilder;
+
+interface SeparatorOptions {
+	divider?: boolean;
+	spacing?: SeparatorSpacingSize;
+	id?: number;
+}
+```
+
+Visual divider between sections. `divider: true` draws a line; `spacing` controls vertical gap.
+
+### `file(options)`
+
+```ts
+function file(options: FileOptions): FileBuilder;
+
+interface FileOptions {
+	url: string;
+	spoiler?: boolean;
+	id?: number;
+}
+```
+
+Embed a file by URL.
+
+### `thumbnail(options)`
+
+```ts
+function thumbnail(options: ThumbnailOptions): ThumbnailBuilder;
+
+interface ThumbnailOptions {
+	url: string;
+	description?: string;
+	spoiler?: boolean;
+	id?: number;
+}
+```
+
+Small image used as a section accessory.
+
+## Form components
+
+### `button(options)`
+
+```ts
+function button(options: ButtonOptions): ButtonBuilder;
+
+type ButtonStyleName = "primary" | "secondary" | "success" | "danger" | "link" | "premium";
+
+type ButtonOptions =
+	| InteractiveButtonOptions   // primary / secondary / success / danger
+	| LinkButtonOptions          // link
+	| PremiumButtonOptions;      // premium
+```
+
+| Style | Required fields |
+| --- | --- |
+| `primary` / `secondary` / `success` / `danger` | `customId`, `label` (and/or `emoji`), optional `disabled` |
+| `link` | `url`, `label` (and/or `emoji`) |
+| `premium` | `skuId` |
+
+```ts
+button({ style: "primary", customId: "ok", label: "OK" });
+button({ style: "link", url: "https://example.com", label: "Docs" });
+```
+
+### `actionRow(options)`
+
+```ts
+function actionRow(options: ActionRowOptions): ActionRowBuilder<MessageActionRowComponentBuilder>;
+
+interface ActionRowOptions {
+	children: readonly MessageActionRowComponentBuilder[];
+	id?: number;
+}
+```
+
+Container for buttons (or string-select-menus from discord.js — same row constraints).
+
+### `modal(options)`
+
+```ts
+function modal(options: ModalOptions): ModalBuilder;
+
+interface ModalOptions {
+	customId: string;
+	title: string;
+	fields: readonly (LabelBuilder | TextInputBuilder)[];
+}
+```
+
+Top-level modal builder. Use with `interaction.showModal(modal(...))`.
+
+### `textInput(options)`
+
+```ts
+function textInput(options: TextInputOptions): TextInputBuilder;
+
+type TextInputStyleName = "short" | "paragraph";
+
+interface TextInputOptions {
+	customId: string;
+	label: string;
+	style?: TextInputStyleName;
+	placeholder?: string;
+	required?: boolean;
+	value?: string;
+	minLength?: number;
+	maxLength?: number;
+}
+```
+
+Single-line (`short`) or multi-line (`paragraph`) text input field.
+
+### `radioGroup(options)`
+
+```ts
+function radioGroup(options: RadioGroupOptions): LabelBuilder;
+
+interface RadioGroupOptions {
+	customId: string;
+	label: string;
+	required?: boolean;
+	options: readonly APIRadioGroupOption[];
+}
+```
+
+Single-choice modal field. Each option is `{ label, value, description?, emoji? }`.
+
+### `checkboxGroup(options)`
+
+```ts
+function checkboxGroup(options: CheckboxGroupOptions): LabelBuilder;
+
+interface CheckboxGroupOptions {
+	customId: string;
+	label: string;
+	required?: boolean;
+	minSelections?: number;
+	maxSelections?: number;
+	options: readonly APICheckboxGroupOption[];
+}
+```
+
+Multi-choice modal field with optional min/max selection bounds.
+
+## Re-exports for convenience
+
+The builder classes from discord.js (`ContainerBuilder`, `ButtonBuilder`, etc.) are not re-exported — import them from `discord.js` directly when you need them. The function API is purely additive on top.

--- a/apps/docs/content/pages/api-reference/core/context.mdx
+++ b/apps/docs/content/pages/api-reference/core/context.mdx
@@ -1,0 +1,61 @@
+---
+title: Context normalizers
+description: Build a CommandRunContext from raw discord.js objects.
+---
+
+The dispatcher uses these internally to turn an incoming `ChatInputCommandInteraction` or `Message` into the unified `CommandRunContext`. They're exported for tests, custom dispatchers, and bridge plugins.
+
+## `normalizeSlashContext(interaction, command, options?)`
+
+```ts
+function normalizeSlashContext<S extends CommandOptions>(
+	interaction: ChatInputCommandInteraction,
+	command: Command<S>,
+	options: ResolveOptions<S>,
+): SlashRunContext<S>;
+```
+
+Builds a `SlashRunContext` from a discord.js interaction.
+
+```ts
+import { extractOptions, normalizeSlashContext } from "@djs-commands/core";
+
+const opts = extractOptions(interaction, ping.options);
+const ctx = normalizeSlashContext(interaction, ping, opts);
+
+await ping.run(ctx);
+```
+
+`reply(...)` on the returned context delegates to `interaction.reply` / `interaction.followUp` as appropriate.
+
+## `normalizeLegacyContext(message, command, options)`
+
+```ts
+function normalizeLegacyContext<S extends CommandOptions>(
+	message: Message,
+	command: Command<S>,
+	options: ResolveOptions<S>,
+): LegacyRunContext<S>;
+```
+
+Builds a `LegacyRunContext` from a discord.js message.
+
+```ts
+import { normalizeLegacyContext, parseLegacyArgs } from "@djs-commands/core";
+
+const parsed = parseLegacyArgs(tokens, ping.options, message);
+if (!parsed.ok) return message.reply(parsed.error);
+
+const ctx = normalizeLegacyContext(message, ping, parsed.options);
+await ping.run(ctx);
+```
+
+`reply(...)` on the returned context delegates to `message.reply`.
+
+## When to use these directly
+
+- Writing unit tests that bypass the dispatcher.
+- Building a bridge plugin (e.g. forwarding from another transport into a `Command`).
+- Custom dispatch flows where you've decided to handle the gating logic yourself.
+
+For everyday command-handling, you don't need to touch these — `createCommandHandler` calls them for you.

--- a/apps/docs/content/pages/api-reference/core/cooldowns.mdx
+++ b/apps/docs/content/pages/api-reference/core/cooldowns.mdx
@@ -1,0 +1,94 @@
+---
+title: Cooldowns
+description: CooldownConfig, CooldownType, CooldownActor, and the CacheAdapter contract.
+---
+
+See [Concepts → Cooldowns](/concepts/cooldowns) for the narrative.
+
+## `CooldownConfig`
+
+```ts
+interface CooldownConfig {
+	type: CooldownType;
+	/** Duration in milliseconds */
+	duration: number;
+}
+```
+
+Attach to a command via the `cooldown` field.
+
+```ts
+defineCommand({
+	name: "vote",
+	description: "Vote on the current poll",
+	cooldown: { type: "perUser", duration: 30_000 },
+	run: async ({ reply }) => { await reply("voted"); },
+});
+```
+
+## `CooldownType`
+
+```ts
+type CooldownType = "perUser" | "perGuild" | "perUserPerGuild" | "global";
+```
+
+| Type | Key shape |
+| --- | --- |
+| `perUser` | `cd:<cmd>:user:<userId>` |
+| `perGuild` | `cd:<cmd>:guild:<guildId>` |
+| `perUserPerGuild` | `cd:<cmd>:user:<userId>:guild:<guildId>` |
+| `global` | `cd:<cmd>:global` |
+
+In DMs, `<guildId>` is the literal `"dm"` so `perGuild` and `perUserPerGuild` keys remain stable.
+
+## `CooldownActor`
+
+```ts
+interface CooldownActor {
+	userId: string;
+	guildId: string | null;
+}
+```
+
+Identifies a single rate-limit subject. The dispatcher derives this automatically; you only construct it yourself if you're using `CooldownEngine` directly to gate non-command flows.
+
+## `CacheAdapter`
+
+```ts
+interface CacheAdapter {
+	get(key: string): Promise<number | null>;
+	set(key: string, expiresAt: number, ttlMs: number): Promise<void>;
+	delete(key: string): Promise<void>;
+}
+```
+
+TTL-native KV contract for distributed cooldowns. `expiresAt` is an absolute UNIX millisecond timestamp; `ttlMs` is the same value as a TTL hint for stores that prefer it (Redis `PX`, Memcached, etc).
+
+`get` should return `null` when the key is missing or already expired. Backends that auto-expire keys (Redis with `PX`) and backends that don't (a SQL `cooldowns` table) both work — the engine cleans up expired entries on read for the latter.
+
+`@djs-commands/adapter-redis` implements this contract — see [Adapter Cookbook → Redis](/adapter-cookbook#redis-cache-adapter-not-storage).
+
+## `CooldownEngine`
+
+```ts
+class CooldownEngine {
+	constructor(cache?: CacheAdapter);
+	check(command: AnyCommand, actor: CooldownActor): Promise<number | null>;
+	start(command: AnyCommand, actor: CooldownActor): Promise<void>;
+}
+```
+
+Construct one yourself to gate non-command flows (autocomplete handlers, button clicks, modal submits) using the same shared cache.
+
+```ts
+import { CooldownEngine } from "@djs-commands/core";
+
+const engine = new CooldownEngine(redisCacheAdapter(redis));
+
+const remaining = await engine.check(myCommand, { userId, guildId });
+if (remaining !== null) {
+	// on cooldown — `remaining` ms left
+}
+
+await engine.start(myCommand, { userId, guildId });
+```

--- a/apps/docs/content/pages/api-reference/core/define-command.mdx
+++ b/apps/docs/content/pages/api-reference/core/define-command.mdx
@@ -1,0 +1,134 @@
+---
+title: defineCommand
+description: Command type, run context, and the identity helper for command definitions.
+---
+
+## `defineCommand(command)`
+
+```ts
+function defineCommand<S extends CommandOptions>(command: Command<S>): Command<S>;
+```
+
+Identity function — returns its argument unchanged. Exists purely for IDE autocomplete and structural validation; at runtime it's the same as the inline object.
+
+```ts
+import { defineCommand } from "@djs-commands/core";
+
+const ping = defineCommand({
+	name: "ping",
+	description: "Replies with pong",
+	run: async ({ reply }) => {
+		await reply("pong");
+	},
+});
+```
+
+## `Command<S>`
+
+```ts
+interface Command<S extends CommandOptions = Record<string, never>> {
+	name: string;
+	description: string;
+	options?: S;
+	run: CommandRun<S>;
+	ownerOnly?: boolean;
+	guildOnly?: boolean;
+	channels?: readonly string[];
+	permissions?: readonly PermissionsString[];
+	roles?: readonly string[];
+	validators?: readonly Validator[];
+	cooldown?: CooldownConfig;
+	legacy?: CommandLegacyConfig;
+}
+```
+
+The full shape of a command definition. See [Concepts → Commands](/concepts/commands) for what each field does.
+
+## `AnyCommand`
+
+```ts
+type AnyCommand = Command<any>;
+```
+
+Erased-generic alias — used in heterogeneous arrays and registries where the option schema varies between commands.
+
+## `CommandRun<S>`
+
+```ts
+type CommandRun<S extends CommandOptions = Record<string, never>> =
+	(ctx: CommandRunContext<S>) => void | Promise<void>;
+```
+
+The handler signature. Receives a [`CommandRunContext`](#commandruncontext).
+
+## `CommandRunContext<S>`
+
+```ts
+type CommandRunContext<S extends CommandOptions = Record<string, never>> =
+	| SlashRunContext<S>
+	| LegacyRunContext<S>;
+
+interface BaseRunContext<S> {
+	client: Client;
+	author: User;
+	guild: Guild | null;
+	member: GuildMember | null;
+	channel: TextBasedChannel | null;
+	channelId: string | null;
+	options: ResolveOptions<S>;
+	reply: (content: string | { content?: string; ephemeral?: boolean }) => Promise<unknown>;
+}
+```
+
+Discriminated union over invocation source.
+
+## `SlashRunContext<S>`
+
+```ts
+type SlashRunContext<S> = BaseRunContext<S> & {
+	type: "slash";
+	interaction: ChatInputCommandInteraction;
+};
+```
+
+The slash-command branch — `interaction` is the raw discord.js interaction.
+
+## `LegacyRunContext<S>`
+
+```ts
+type LegacyRunContext<S> = BaseRunContext<S> & {
+	type: "legacy";
+	message: Message;
+};
+```
+
+The legacy-prefix branch — `message` is the raw discord.js message.
+
+```ts
+run: async (ctx) => {
+	if (ctx.type === "slash") {
+		await ctx.interaction.deferReply({ ephemeral: true });
+	}
+	await ctx.reply("hi");
+}
+```
+
+## `CommandLegacyConfig`
+
+```ts
+interface CommandLegacyConfig {
+	enabled?: boolean;
+	aliases?: readonly string[];
+}
+```
+
+Per-command legacy-mode opt-in. `enabled` defaults to `true` when the handler-level legacy switch is on. `aliases` are alternative invocation names.
+
+```ts
+defineCommand({
+	name: "ping",
+	description: "Replies with pong",
+	legacy: { enabled: true, aliases: ["p", "pong"] },
+	run: async ({ reply }) => { await reply("pong"); },
+});
+```

--- a/apps/docs/content/pages/api-reference/core/events.mdx
+++ b/apps/docs/content/pages/api-reference/core/events.mdx
@@ -1,0 +1,61 @@
+---
+title: Events
+description: defineEvent and EventDefinition for typed discord.js event handlers.
+---
+
+## `defineEvent(definition)`
+
+```ts
+function defineEvent<E extends keyof ClientEvents>(
+	def: EventDefinition<E>,
+): EventDefinition<E>;
+```
+
+Identity helper — same role as `defineCommand`. Returns the argument unchanged but lets TypeScript infer the event payload.
+
+```ts
+import { defineEvent } from "@djs-commands/core";
+import { Events } from "discord.js";
+
+export default defineEvent({
+	event: Events.GuildMemberAdd,
+	handler: async (member) => {
+		// `member` is fully typed as GuildMember
+		await member.send("Welcome!");
+	},
+});
+```
+
+Drop event files into the `eventDir` you pass to `createCommandHandler` and they're auto-registered:
+
+```ts
+createCommandHandler({
+	client,
+	commands: [...],
+	eventDir: "./src/events",
+});
+```
+
+## `EventDefinition<E>`
+
+```ts
+interface EventDefinition<E extends keyof ClientEvents = keyof ClientEvents> {
+	event: E;
+	once?: boolean;
+	handler: (...args: ClientEvents[E]) => void | Promise<void>;
+}
+```
+
+| Field | Notes |
+| --- | --- |
+| `event` | A `keyof ClientEvents` — use the `Events.*` enum from discord.js for v15 readiness. |
+| `once` | When `true`, the handler is registered with `client.once` instead of `client.on`. |
+| `handler` | Called with whatever payload discord.js fires for the event — fully typed via `ClientEvents[E]`. |
+
+```ts
+defineEvent({
+	event: Events.ClientReady,
+	once: true,
+	handler: (c) => console.log(`Logged in as ${c.user.tag}`),
+});
+```

--- a/apps/docs/content/pages/api-reference/core/fs-loader.mdx
+++ b/apps/docs/content/pages/api-reference/core/fs-loader.mdx
@@ -1,0 +1,66 @@
+---
+title: fs-loader
+description: loadCommandsFromDir, loadEventsFromDir, watchCommandsDir.
+---
+
+The fs-loader walks a directory recursively, dynamically imports each file, and treats valid default exports as `Command`s or `EventDefinition`s. The `commandDir` / `eventDir` options on `createCommandHandler` use these functions internally; you can also call them directly if you need the loaded array.
+
+## `loadCommandsFromDir(dir)`
+
+```ts
+function loadCommandsFromDir(dir: string): Promise<AnyCommand[]>;
+```
+
+Walks `dir` recursively, imports each `.ts` / `.js` / `.mts` / `.mjs` file's default export, and returns the ones that look like `Command` objects (have `name`, `description`, and `run`).
+
+```ts
+import { loadCommandsFromDir } from "@djs-commands/core";
+
+const commands = await loadCommandsFromDir("./src/commands");
+// → AnyCommand[]
+```
+
+Files that fail to import or whose default export isn't command-shaped are logged and skipped — they don't abort the load.
+
+## `loadEventsFromDir(dir)`
+
+```ts
+function loadEventsFromDir(dir: string): Promise<EventDefinition[]>;
+```
+
+Same shape as `loadCommandsFromDir`, for event files (`{ event, handler }`).
+
+```ts
+import { loadEventsFromDir } from "@djs-commands/core";
+
+const events = await loadEventsFromDir("./src/events");
+```
+
+## `watchCommandsDir(dir, options)`
+
+```ts
+function watchCommandsDir(
+	dir: string,
+	options: { onCommandChange: (changed: { added: AnyCommand[]; removed: string[] }) => void },
+): { stop: () => void };
+```
+
+Hot-reloads commands on file changes. Returns a handle with `stop()` to detach the watcher.
+
+The handler uses this internally when `dev` is `true` (or `NODE_ENV !== "production"`). Use it directly if you want the same behavior outside of `createCommandHandler`.
+
+```ts
+import { watchCommandsDir } from "@djs-commands/core";
+
+const watcher = watchCommandsDir("./src/commands", {
+	onCommandChange: ({ added, removed }) => {
+		for (const c of added) console.log("loaded", c.name);
+		for (const name of removed) console.log("unloaded", name);
+	},
+});
+
+// later
+watcher.stop();
+```
+
+Renames are surfaced as `removed` followed by `added`. The watcher uses cache-busting `import` URLs (`?v=<timestamp>`) so re-imports pick up edits without restarting the process.

--- a/apps/docs/content/pages/api-reference/core/index.mdx
+++ b/apps/docs/content/pages/api-reference/core/index.mdx
@@ -1,0 +1,29 @@
+---
+title: Overview
+description: Reference for every public export of @djs-commands/core.
+---
+
+import { Cards, Card } from "fumadocs-ui/components/card";
+
+`@djs-commands/core` is the only required package — it ships the dispatcher, command definition, validators, cooldowns, plugins, storage contract, fs-autoloader, and the function-form Components V2 builders.
+
+```bash
+bun add @djs-commands/core discord.js
+```
+
+## Symbols by topic
+
+<Cards>
+	<Card title="defineCommand" href="/api-reference/core/define-command" description="Command, AnyCommand, CommandRunContext, SlashRunContext, LegacyRunContext, CommandRun, CommandLegacyConfig" />
+	<Card title="createCommandHandler" href="/api-reference/core/command-handler" description="CommandHandler, CommandHandlerOptions, HandlerLegacyConfig" />
+	<Card title="Options" href="/api-reference/core/options" description="Every CommandOption type, ResolveOption, ResolveOptions" />
+	<Card title="Validators" href="/api-reference/core/validators" description="Validator, ValidatorContext, ValidationResult, ValidatorSource, CanRunCommand" />
+	<Card title="Cooldowns" href="/api-reference/core/cooldowns" description="CooldownConfig, CooldownType, CooldownActor, CacheAdapter" />
+	<Card title="Plugins" href="/api-reference/core/plugins" description="PluginManifest, PluginSetupContext" />
+	<Card title="Storage" href="/api-reference/core/storage" description="Storage, StorageWhere, StorageFindOpts, runStorageConformance, framework models + helpers" />
+	<Card title="Events" href="/api-reference/core/events" description="defineEvent, EventDefinition" />
+	<Card title="fs-loader" href="/api-reference/core/fs-loader" description="loadCommandsFromDir, loadEventsFromDir, watchCommandsDir" />
+	<Card title="Legacy parser" href="/api-reference/core/legacy-parser" description="parseLegacyArgs, LegacyParseResult" />
+	<Card title="Context normalizers" href="/api-reference/core/context" description="normalizeSlashContext, normalizeLegacyContext" />
+	<Card title="Components V2 (functions)" href="/api-reference/core/components-v2-functions" description="container, section, button, modal, …" />
+</Cards>

--- a/apps/docs/content/pages/api-reference/core/legacy-parser.mdx
+++ b/apps/docs/content/pages/api-reference/core/legacy-parser.mdx
@@ -1,0 +1,57 @@
+---
+title: Legacy parser
+description: parseLegacyArgs and LegacyParseResult — turn a message into typed options.
+---
+
+The legacy parser converts `message.content` (already stripped of the prefix and command name) into a typed `options` object that matches a slash-command schema. The dispatcher uses it internally for legacy invocations; expose it directly only if you're rolling a custom prefix dispatcher.
+
+## `parseLegacyArgs(tokens, schema, message)`
+
+```ts
+function parseLegacyArgs<S extends CommandOptions>(
+	tokens: string[],
+	schema: S | undefined,
+	message: Message,
+): LegacyParseResult<S>;
+```
+
+| Argument | Notes |
+| --- | --- |
+| `tokens` | Whitespace-split arguments (the bot has already stripped the prefix and command name). |
+| `schema` | The command's `options` schema — same shape used in `defineCommand`. `undefined` produces an empty result. |
+| `message` | Used for resolving mentions (`<@id>`, `<#id>`, `<@&id>`) and for `attachment` options (which read `message.attachments.first()`). |
+
+```ts
+import { parseLegacyArgs } from "@djs-commands/core";
+
+const result = parseLegacyArgs(
+	["123456789012345678", "spam"],
+	{
+		target: { type: "user", description: "Who to ban", required: true },
+		reason: { type: "string", description: "Why" },
+	},
+	message,
+);
+
+if (result.ok) {
+	result.options.target;  // User
+	result.options.reason;  // "spam"
+}
+```
+
+### Special behavior
+
+- **Last-string-takes-rest.** If the last option in the schema is `string`, it consumes all remaining tokens joined by spaces. So `!echo hello world` works for `{ message: { type: "string" } }`.
+- **Attachments don't consume tokens.** They read `message.attachments.first()` and leave the cursor untouched.
+- **Mention forms accepted:** `<@id>`, `<@!id>`, `<#id>`, `<@&id>`, plus raw 17–20-digit IDs.
+- **Booleans accept** `true|yes|y|1|on` / `false|no|n|0|off` (case-insensitive).
+
+## `LegacyParseResult<S>`
+
+```ts
+type LegacyParseResult<S extends CommandOptions> =
+	| { ok: true; options: ResolveOptions<S> }
+	| { ok: false; error: string };
+```
+
+`error` is a short, user-facing string suitable for replying back to the message author.

--- a/apps/docs/content/pages/api-reference/core/meta.json
+++ b/apps/docs/content/pages/api-reference/core/meta.json
@@ -1,0 +1,19 @@
+{
+	"title": "@djs-commands/core",
+	"icon": "Package",
+	"pages": [
+		"index",
+		"define-command",
+		"command-handler",
+		"options",
+		"validators",
+		"cooldowns",
+		"plugins",
+		"storage",
+		"events",
+		"fs-loader",
+		"legacy-parser",
+		"context",
+		"components-v2-functions"
+	]
+}

--- a/apps/docs/content/pages/api-reference/core/options.mdx
+++ b/apps/docs/content/pages/api-reference/core/options.mdx
@@ -1,0 +1,177 @@
+---
+title: Options
+description: Typed slash-command options and the inferred ResolveOptions mapped type.
+---
+
+`CommandOptions` is the schema for `command.options`. Each field's runtime type is inferred via `ResolveOptions<S>` so your `run` handler is fully typed.
+
+```ts
+defineCommand({
+	name: "ban",
+	description: "Ban a user",
+	options: {
+		target: { type: "user", description: "Who to ban", required: true },
+		reason: { type: "string", description: "Why" },
+		days:   { type: "integer", description: "Days of messages to delete", choices: [0, 1, 7] as const },
+	},
+	run: async ({ options }) => {
+		options.target;  // User
+		options.reason;  // string | undefined
+		options.days;    // 0 | 1 | 7 | undefined
+	},
+});
+```
+
+## `CommandOptions`
+
+```ts
+type CommandOptions = Record<string, CommandOption>;
+```
+
+A record of `CommandOption`s keyed by option name.
+
+## `CommandOption`
+
+```ts
+type CommandOption =
+	| StringOption
+	| IntegerOption
+	| NumberOption
+	| BooleanOption
+	| UserOption
+	| ChannelOption
+	| RoleOption
+	| MentionableOption
+	| AttachmentOption;
+```
+
+Discriminated union over the nine supported option types.
+
+## `StringOption`
+
+```ts
+interface StringOption {
+	type: "string";
+	description: string;
+	required?: boolean;
+	choices?: readonly string[];
+}
+```
+
+Resolves to `string` (or one of `choices` as a literal union when present).
+
+## `IntegerOption`
+
+```ts
+interface IntegerOption {
+	type: "integer";
+	description: string;
+	required?: boolean;
+	choices?: readonly number[];
+}
+```
+
+Resolves to `number` (or a literal-number union when `choices` is given).
+
+## `NumberOption`
+
+```ts
+interface NumberOption {
+	type: "number";
+	description: string;
+	required?: boolean;
+}
+```
+
+Resolves to `number`. (Discord's "Number" option type — float-friendly.)
+
+## `BooleanOption`
+
+```ts
+interface BooleanOption {
+	type: "boolean";
+	description: string;
+	required?: boolean;
+}
+```
+
+Resolves to `boolean`.
+
+## `UserOption`
+
+```ts
+interface UserOption {
+	type: "user";
+	description: string;
+	required?: boolean;
+}
+```
+
+Resolves to `User`.
+
+## `ChannelOption`
+
+```ts
+interface ChannelOption {
+	type: "channel";
+	description: string;
+	required?: boolean;
+}
+```
+
+Resolves to `GuildBasedChannel`.
+
+## `RoleOption`
+
+```ts
+interface RoleOption {
+	type: "role";
+	description: string;
+	required?: boolean;
+}
+```
+
+Resolves to `Role`.
+
+## `MentionableOption`
+
+```ts
+interface MentionableOption {
+	type: "mentionable";
+	description: string;
+	required?: boolean;
+}
+```
+
+Resolves to `User | GuildMember | Role`.
+
+## `AttachmentOption`
+
+```ts
+interface AttachmentOption {
+	type: "attachment";
+	description: string;
+	required?: boolean;
+}
+```
+
+Resolves to `Attachment`. In legacy mode, this consumes `message.attachments.first()`.
+
+## `ResolveOption<O>`
+
+```ts
+type ResolveOption<O extends CommandOption> =
+	O extends { required: true } ? ResolveValue<O> : ResolveValue<O> | undefined;
+```
+
+Per-option mapped type — produces the runtime type for a single `CommandOption`. Adds `| undefined` for optional fields.
+
+## `ResolveOptions<S>`
+
+```ts
+type ResolveOptions<S extends CommandOptions> = {
+	[K in keyof S]: ResolveOption<S[K]>;
+};
+```
+
+Schema-wide mapped type — used by `CommandRunContext<S>`'s `options` field.

--- a/apps/docs/content/pages/api-reference/core/plugins.mdx
+++ b/apps/docs/content/pages/api-reference/core/plugins.mdx
@@ -1,0 +1,59 @@
+---
+title: Plugins
+description: PluginManifest and PluginSetupContext for cross-cutting hooks.
+---
+
+See [Concepts → Plugins](/concepts/plugins) for the narrative.
+
+## `PluginManifest`
+
+```ts
+interface PluginManifest {
+	name: string;
+	commands?: AnyCommand[];
+	setup?: (ctx: PluginSetupContext) => void | Promise<void>;
+	teardown?: () => void | Promise<void>;
+}
+```
+
+A plain object passed to `createCommandHandler`'s `plugins` array. Convention is to expose it as a factory function so consumers can configure it.
+
+```ts
+import type { PluginManifest } from "@djs-commands/core";
+
+export function loggingPlugin(opts: { level?: "info" | "debug" } = {}): PluginManifest {
+	return {
+		name: "logging",
+		setup({ client }) {
+			client.on("interactionCreate", (i) => {
+				if (i.isChatInputCommand()) {
+					console.log(`[${opts.level ?? "info"}]`, i.commandName, "by", i.user.tag);
+				}
+			});
+		},
+	};
+}
+```
+
+| Field | Notes |
+| --- | --- |
+| `name` | Human-readable identifier; surfaces in error messages. |
+| `commands` | Commands merged into the dispatcher at boot — same shape as the top-level `commands`. Duplicate names throw at boot. |
+| `setup` | Awaited at boot in registration order. **Throwing aborts handler boot** (`handler.ready` rejects). |
+| `teardown` | Awaited on `handler.destroy()` in reverse-registration order. Errors are logged but don't block other teardowns. |
+
+## `PluginSetupContext`
+
+```ts
+interface PluginSetupContext {
+	client: Client;
+}
+```
+
+Intentionally minimal. Plugins that need to expose state to commands typically:
+
+- Attach to the client as a property: `client.myState = ...`. Type via module augmentation.
+- Close over their own values and inject them into the commands they ship.
+- Use the `Storage` adapter for persistent state.
+
+Avoid module-scoped singletons in plugin code — that breaks tests that want to construct multiple handlers in the same process.

--- a/apps/docs/content/pages/api-reference/core/storage.mdx
+++ b/apps/docs/content/pages/api-reference/core/storage.mdx
@@ -1,0 +1,142 @@
+---
+title: Storage
+description: Storage CRUD interface, framework models, helpers, and the conformance suite.
+---
+
+See [Concepts → Storage](/concepts/storage) for the narrative.
+
+## `Storage`
+
+```ts
+interface Storage {
+	create<T>(model: string, data: T): Promise<T>;
+	findOne<T>(model: string, where: StorageWhere): Promise<T | null>;
+	findMany<T>(model: string, opts?: StorageFindOpts): Promise<T[]>;
+	update<T>(model: string, where: StorageWhere, data: Partial<T>): Promise<T>;
+	delete(model: string, where: StorageWhere): Promise<void>;
+	count(model: string, where?: StorageWhere): Promise<number>;
+}
+```
+
+Generic CRUD contract that adapters implement once and the framework consumes for every persistent feature. `create<T>` should return the persisted row (use `RETURNING` or re-fetch).
+
+## `StorageWhere`
+
+```ts
+type StorageWhere = Record<string, string | number | null>;
+```
+
+Equality-only filter. Implementations should treat `null` as `IS NULL` (or the document equivalent).
+
+## `StorageFindOpts`
+
+```ts
+interface StorageFindOpts {
+	where?: StorageWhere;
+	limit?: number;
+	offset?: number;
+	orderBy?: { field: string; direction: "asc" | "desc" };
+}
+```
+
+Pagination + ordering options for `findMany`.
+
+## `runStorageConformance(name, factory)`
+
+```ts
+function runStorageConformance(
+	name: string,
+	factory: () => Storage | Promise<Storage>,
+): void;
+```
+
+Shared test suite that exercises every CRUD path the framework relies on. Call from any `bun test` (or compatible) file:
+
+```ts
+import { runStorageConformance } from "@djs-commands/core";
+
+runStorageConformance("my-adapter", () => myStorageFactory());
+```
+
+Pass it and your adapter will work for every shipped feature, including upserts, partial updates, and find-with-options.
+
+## Framework models
+
+The framework reads/writes three built-in models. All adapters ship schemas for them out of the box.
+
+### `GuildPrefixModel` / `GuildPrefixRow`
+
+```ts
+const GuildPrefixModel = "guild_prefix";
+
+interface GuildPrefixRow {
+	guild_id: string;
+	prefix: string;
+}
+```
+
+### `DisabledCommandsModel` / `DisabledCommandRow`
+
+```ts
+const DisabledCommandsModel = "disabled_commands";
+
+interface DisabledCommandRow {
+	guild_id: string;
+	command_name: string;
+}
+```
+
+### `ChannelLocksModel` / `ChannelLockRow`
+
+```ts
+const ChannelLocksModel = "channel_locks";
+
+interface ChannelLockRow {
+	guild_id: string;
+	command_name: string;
+	channel_id: string;
+}
+```
+
+## GuildPrefix helpers
+
+```ts
+function getGuildPrefix(storage: Storage, guildId: string): Promise<string | null>;
+function setGuildPrefix(storage: Storage, guildId: string, prefix: string): Promise<void>;
+function clearGuildPrefix(storage: Storage, guildId: string): Promise<void>;
+```
+
+Read / upsert / delete a guild's prefix override.
+
+```ts
+import { getGuildPrefix, setGuildPrefix } from "@djs-commands/core";
+
+const prefix = (await getGuildPrefix(storage, guildId)) ?? "!";
+await setGuildPrefix(storage, guildId, "?");
+```
+
+## DisabledCommands helpers
+
+```ts
+function isCommandDisabled(storage: Storage, guildId: string, commandName: string): Promise<boolean>;
+function disableCommand(storage: Storage, guildId: string, commandName: string): Promise<void>;
+function enableCommand(storage: Storage, guildId: string, commandName: string): Promise<void>;
+```
+
+The dispatcher consults `isCommandDisabled` automatically — you don't wire it into your validators.
+
+## ChannelLocks helpers
+
+```ts
+function getChannelLocks(storage: Storage, guildId: string, commandName: string): Promise<string[]>;
+function lockCommandToChannel(storage: Storage, guildId: string, commandName: string, channelId: string): Promise<void>;
+function unlockCommandFromChannel(storage: Storage, guildId: string, commandName: string, channelId: string): Promise<void>;
+```
+
+Empty list = no restriction. Non-empty = command runs only in those channels for that guild.
+
+```ts
+import { lockCommandToChannel } from "@djs-commands/core";
+
+await lockCommandToChannel(storage, guildId, "music-play", musicChannelId);
+```

--- a/apps/docs/content/pages/api-reference/core/validators.mdx
+++ b/apps/docs/content/pages/api-reference/core/validators.mdx
@@ -1,0 +1,93 @@
+---
+title: Validators
+description: Pre-handler gate types — Validator, ValidatorContext, ValidationResult, CanRunCommand.
+---
+
+See [Concepts → Validators](/concepts/validators) for the narrative.
+
+## `Validator`
+
+```ts
+type Validator =
+	(ctx: ValidatorContext) => ValidationResult | Promise<ValidationResult>;
+```
+
+A predicate that runs before `command.run`. Returning `{ ok: false }` short-circuits the dispatch.
+
+```ts
+import type { Validator } from "@djs-commands/core";
+
+const inVoiceChannel: Validator = async ({ member }) => {
+	if (member?.voice.channel) return { ok: true };
+	return { ok: false, reason: "Join a voice channel first." };
+};
+```
+
+## `ValidatorContext`
+
+```ts
+interface ValidatorContext {
+	command: AnyCommand;
+	botOwners: readonly string[];
+	user: User;
+	guild: Guild | null;
+	member: GuildMember | null;
+	channelId: string;
+	source: ValidatorSource;
+}
+```
+
+Unified shape across slash and legacy invocations. Most validators don't need to look at `source`; narrow on `source.type` only when the check needs the raw interaction or message.
+
+## `ValidatorSource`
+
+```ts
+type ValidatorSource =
+	| { type: "slash"; interaction: ChatInputCommandInteraction }
+	| { type: "legacy"; message: Message };
+```
+
+Discriminated reference to the original event payload.
+
+## `ValidationResult`
+
+```ts
+type ValidationResult = { ok: true } | { ok: false; reason: string };
+```
+
+`reason` is shown to the user as the rejection text. Keep it short and actionable.
+
+## `CanRunCommand`
+
+```ts
+type CanRunCommand =
+	(ctx: ValidatorContext) => boolean | string | Promise<boolean | string>;
+```
+
+Slimmer single-callback gate, passed to `createCommandHandler` as the `canRunCommand` option:
+
+- Return `true` → allow.
+- Return `false` → reject with the default reason.
+- Return a string → reject with that reason.
+
+```ts
+createCommandHandler({
+	client,
+	commands: [...],
+	canRunCommand: ({ command, user }) => {
+		if (command.name === "admin" && !admins.has(user.id)) return "Admins only.";
+		return true;
+	},
+});
+```
+
+## Order of evaluation
+
+The dispatcher runs validators in this order — first failure wins:
+
+1. Built-ins (`ownerOnly` → `guildOnly` → `channels` → `permissions` → `roles`)
+2. Handler-level `validators`
+3. Command-level `validators`
+4. Handler-level `canRunCommand`
+
+Cooldowns are checked **after** all validators pass. A failing validator never starts a cooldown.

--- a/apps/docs/content/pages/api-reference/index.mdx
+++ b/apps/docs/content/pages/api-reference/index.mdx
@@ -1,158 +1,24 @@
 ---
 title: API Reference
-description: Public surface area of the @djs-commands/* packages.
+description: Public surface area of every @djs-commands/* package, symbol by symbol.
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";
 
-This page lists every public symbol the framework exports. Each link jumps to the concept page that explains it in context — start there for examples and trade-offs.
+The reference docs cover **every public export** from every published package, with TypeScript signatures and a one-shot example for each. If you're new, start with [Concepts](/concepts) for the narrative.
 
 <Cards>
-	<Card title="Concepts" href="/concepts" description="The narrative documentation. Start here if you're new." />
-	<Card title="Components V2" href="/components-v2" description="Full JSX + function reference for the layout/form primitives." />
-	<Card title="Adapter Cookbook" href="/adapter-cookbook" description="Soup-to-nuts guides for each first-party adapter." />
+	<Card title="@djs-commands/core" href="/api-reference/core" description="Dispatcher, defineCommand, validators, cooldowns, plugins, storage, fs-autoloader, components-v2 functions" />
 </Cards>
 
-## `@djs-commands/core`
+## Companion-package references
 
-### Commands
+JSX runtime and storage adapters each ship from their own packages. Their reference pages live alongside their concept walk-throughs:
 
-| Export | Kind | Page |
-| --- | --- | --- |
-| `defineCommand` | function | [Commands](/concepts/commands#definecommand) |
-| `Command` | type | [Commands](/concepts/commands#definecommand) |
-| `AnyCommand` | type | [Commands](/concepts/commands#definecommand) |
-| `CommandRunContext` | type | [Commands](/concepts/commands#commandruncontext) |
-| `SlashRunContext` | type | [Commands](/concepts/commands#commandruncontext) |
-| `LegacyRunContext` | type | [Commands](/concepts/commands#commandruncontext) |
-| `CommandRun` | type | [Commands](/concepts/commands#commandruncontext) |
-| `CommandLegacyConfig` | type | [Commands](/concepts/commands) |
+- **[`@djs-commands/jsx`](/components-v2)** — JSX runtime + Components V2 component set.
+- **[`@djs-commands/adapter-drizzle`](/adapter-cookbook#drizzle-postgres)** — Drizzle/Postgres `Storage`.
+- **[`@djs-commands/adapter-prisma`](/adapter-cookbook#prisma)** — Prisma `Storage`.
+- **[`@djs-commands/adapter-mongoose`](/adapter-cookbook#mongoose-mongodb)** — Mongoose `Storage`.
+- **[`@djs-commands/adapter-redis`](/adapter-cookbook#redis-cache-adapter-not-storage)** — Redis `CacheAdapter` for distributed cooldowns.
 
-### Options
-
-| Export | Kind | Page |
-| --- | --- | --- |
-| `CommandOption` / `CommandOptions` | type | [Commands → Options](/concepts/commands#options) |
-| `StringOption`, `IntegerOption`, `NumberOption`, `BooleanOption`, `UserOption`, `ChannelOption`, `RoleOption`, `MentionableOption`, `AttachmentOption` | type | [Commands → Options](/concepts/commands#options) |
-| `ResolveOption` / `ResolveOptions` | type | [Commands → Options](/concepts/commands#options) |
-
-### Handler
-
-| Export | Kind | Page |
-| --- | --- | --- |
-| `createCommandHandler` | function | [Commands → Registering](/concepts/commands#registering-commands) |
-| `CommandHandler` | type | [Commands](/concepts/commands#registering-commands) |
-| `CommandHandlerOptions` | type | [Commands](/concepts/commands#registering-commands) |
-| `HandlerLegacyConfig` | type | [Commands](/concepts/commands) |
-
-### Validators
-
-| Export | Kind | Page |
-| --- | --- | --- |
-| `Validator` | type | [Validators](/concepts/validators#custom-validators) |
-| `ValidatorContext` | type | [Validators](/concepts/validators#validatorcontext) |
-| `ValidationResult` | type | [Validators](/concepts/validators#validationresult) |
-| `ValidatorSource` | type | [Validators](/concepts/validators#validatorcontext) |
-| `CanRunCommand` | type | [Validators](/concepts/validators#canruncommand-shorthand) |
-
-### Cooldowns
-
-| Export | Kind | Page |
-| --- | --- | --- |
-| `CooldownConfig` | type | [Cooldowns](/concepts/cooldowns#configuring-a-cooldown) |
-| `CooldownType` | type | [Cooldowns → Types](/concepts/cooldowns#cooldown-types) |
-| `CooldownActor` | type | [Cooldowns](/concepts/cooldowns#cooldownengine-directly) |
-| `CacheAdapter` | type | [Cooldowns](/concepts/cooldowns#writing-a-custom-cacheadapter) |
-
-### Plugins
-
-| Export | Kind | Page |
-| --- | --- | --- |
-| `PluginManifest` | type | [Plugins](/concepts/plugins#plugin-manifest) |
-| `PluginSetupContext` | type | [Plugins](/concepts/plugins#manifest-fields) |
-
-### Storage
-
-| Export | Kind | Page |
-| --- | --- | --- |
-| `Storage` | type | [Storage](/concepts/storage#the-storage-interface) |
-| `StorageWhere` / `StorageFindOpts` | type | [Storage](/concepts/storage#the-storage-interface) |
-| `runStorageConformance` | function | [Storage → Custom adapter](/concepts/storage#writing-a-custom-adapter) |
-| `GuildPrefixModel` / `GuildPrefixRow` | const / type | [Storage → Helpers](/concepts/storage#guild-prefix) |
-| `getGuildPrefix` / `setGuildPrefix` / `clearGuildPrefix` | function | [Storage → Helpers](/concepts/storage#guild-prefix) |
-| `DisabledCommandsModel` / `DisabledCommandRow` | const / type | [Storage → Helpers](/concepts/storage#disabled-commands) |
-| `isCommandDisabled` / `disableCommand` / `enableCommand` | function | [Storage → Helpers](/concepts/storage#disabled-commands) |
-| `ChannelLocksModel` / `ChannelLockRow` | const / type | [Storage → Helpers](/concepts/storage#channel-locks) |
-| `getChannelLocks` / `lockCommandToChannel` / `unlockCommandFromChannel` | function | [Storage → Helpers](/concepts/storage#channel-locks) |
-
-### Filesystem loader
-
-| Export | Kind | Page |
-| --- | --- | --- |
-| `loadCommandsFromDir` | function | [Commands → Loading](/concepts/commands#loading-commands-from-a-directory) |
-| `loadEventsFromDir` | function | [Commands → Loading](/concepts/commands#loading-commands-from-a-directory) |
-| `watchCommandsDir` | function | [Commands → Loading](/concepts/commands#loading-commands-from-a-directory) |
-
-### Events
-
-| Export | Kind | Description |
-| --- | --- | --- |
-| `defineEvent` | function | Define a discord.js event handler with full type-safety. |
-| `EventDefinition` | type | The shape `defineEvent` returns. |
-
-### Components V2 (function API)
-
-| Export | Returns |
-| --- | --- |
-| `container` | `ContainerBuilder` |
-| `section` | `SectionBuilder` |
-| `textDisplay` | `TextDisplayBuilder` |
-| `mediaGallery` | `MediaGalleryBuilder` |
-| `separator` | `SeparatorBuilder` |
-| `file` | `FileBuilder` |
-| `thumbnail` | `ThumbnailBuilder` |
-| `button` | `ButtonBuilder` |
-| `actionRow` | `ActionRowBuilder` |
-| `modal` | `ModalBuilder` |
-| `textInput` | `TextInputBuilder` |
-| `radioGroup` / `checkboxGroup` | `LabelBuilder` |
-
-Each takes an `*Options` object — see [Components V2](/components-v2) for full signatures and examples.
-
-### Legacy parser
-
-| Export | Description |
-| --- | --- |
-| `parseLegacyArgs` | Parse a legacy message into a typed argument object using a command's `options` schema. |
-| `LegacyParseResult` | Discriminated union of `{ ok: true; values }` / `{ ok: false; reason }`. |
-
-### Context normalizers
-
-| Export | Description |
-| --- | --- |
-| `normalizeSlashContext` | Build a `SlashRunContext` from a discord.js interaction. |
-| `normalizeLegacyContext` | Build a `LegacyRunContext` from a discord.js message. |
-
-## `@djs-commands/jsx`
-
-| Export | Kind | Description |
-| --- | --- | --- |
-| `render` | function | Compile a JSX tree into discord.js component builders. |
-| `renderModal` | function | Compile a `<Modal>` JSX tree into a `ModalBuilder`. |
-| `Container`, `Section`, `TextDisplay`, `MediaGallery`, `Separator`, `File`, `Thumbnail` | component | Display primitives. |
-| `ActionRow`, `Button`, `TextInput`, `RadioGroup`, `CheckboxGroup`, `Modal` | component | Form primitives. |
-| `Fragment` | component | Group children without nesting. |
-| `*Props`, `ButtonStyleName`, `TextInputStyleName`, `DjsxNode` | type | TypeScript helpers. |
-
-JSX runtime entry points: `@djs-commands/jsx/jsx-runtime` and `@djs-commands/jsx/jsx-dev-runtime` — set `jsxImportSource: "@djs-commands/jsx"` in your tsconfig.
-
-## Adapters
-
-| Package | Factory | Notes |
-| --- | --- | --- |
-| `@djs-commands/adapter-drizzle` | `drizzleStorage(db, options?)` | Postgres via Drizzle. Schema exported from `./schema`. |
-| `@djs-commands/adapter-prisma` | `prismaStorage(prisma, options?)` | Generic Prisma client; ships schema fragments to copy in. |
-| `@djs-commands/adapter-mongoose` | `mongooseStorage(connection, options?)` | Auto-creates Mongoose models if you don't pass your own. |
-| `@djs-commands/adapter-redis` | `redisCacheAdapter(redis, options?)` | TTL-native `CacheAdapter` for distributed cooldowns. |
-
-See [Adapter Cookbook](/adapter-cookbook) for a walk-through per adapter.
+Standalone reference sections for these are tracked in [issue #104](https://github.com/D3OXY/djs-commands/issues/104).

--- a/apps/docs/content/pages/api-reference/meta.json
+++ b/apps/docs/content/pages/api-reference/meta.json
@@ -1,5 +1,5 @@
 {
 	"title": "API Reference",
 	"icon": "Code",
-	"pages": ["index"]
+	"pages": ["index", "core"]
 }


### PR DESCRIPTION
Closes #103.

## What

12 new sub-pages under `apps/docs/content/pages/api-reference/core/`. Every named export from `packages/core/src/index.ts` is documented with its TypeScript signature plus a one-shot usage example, grouped by topic:

| Page | Symbols |
|---|---|
| `define-command` | `Command`, `AnyCommand`, `CommandRunContext`, `SlashRunContext`, `LegacyRunContext`, `CommandRun`, `CommandLegacyConfig` |
| `command-handler` | `createCommandHandler`, `CommandHandler`, `CommandHandlerOptions`, `HandlerLegacyConfig` |
| `options` | All 9 `*Option` types, `ResolveOption`, `ResolveOptions` |
| `validators` | `Validator`, `ValidatorContext`, `ValidationResult`, `ValidatorSource`, `CanRunCommand` |
| `cooldowns` | `CooldownConfig`, `CooldownType`, `CooldownActor`, `CacheAdapter`, `CooldownEngine` |
| `plugins` | `PluginManifest`, `PluginSetupContext` |
| `storage` | `Storage`, `StorageWhere`, `StorageFindOpts`, `runStorageConformance`, framework models + 9 helpers |
| `events` | `defineEvent`, `EventDefinition` |
| `fs-loader` | `loadCommandsFromDir`, `loadEventsFromDir`, `watchCommandsDir` |
| `legacy-parser` | `parseLegacyArgs`, `LegacyParseResult` |
| `context` | `normalizeSlashContext`, `normalizeLegacyContext` |
| `components-v2-functions` | `container`, `section`, `textDisplay`, `mediaGallery`, `separator`, `file`, `thumbnail`, `button`, `actionRow`, `modal`, `textInput`, `radioGroup`, `checkboxGroup` + every `*Options` type |

`api-reference/index.mdx` was rewritten as a clean landing that points at the new `core` section and briefly links the upcoming jsx + adapter ref pages (tracked in #104).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run check` clean
- [x] `bun run build:docs` clean
- [ ] After merge: spot-check the new sidebar group is surfacing all 12 sub-pages with the new lucide icons (depends on #107)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API reference documentation for the @djs-commands/core package, including guides for command definitions, handlers, options, validators, cooldowns, plugins, storage adapters, event registration, legacy parsing, and Components V2 function API with TypeScript signatures and practical usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->