### PR TITLE
fix(docs): keep page-tree icons serializable across server → client

### DIFF
--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,21 +1,18 @@
 import { loader } from "fumadocs-core/source";
-import * as Icons from "lucide-react";
-import { createElement } from "react";
 import { docs } from "../../.source/server";
 
 /*
- * meta.json files set `icon: "Rocket"` (a lucide-react export name). The loader
- * resolves the string to a real React component here so the sidebar renders an
- * icon next to each section. Unknown names fall back to undefined (no icon).
+ * Icons stay as STRINGS through the source loader so the page tree remains
+ * serializable across server → client. TanStack's serializer (seroval) bails
+ * on React elements with `Symbol(react.transitional.element)`, which leaves
+ * the page blank after hydration. The lucide-react → React element conversion
+ * happens in routes/$.tsx via `reviveTreeIcons` once the tree lands on the
+ * client.
  */
 export const source = loader({
 	source: docs.toFumadocsSource(),
 	baseUrl: "/",
 	icon(icon) {
-		if (!icon) return undefined;
-		const Icon = (Icons as unknown as Record<string, unknown>)[icon];
-		if (!Icon) return undefined;
-		// biome-ignore lint/suspicious/noExplicitAny: lucide icons all share the same prop shape
-		return createElement(Icon as any);
+		return icon;
 	},
 });

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
-import type { Root as PageTreeRoot } from "fumadocs-core/page-tree";
+import type { Node as PageTreeNode, Root as PageTreeRoot } from "fumadocs-core/page-tree";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle, PageLastUpdate, ViewOptionsPopover } from "fumadocs-ui/layouts/docs/page";
+import * as Icons from "lucide-react";
 import type React from "react";
+import { createElement, useMemo } from "react";
 import { mdxComponents } from "@/lib/mdx-components";
 import browserCollections from "../../.source/browser";
 
@@ -137,13 +139,33 @@ function DocsLayoutWrapper({ children, tree }: DocsLayoutWrapperProps) {
 	);
 }
 
+/*
+ * Walk the serialized tree and replace each string icon (e.g. "Rocket") with
+ * a real lucide-react element. Icons stay as strings on the wire — see
+ * lib/source.ts for the rationale. Tree shape is `Root | Folder | Item |
+ * Separator`; only Folder has children.
+ */
+function reviveTreeIcons<T extends PageTreeRoot | PageTreeNode>(node: T): T {
+	const next = { ...node } as T & { icon?: React.ReactNode; children?: PageTreeNode[] };
+	if (typeof next.icon === "string") {
+		const Icon = (Icons as unknown as Record<string, React.ComponentType<{ className?: string }>>)[next.icon];
+		if (Icon) next.icon = createElement(Icon);
+		else next.icon = undefined;
+	}
+	if (Array.isArray(next.children)) {
+		next.children = next.children.map((child) => reviveTreeIcons(child));
+	}
+	return next;
+}
+
 function Page() {
 	const data = Route.useLoaderData();
 	const Content = clientLoader.getComponent(data.path);
 	const githubUrl = `https://github.com/${REPO}/blob/${REPO_BRANCH}/${CONTENT_PATH}/${data.path}`;
+	const tree = useMemo(() => reviveTreeIcons(data.tree), [data.tree]);
 
 	return (
-		<DocsLayoutWrapper tree={data.tree}>
+		<DocsLayoutWrapper tree={tree}>
 			<Content githubUrl={githubUrl} />
 		</DocsLayoutWrapper>
 	);


### PR DESCRIPTION
## Symptom

After all 6 docs PRs landed on `main`, every doc page rendered briefly via SSR then **blanked out instantly** in the browser.

## Root cause

`apps/docs/src/lib/source.ts` (added in #107) had an icon resolver that called `createElement(Icon)`, baking React element nodes — `Symbol(react.transitional.element)` — into every node of `source.pageTree`.

The route's `getPageTree` is a `createServerFn`. TanStack Start serializes the loader payload via [seroval](https://github.com/lxsmnsyc/seroval), which **throws on React element symbols**:

```
Error: Seroval Error (specific: 1)
   { value: Symbol(react.transitional.element) }
```

Seroval failure → loader payload never reached the client → React 19 unmounted the SSR'd HTML on hydration → blank page. SSR `curl` returned valid HTML so it slipped through earlier checks.

## Fix

Two surgical changes:

- **`apps/docs/src/lib/source.ts`** — icon resolver now returns the icon **name as a string** (a serializable `ReactNode`), leaving the entire page tree wire-safe.
- **`apps/docs/src/routes/$.tsx`** — adds `reviveTreeIcons()` which walks the tree on the client (memoized via `useMemo`), replacing each string icon with a real `<Icon />` element via `createElement(Icons[name])`. Sidebar icons render identically.

Net behavior: same UI, same icons in the sidebar — just no React element symbols crossing the wire.

## Verification

- ✅ `bun run dev` — no seroval errors in the dev log on any docs page request
- ✅ Rendered HTML still contains all expected lucide icon classes (`lucide-rocket`, `lucide-database`, etc.)
- ✅ User confirmed in browser: pages stay rendered, no blank-out
- ✅ `bun run typecheck` clean
- ✅ `bun run check` clean