### PR TITLE
docs(#105): edit-on-github + last-updated + prev/next footer

### DIFF
--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig, defineDocs } from "fumadocs-mdx/config";
+import lastModified from "fumadocs-mdx/plugins/last-modified";
 
 export const docs = defineDocs({
 	dir: "content/pages",
 });
 
-export default defineConfig();
+export default defineConfig({
+	/*
+	 * `lastModified` reads the file's last git timestamp and exposes it on the
+	 * compiled MDX module. On Vercel, set VERCEL_DEEP_CLONE=true so the build
+	 * has full git history (otherwise this plugin no-ops on remote builds).
+	 */
+	plugins: [lastModified()],
+});

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -2,10 +2,14 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import type { Root as PageTreeRoot } from "fumadocs-core/page-tree";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
-import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/layouts/docs/page";
+import { DocsBody, DocsDescription, DocsPage, DocsTitle, PageLastUpdate, ViewOptionsPopover } from "fumadocs-ui/layouts/docs/page";
 import type React from "react";
 import { mdxComponents } from "@/lib/mdx-components";
 import browserCollections from "../../.source/browser";
+
+const REPO = "D3OXY/djs-commands";
+const REPO_BRANCH = "main";
+const CONTENT_PATH = "apps/docs/content/pages";
 
 export const Route = createFileRoute("/$")({
 	component: Page,
@@ -43,17 +47,26 @@ const getPageTree = createServerFn({
 	return source.pageTree;
 });
 
-const clientLoader = browserCollections.docs.createClientLoader({
+interface DocClientProps {
+	githubUrl: string;
+}
+
+const clientLoader = browserCollections.docs.createClientLoader<DocClientProps>({
 	id: "docs",
-	component(doc) {
+	component(doc, { githubUrl }) {
 		const MDX = doc.default;
+		const lastModified = (doc as { lastModified?: Date | string }).lastModified;
+		const lastModifiedDate = lastModified ? new Date(lastModified) : undefined;
+
 		return (
-			<DocsPage toc={doc.toc} tableOfContent={{ style: "clerk" }}>
+			<DocsPage toc={doc.toc} tableOfContent={{ style: "clerk" }} footer={{ enabled: true }}>
 				<DocsTitle>{doc.frontmatter.title}</DocsTitle>
 				{doc.frontmatter.description && <DocsDescription>{doc.frontmatter.description}</DocsDescription>}
 				<DocsBody>
 					<MDX components={mdxComponents} />
+					{lastModifiedDate && <PageLastUpdate date={lastModifiedDate} />}
 				</DocsBody>
+				<ViewOptionsPopover githubUrl={githubUrl} />
 			</DocsPage>
 		);
 	},
@@ -99,12 +112,12 @@ function DocsLayoutWrapper({ children, tree }: DocsLayoutWrapperProps) {
 
 function Page() {
 	const data = Route.useLoaderData();
-	// fumadocs types getComponent as FC<undefined>; cast needed to render as no-props component
-	const Content = clientLoader.getComponent(data.path) as unknown as React.ComponentType;
+	const Content = clientLoader.getComponent(data.path);
+	const githubUrl = `https://github.com/${REPO}/blob/${REPO_BRANCH}/${CONTENT_PATH}/${data.path}`;
 
 	return (
 		<DocsLayoutWrapper tree={data.tree}>
-			<Content />
+			<Content githubUrl={githubUrl} />
 		</DocsLayoutWrapper>
 	);
 }


### PR DESCRIPTION
Closes #105.

## What

Three small but visible polish items wired into `DocsPage`:

- **Edit on GitHub** — `<ViewOptionsPopover githubUrl=... />` opens a popover with an "Edit" link pointing at the source MDX on `main`. URL is constructed from the page's path: `https://github.com/D3OXY/djs-commands/blob/main/apps/docs/content/pages/<slug>.mdx`.
- **Last updated** — `source.config.ts` enables fumadocs-mdx's `lastModified` plugin (reads file timestamp from git); `<PageLastUpdate date={…} />` renders "Last updated on …" at the bottom of every page.
- **Prev / Next footer** — `footer={{ enabled: true }}` on `DocsPage`. fumadocs derives the order from the sidebar / page tree.

## ⚠️ Vercel deploy note

The `lastModified` plugin reads from git. Vercel does **shallow clones by default**, which makes the plugin no-op on remote builds. Set the project env var `VERCEL_DEEP_CLONE=true` in Vercel → Settings → Environment Variables for it to populate timestamps on the deployed site. (Local dev works with no setup.)

## Verified locally

- View source on `/concepts/cooldowns` shows the "Open" view-options button + prev/next `<a>` cards (`/concepts/validators`, `/concepts/plugins`)
- `Last updated on …` element rendered
- `bun run typecheck` clean
- `bun run check` clean

## Test plan

- [ ] After merge: confirm Vercel preview shows "Last updated" with actual timestamps (set `VERCEL_DEEP_CLONE=true` first)
- [ ] After merge: click ViewOptions "Open" → "Edit on GitHub", verify it lands on the right MDX file