### PR TITLE
docs(#104): API reference for @djs-commands/jsx + 4 adapters

### DIFF
--- a/apps/docs/content/pages/api-reference/adapters/drizzle.mdx
+++ b/apps/docs/content/pages/api-reference/adapters/drizzle.mdx
@@ -1,0 +1,89 @@
+---
+title: adapter-drizzle
+description: Drizzle/Postgres Storage adapter — drizzleStorage and schema exports.
+---
+
+```bash
+bun add @djs-commands/core @djs-commands/adapter-drizzle drizzle-orm pg
+```
+
+For setup (migrations, drizzle.config, etc.) see [Adapter Cookbook → Drizzle](/adapter-cookbook#drizzle-postgres).
+
+## `drizzleStorage(db, options?)`
+
+```ts
+function drizzleStorage(
+	db: NodePgDatabase,
+	options?: DrizzleStorageOptions,
+): Storage;
+```
+
+Returns a [`Storage`](/api-reference/core/storage) implementation backed by Drizzle. Pass to `createCommandHandler` as `storage`.
+
+```ts
+import { drizzleStorage } from "@djs-commands/adapter-drizzle";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const db = drizzle(pool);
+
+createCommandHandler({
+	client,
+	commands: [...],
+	storage: drizzleStorage(db),
+});
+```
+
+The dispatcher reads/writes `guild_prefix`, `disabled_commands`, and `channel_locks` automatically — you don't write any code for the framework models, just make sure the tables exist.
+
+## `DrizzleStorageOptions`
+
+```ts
+interface DrizzleStorageOptions {
+	tables?: Partial<{
+		guildPrefix: typeof guildPrefix;
+		disabledCommands: typeof disabledCommands;
+		channelLocks: typeof channelLocks;
+	}>;
+}
+```
+
+Override one or more table objects (rename columns, add fields, share with your app's schema):
+
+```ts
+import { drizzleStorage } from "@djs-commands/adapter-drizzle";
+import { myGuildPrefixTable } from "./schema";
+
+drizzleStorage(db, {
+	tables: { guildPrefix: myGuildPrefixTable },
+});
+```
+
+## Schema exports
+
+```ts
+import {
+	guildPrefix,
+	disabledCommands,
+	channelLocks,
+} from "@djs-commands/adapter-drizzle/schema";
+```
+
+The three built-in Drizzle table objects. Re-export from your own schema file so `drizzle-kit` picks them up:
+
+```ts title="src/db/schema.ts"
+export { channelLocks, disabledCommands, guildPrefix } from "@djs-commands/adapter-drizzle/schema";
+```
+
+## Row types
+
+```ts
+import type {
+	GuildPrefixRow,
+	DisabledCommandRow,
+	ChannelLockRow,
+} from "@djs-commands/adapter-drizzle";
+```
+
+Re-exports of the framework's row types — same shapes used by [Storage helpers](/api-reference/core/storage#guildprefix-helpers) like `getGuildPrefix`.

--- a/apps/docs/content/pages/api-reference/adapters/index.mdx
+++ b/apps/docs/content/pages/api-reference/adapters/index.mdx
@@ -1,0 +1,17 @@
+---
+title: Overview
+description: Storage and cache adapters for djs-commands — bring your own DB.
+---
+
+import { Cards, Card } from "fumadocs-ui/components/card";
+
+Each adapter implements the same `Storage` (or `CacheAdapter`) contract from [`@djs-commands/core`](/api-reference/core/storage). The framework's three built-in models — guild prefixes, disabled commands, channel locks — work transparently across all of them; pick whichever fits your stack.
+
+For end-to-end setup walk-throughs (migrations, schema configuration, environment variables), see the [Adapter Cookbook](/adapter-cookbook).
+
+<Cards>
+	<Card title="@djs-commands/adapter-drizzle" href="/api-reference/adapters/drizzle" description="Postgres via Drizzle. drizzleStorage(db, options?)." />
+	<Card title="@djs-commands/adapter-prisma" href="/api-reference/adapters/prisma" description="Generic Prisma client. prismaStorage(prisma, options?)." />
+	<Card title="@djs-commands/adapter-mongoose" href="/api-reference/adapters/mongoose" description="MongoDB via Mongoose. mongooseStorage(connection, options?)." />
+	<Card title="@djs-commands/adapter-redis" href="/api-reference/adapters/redis" description="TTL-native CacheAdapter for distributed cooldowns. redisCacheAdapter(redis, options?)." />
+</Cards>

--- a/apps/docs/content/pages/api-reference/adapters/meta.json
+++ b/apps/docs/content/pages/api-reference/adapters/meta.json
@@ -1,0 +1,5 @@
+{
+	"title": "Adapters",
+	"icon": "Plug",
+	"pages": ["index", "drizzle", "prisma", "mongoose", "redis"]
+}

--- a/apps/docs/content/pages/api-reference/adapters/mongoose.mdx
+++ b/apps/docs/content/pages/api-reference/adapters/mongoose.mdx
@@ -1,0 +1,92 @@
+---
+title: adapter-mongoose
+description: Mongoose/MongoDB Storage adapter — the v1 continuity path.
+---
+
+```bash
+bun add @djs-commands/core @djs-commands/adapter-mongoose mongoose
+```
+
+For setup walk-through see [Adapter Cookbook → Mongoose](/adapter-cookbook#mongoose-mongodb). This is the continuity path for v1 (`@d3oxy/djs-commands`) users — v1 was Mongo-first.
+
+## `mongooseStorage(connection, options?)`
+
+```ts
+function mongooseStorage(
+	connection: mongoose.Connection,
+	options?: MongooseStorageOptions,
+): Storage;
+```
+
+Returns a [`Storage`](/api-reference/core/storage) backed by Mongoose. Pass a `Connection` (not `mongoose` itself) so the adapter can register models on it.
+
+```ts
+import mongoose from "mongoose";
+import { mongooseStorage } from "@djs-commands/adapter-mongoose";
+
+const connection = mongoose.createConnection(process.env.MONGO_URL!);
+await connection.asPromise();
+
+createCommandHandler({
+	client,
+	commands: [...],
+	storage: mongooseStorage(connection),
+});
+```
+
+The adapter lazy-creates the framework models on the connection the first time each is needed. Mongoose caches models by name on the connection, so re-instantiating the storage with the same connection is cheap.
+
+## `MongooseStorageOptions`
+
+```ts
+interface MongooseStorageOptions {
+	models?: {
+		guildPrefix?: Model<GuildPrefixDoc>;
+		disabledCommand?: Model<DisabledCommandDoc>;
+		channelLock?: Model<ChannelLockDoc>;
+	};
+}
+```
+
+If you've already registered compatible models on the connection (e.g. to share with other code), pass them explicitly:
+
+```ts
+import {
+	createGuildPrefixModel,
+	mongooseStorage,
+} from "@djs-commands/adapter-mongoose";
+
+const guildPrefix = createGuildPrefixModel(connection);
+
+mongooseStorage(connection, {
+	models: { guildPrefix },
+});
+```
+
+## Model factories
+
+```ts
+function createGuildPrefixModel(connection: Connection, name?: string): Model<GuildPrefixDoc>;
+function createDisabledCommandModel(connection: Connection, name?: string): Model<DisabledCommandDoc>;
+function createChannelLockModel(connection: Connection, name?: string): Model<ChannelLockDoc>;
+```
+
+Construct the framework's models on a connection. `name` is optional and overrides the default model name (useful if you need multiple instances). Each factory deduplicates — calling it twice on the same connection returns the cached model.
+
+```ts
+import { createGuildPrefixModel } from "@djs-commands/adapter-mongoose";
+
+const guildPrefix = createGuildPrefixModel(connection);
+```
+
+## Doc types
+
+```ts
+import type {
+	GuildPrefixDoc,
+	DisabledCommandDoc,
+	ChannelLockDoc,
+} from "@djs-commands/adapter-mongoose";
+```
+
+Plain interfaces matching the framework row shapes — useful when typing custom Mongoose schemas.

--- a/apps/docs/content/pages/api-reference/adapters/prisma.mdx
+++ b/apps/docs/content/pages/api-reference/adapters/prisma.mdx
@@ -1,0 +1,86 @@
+---
+title: adapter-prisma
+description: Prisma Storage adapter — prismaStorage, options, schema fragments.
+---
+
+```bash
+bun add @djs-commands/core @djs-commands/adapter-prisma @prisma/client
+bun add -d prisma
+```
+
+For setup (schema model copies, migrations) see [Adapter Cookbook → Prisma](/adapter-cookbook#prisma).
+
+## `prismaStorage(prisma, options?)`
+
+```ts
+function prismaStorage(
+	prisma: PrismaClientLike,
+	options?: PrismaStorageOptions,
+): Storage;
+```
+
+Returns a [`Storage`](/api-reference/core/storage) backed by a Prisma Client.
+
+```ts
+import { prismaStorage } from "@djs-commands/adapter-prisma";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+createCommandHandler({
+	client,
+	commands: [...],
+	storage: prismaStorage(prisma),
+});
+```
+
+## `PrismaClientLike`
+
+```ts
+type PrismaClientLike = Record<string, unknown>;
+```
+
+Intentionally loose typing so the package doesn't require `@prisma/client` as a hard dependency. The adapter accesses delegates by name (`prisma.guildPrefix.findUnique(...)` etc.).
+
+## `PrismaStorageOptions`
+
+```ts
+interface PrismaStorageOptions {
+	delegates?: Partial<{
+		guildPrefix: unknown;
+		disabledCommands: unknown;
+		channelLocks: unknown;
+	}>;
+}
+```
+
+If you renamed the framework models in your schema, pass the delegates explicitly:
+
+```ts
+prismaStorage(prisma, {
+	delegates: { guildPrefix: prisma.myCustomGuildPrefix },
+});
+```
+
+## Schema fragment exports
+
+```ts
+import {
+	GUILD_PREFIX_PRISMA_MODEL,
+	DISABLED_COMMANDS_PRISMA_MODEL,
+	CHANNEL_LOCKS_PRISMA_MODEL,
+} from "@djs-commands/adapter-prisma";
+```
+
+Each is a multi-line `string` containing the Prisma DSL for that model. Use them programmatically (e.g. for codegen / docs); for everyday use, copy the model definitions into your `schema.prisma` directly:
+
+```prisma
+model GuildPrefix {
+	guildId String @id @map("guild_id")
+	prefix  String
+
+	@@map("guild_prefix")
+}
+```
+
+(See the cookbook for the full set.)

--- a/apps/docs/content/pages/api-reference/adapters/redis.mdx
+++ b/apps/docs/content/pages/api-reference/adapters/redis.mdx
@@ -1,0 +1,64 @@
+---
+title: adapter-redis
+description: Redis-backed CacheAdapter for distributed cooldowns.
+---
+
+```bash
+bun add @djs-commands/core @djs-commands/adapter-redis ioredis
+```
+
+The Redis adapter is **not** a `Storage` — it's a [`CacheAdapter`](/api-reference/core/cooldowns#cacheadapter) for cooldowns. Use it alongside one of the storage adapters.
+
+For setup walk-through see [Adapter Cookbook → Redis](/adapter-cookbook#redis-cache-adapter-not-storage).
+
+## `redisCacheAdapter(redis, options?)`
+
+```ts
+function redisCacheAdapter(
+	redis: Redis,
+	options?: RedisCacheAdapterOptions,
+): CacheAdapter;
+```
+
+Returns a `CacheAdapter` backed by an `ioredis` client. Pass to `createCommandHandler` as `cacheAdapter`.
+
+```ts
+import { redisCacheAdapter } from "@djs-commands/adapter-redis";
+import Redis from "ioredis";
+
+const redis = new Redis(process.env.REDIS_URL!);
+
+createCommandHandler({
+	client,
+	commands: [...],
+	cacheAdapter: redisCacheAdapter(redis),
+});
+```
+
+The adapter writes with `SET key value PX <ttl>` so Redis handles expiry server-side and you never accumulate dead keys.
+
+## `RedisCacheAdapterOptions`
+
+```ts
+interface RedisCacheAdapterOptions {
+	keyPrefix?: string;  // default: "djs-commands:"
+}
+```
+
+| Field | Notes |
+| --- | --- |
+| `keyPrefix` | Prepended to every key the adapter reads or writes. Use to isolate multiple bots sharing one Redis. Default `"djs-commands:"`. |
+
+```ts
+redisCacheAdapter(redis, { keyPrefix: "moderation-bot:" });
+```
+
+## Redis commands used
+
+| `CacheAdapter` method | Redis command |
+| --- | --- |
+| `set` | `SET <prefix><key> <expiresAt> PX <ttlMs>` |
+| `get` | `GET <prefix><key>` then parse to number |
+| `delete` | `DEL <prefix><key>` |
+
+`get` returns `null` for missing keys, non-numeric values, or timestamps in the past — defensive against clock skew.

--- a/apps/docs/content/pages/api-reference/jsx/display.mdx
+++ b/apps/docs/content/pages/api-reference/jsx/display.mdx
@@ -1,0 +1,129 @@
+---
+title: Display components
+description: Container, Section, TextDisplay, MediaGallery, Separator, File, Thumbnail.
+---
+
+Display components are the layout primitives of a Components V2 message. Use them inside `render()` to produce the `components: …` array.
+
+## `<Container>`
+
+```tsx
+interface ContainerProps {
+	accentColor?: number | readonly [number, number, number];
+	spoiler?: boolean;
+	id?: number;
+	children?: DjsxNode | readonly DjsxNode[];
+}
+```
+
+Top-level layout primitive. Children may be `<Section>`, `<TextDisplay>`, `<MediaGallery>`, `<Separator>`, `<File>`, or `<ActionRow>`.
+
+```tsx
+<Container accentColor={0x5865f2}>
+	<TextDisplay># Welcome</TextDisplay>
+</Container>
+```
+
+## `<Section>`
+
+```tsx
+interface SectionProps {
+	accessory: DjsxNode;       // typically <Button> or <Thumbnail>
+	id?: number;
+	children?: DjsxNode | readonly DjsxNode[];   // text content
+}
+```
+
+Renders text on the left and an accessory (button or thumbnail) on the right.
+
+```tsx
+<Section accessory={<Button style="primary" customId="ok" label="OK" />}>
+	Click OK to continue.
+</Section>
+```
+
+## `<TextDisplay>`
+
+```tsx
+interface TextDisplayProps {
+	id?: number;
+	children?: string | readonly string[];
+}
+```
+
+Markdown text. Supports headings, lists, links, code spans — anything Discord's V2 markdown allows.
+
+```tsx
+<TextDisplay># Title{"\n\n"}Some **bold** text.</TextDisplay>
+```
+
+## `<MediaGallery>`
+
+```tsx
+interface MediaGalleryProps {
+	id?: number;
+	items: readonly { url: string; description?: string; spoiler?: boolean }[];
+}
+```
+
+Image carousel. Each item is `{ url, description?, spoiler? }`.
+
+```tsx
+<MediaGallery
+	items={[
+		{ url: "https://example.com/a.png" },
+		{ url: "https://example.com/b.png", description: "Caption", spoiler: true },
+	]}
+/>
+```
+
+## `<Separator>`
+
+```tsx
+interface SeparatorProps {
+	divider?: boolean;
+	spacing?: "small" | "large";
+	id?: number;
+}
+```
+
+Visual divider between sections. `divider: true` draws a line; `spacing` controls vertical gap.
+
+```tsx
+<Separator divider={true} spacing="large" />
+```
+
+## `<File>`
+
+```tsx
+interface FileProps {
+	url: string;
+	spoiler?: boolean;
+	id?: number;
+}
+```
+
+Embed a file by URL.
+
+```tsx
+<File url="https://example.com/document.pdf" />
+```
+
+## `<Thumbnail>`
+
+```tsx
+interface ThumbnailProps {
+	url: string;
+	description?: string;
+	spoiler?: boolean;
+	id?: number;
+}
+```
+
+Small image used as a section accessory. Pair with `<Section>`.
+
+```tsx
+<Section accessory={<Thumbnail url="https://example.com/avatar.png" description="Avatar" />}>
+	Profile information…
+</Section>
+```

--- a/apps/docs/content/pages/api-reference/jsx/forms.mdx
+++ b/apps/docs/content/pages/api-reference/jsx/forms.mdx
@@ -1,0 +1,166 @@
+---
+title: Form components
+description: ActionRow, Button, Modal, TextInput, RadioGroup, CheckboxGroup.
+---
+
+Form components are the interactive primitives — buttons in messages, fields in modals.
+
+## `<ActionRow>`
+
+```tsx
+interface ActionRowProps {
+	id?: number;
+	children?: DjsxNode | readonly DjsxNode[];
+}
+```
+
+Container for buttons (or string-select-menus from discord.js — same row constraints).
+
+```tsx
+<ActionRow>
+	<Button style="primary" customId="ok" label="OK" />
+	<Button style="danger" customId="cancel" label="Cancel" />
+</ActionRow>
+```
+
+## `<Button>`
+
+```tsx
+type ButtonStyleName = "primary" | "secondary" | "success" | "danger" | "link" | "premium";
+
+type ButtonProps =
+	| InteractiveButtonProps   // primary / secondary / success / danger
+	| LinkButtonProps          // link
+	| PremiumButtonProps;      // premium
+```
+
+Discriminated union over the three button "shapes". TypeScript narrows the required props once you set `style`.
+
+| Style | Required props |
+| --- | --- |
+| `primary` / `secondary` / `success` / `danger` | `customId`, `label` (and/or `emoji`), optional `disabled` |
+| `link` | `url`, `label` (and/or `emoji`) |
+| `premium` | `skuId` |
+
+```tsx
+<Button style="primary" customId="ok" label="OK" />
+<Button style="link" url="https://example.com" label="Docs" />
+<Button style="premium" skuId="123456789012345678" />
+```
+
+## `<Modal>`
+
+```tsx
+interface ModalProps {
+	customId: string;
+	title: string;
+	children?: DjsxNode | readonly DjsxNode[];
+}
+```
+
+Top-level modal element. Use with `renderModal()` and `interaction.showModal`. Accepts `<TextInput>`, `<RadioGroup>`, or `<CheckboxGroup>` as children.
+
+```tsx
+await interaction.showModal(
+	renderModal(
+		<Modal title="Send feedback" customId="feedback-modal">
+			<TextInput customId="subject" label="Subject" />
+		</Modal>
+	)
+);
+```
+
+## `<TextInput>`
+
+```tsx
+type TextInputStyleName = "short" | "paragraph";
+
+interface TextInputProps {
+	customId: string;
+	label: string;
+	style?: TextInputStyleName;
+	placeholder?: string;
+	required?: boolean;
+	value?: string;
+	minLength?: number;
+	maxLength?: number;
+}
+```
+
+Single-line (`short`, default) or multi-line (`paragraph`) text input field.
+
+```tsx
+<TextInput
+	customId="bio"
+	label="Bio"
+	style="paragraph"
+	placeholder="Tell us about yourself"
+	required={true}
+	maxLength={500}
+/>
+```
+
+## `<RadioGroup>`
+
+```tsx
+interface RadioGroupProps {
+	customId: string;
+	label: string;
+	required?: boolean;
+	options: readonly {
+		label: string;
+		value: string;
+		description?: string;
+		emoji?: { name?: string; id?: string; animated?: boolean };
+	}[];
+}
+```
+
+Single-choice modal field.
+
+```tsx
+<RadioGroup
+	customId="size"
+	label="T-shirt size"
+	required={true}
+	options={[
+		{ label: "Small", value: "s" },
+		{ label: "Medium", value: "m" },
+		{ label: "Large", value: "l" },
+	]}
+/>
+```
+
+## `<CheckboxGroup>`
+
+```tsx
+interface CheckboxGroupProps {
+	customId: string;
+	label: string;
+	required?: boolean;
+	minSelections?: number;
+	maxSelections?: number;
+	options: readonly {
+		label: string;
+		value: string;
+		description?: string;
+		emoji?: { name?: string; id?: string; animated?: boolean };
+	}[];
+}
+```
+
+Multi-choice modal field with optional min/max selection bounds.
+
+```tsx
+<CheckboxGroup
+	customId="topics"
+	label="Topics you're interested in"
+	minSelections={1}
+	maxSelections={3}
+	options={[
+		{ label: "TypeScript", value: "ts" },
+		{ label: "React", value: "react" },
+		{ label: "Node.js", value: "node" },
+	]}
+/>
+```

--- a/apps/docs/content/pages/api-reference/jsx/index.mdx
+++ b/apps/docs/content/pages/api-reference/jsx/index.mdx
@@ -1,0 +1,48 @@
+---
+title: Overview
+description: JSX runtime + Components V2 component set for Discord.js bots.
+---
+
+import { Cards, Card } from "fumadocs-ui/components/card";
+
+`@djs-commands/jsx` is an opt-in JSX runtime that compiles JSX trees into discord.js component builders for [Components V2](https://discord.com/developers/docs/components/reference). Output is identical to the function-form API in [`@djs-commands/core`](/api-reference/core/components-v2-functions) — mix the two freely.
+
+```bash
+bun add @djs-commands/jsx
+```
+
+```json title="tsconfig.json"
+{
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "@djs-commands/jsx"
+	}
+}
+```
+
+No Babel, no SWC, no React. The TypeScript compiler (and Bun's transpiler) emits `import { jsx } from "@djs-commands/jsx/jsx-runtime"` automatically.
+
+```tsx
+import { Container, Section, TextDisplay, Button, render } from "@djs-commands/jsx";
+import { MessageFlags } from "discord.js";
+
+await interaction.reply({
+	flags: MessageFlags.IsComponentsV2,
+	components: render(
+		<Container accentColor={0x5865f2}>
+			<TextDisplay># Welcome</TextDisplay>
+			<Section accessory={<Button style="primary" customId="ok" label="OK" />}>
+				Click the button to continue.
+			</Section>
+		</Container>
+	),
+});
+```
+
+## Symbols by topic
+
+<Cards>
+	<Card title="render / renderModal" href="/api-reference/jsx/render" description="Compile JSX trees to discord.js builders, plus the Fragment helper." />
+	<Card title="Display components" href="/api-reference/jsx/display" description="Container, Section, TextDisplay, MediaGallery, Separator, File, Thumbnail." />
+	<Card title="Form components" href="/api-reference/jsx/forms" description="ActionRow, Button, Modal, TextInput, RadioGroup, CheckboxGroup." />
+</Cards>

--- a/apps/docs/content/pages/api-reference/jsx/meta.json
+++ b/apps/docs/content/pages/api-reference/jsx/meta.json
@@ -1,0 +1,5 @@
+{
+	"title": "@djs-commands/jsx",
+	"icon": "Sparkles",
+	"pages": ["index", "render", "display", "forms"]
+}

--- a/apps/docs/content/pages/api-reference/jsx/render.mdx
+++ b/apps/docs/content/pages/api-reference/jsx/render.mdx
@@ -1,0 +1,103 @@
+---
+title: Renderers
+description: render, renderModal, Fragment — turn JSX trees into discord.js builders.
+---
+
+## `render(tree)`
+
+```ts
+function render(tree: TopLevelNode | DjsxNode | readonly DjsxNode[]): ComponentBuilderArray;
+```
+
+Compiles a JSX tree into the array of discord.js component builders that `interaction.reply` accepts when `flags: MessageFlags.IsComponentsV2` is set.
+
+```tsx
+import { Container, Section, TextDisplay, render } from "@djs-commands/jsx";
+import { MessageFlags } from "discord.js";
+
+await interaction.reply({
+	flags: MessageFlags.IsComponentsV2,
+	components: render(
+		<Container>
+			<TextDisplay># Hello</TextDisplay>
+		</Container>
+	),
+});
+```
+
+You may pass:
+- A single `<Container>` / `<ActionRow>` / `<TextDisplay>` etc. (any top-level component).
+- An array of top-level components (e.g. multiple containers in one reply).
+- A `<Fragment>` wrapping multiple top-level components.
+
+## `renderModal(modalNode)`
+
+```ts
+function renderModal(modal: ModalNode | DjsxNode): ModalBuilder;
+```
+
+Compiles a `<Modal>` JSX tree into a `ModalBuilder` ready to pass to `interaction.showModal`.
+
+```tsx
+import { Modal, TextInput, renderModal } from "@djs-commands/jsx";
+
+await interaction.showModal(
+	renderModal(
+		<Modal title="Send feedback" customId="feedback-modal">
+			<TextInput customId="subject" label="Subject" style="short" required={true} />
+			<TextInput customId="body" label="Tell us more" style="paragraph" />
+		</Modal>
+	)
+);
+```
+
+The argument can be either a `<Modal>` element directly, or any `DjsxNode` that resolves to one.
+
+## `ComponentBuilderArray`
+
+```ts
+type ComponentBuilderArray = (
+	| ContainerBuilder
+	| ActionRowBuilder<MessageActionRowComponentBuilder>
+	| TextDisplayBuilder
+	| SectionBuilder
+	| MediaGalleryBuilder
+	| SeparatorBuilder
+	| FileBuilder
+)[];
+```
+
+Return type of `render()`. Matches the `components: ...` array shape that discord.js accepts when sending Components V2 messages.
+
+## `Fragment`
+
+```ts
+const Fragment: (props: { children?: DjsxNode | readonly DjsxNode[] }) => DjsxNode;
+```
+
+JSX fragment helper — group multiple children without wrapping them in another component. Same role as React's `<>...</>`.
+
+```tsx
+render(
+	<>
+		<Container><TextDisplay># Container 1</TextDisplay></Container>
+		<Container><TextDisplay># Container 2</TextDisplay></Container>
+	</>
+);
+```
+
+## `DjsxNode`
+
+```ts
+type DjsxNode = /* opaque internal IR */;
+```
+
+Internal node type produced by every JSX component in this package. You don't typically reference it directly — accept it as `children` if you write a wrapping component:
+
+```tsx
+import type { DjsxNode } from "@djs-commands/jsx";
+
+function MyContainer({ children }: { children: DjsxNode | readonly DjsxNode[] }) {
+	return <Container accentColor={0x5865f2}>{children}</Container>;
+}
+```

--- a/apps/docs/content/pages/api-reference/meta.json
+++ b/apps/docs/content/pages/api-reference/meta.json
@@ -1,5 +1,5 @@
 {
 	"title": "API Reference",
 	"icon": "Code",
-	"pages": ["index", "core"]
+	"pages": ["index", "core", "jsx", "adapters"]
 }


### PR DESCRIPTION
Closes #104. **Stacked on #109** — base: `docs/api-ref-core`.

## What

### JSX runtime (`apps/docs/content/pages/api-reference/jsx/`)

| Page | Symbols |
|---|---|
| `index` | Overview, install, tsconfig snippet, navigation |
| `render` | `render()`, `renderModal()`, `Fragment`, `ComponentBuilderArray`, `DjsxNode` |
| `display` | `Container`, `Section`, `TextDisplay`, `MediaGallery`, `Separator`, `File`, `Thumbnail` (every `*Props`) |
| `forms` | `ActionRow`, `Button` (3 variants), `Modal`, `TextInput`, `RadioGroup`, `CheckboxGroup` |

### Adapters (`apps/docs/content/pages/api-reference/adapters/`)

| Page | Symbols |
|---|---|
| `index` | Overview cards across all 4 adapters |
| `drizzle` | `drizzleStorage()`, `DrizzleStorageOptions`, schema + row type exports |
| `prisma` | `prismaStorage()`, `PrismaClientLike`, `PrismaStorageOptions`, the 3 `*_PRISMA_MODEL` fragment strings |
| `mongoose` | `mongooseStorage()`, `MongooseStorageOptions`, the 3 model-factory functions, doc types |
| `redis` | `redisCacheAdapter()`, `RedisCacheAdapterOptions`, Redis command mapping table |

`apps/docs/content/pages/api-reference/meta.json` updated to include the new `jsx` and `adapters` sub-sections in the sidebar.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run check` clean
- [x] `bun run build:docs` clean — every page prerenders
- [ ] After #109 + this merge: spot-check sidebar shows all sub-sections under API Reference