### PR TITLE
feat(core): add explicit command registration sync

### DIFF
--- a/.changeset/quiet-socks-drum.md
+++ b/.changeset/quiet-socks-drum.md
@@ -1,0 +1,6 @@
+---
+"@djs-commands/core": minor
+"create-djs-commands": patch
+---
+
+Add explicit global and guild command registration sync controls.

--- a/apps/docs/content/pages/api-reference/core/command-handler.mdx
+++ b/apps/docs/content/pages/api-reference/core/command-handler.mdx
@@ -43,6 +43,7 @@ interface CommandHandlerOptions {
 	validators?: readonly Validator[];
 	canRunCommand?: CanRunCommand;
 	plugins?: PluginManifest[];
+	registration?: HandlerRegistrationConfig;
 	cacheAdapter?: CacheAdapter;
 	legacy?: HandlerLegacyConfig;
 	storage?: Storage;
@@ -61,10 +62,56 @@ interface CommandHandlerOptions {
 | `validators` | Global validators run on every command. |
 | `canRunCommand` | Slimmer single-callback gate — return `true` / `false` / a reason string. |
 | `plugins` | Plugin manifests merged at boot. |
+| `registration` | Discord application command scopes the handler owns. Defaults to global sync; pass `false` to disable framework registration. |
 | `cacheAdapter` | TTL-native cache for cooldowns. Without it, cooldowns are in-memory. |
 | `legacy` | Master switch + default prefix for legacy invocation. |
 | `storage` | Persistence adapter for enabled framework storage features. |
 | `storageFeatures` | Opt into storage-backed framework features. `guildPrefixes` defaults to `legacy.enabled`; `disabledCommands` and `channelLocks` default to `false`. |
+
+## `HandlerRegistrationConfig`
+
+```ts
+type HandlerRegistrationConfig =
+	| false
+	| {
+			enabled?: boolean;
+			global?: "sync" | "clear" | "ignore" | { mode: "sync" | "clear" | "ignore" };
+			guilds?: readonly (string | { id: string; mode?: "sync" | "clear" | "ignore" })[];
+	  };
+```
+
+When `registration` is omitted, the handler syncs global commands. When you pass an object, only listed scopes are managed; omitted scopes are ignored.
+
+`sync` overwrites that Discord scope with the current command list. `clear` overwrites it with an empty list. Both are destructive for that configured scope, and Discord commands persist until overwritten or cleared. Stopping your bot does not delete commands.
+
+```ts
+createCommandHandler({
+	client,
+	commandDir: "./src/commands",
+	registration: {
+		global: "clear",
+		guilds: [{ id: "123456789012345678", mode: "sync" }],
+	},
+});
+```
+
+Per-command overrides:
+
+```ts
+defineCommand({
+	name: "admin",
+	description: "Guild-only admin command",
+	registration: { global: false, guilds: ["123456789012345678"] },
+	run: async () => {},
+});
+
+defineCommand({
+	name: "runtime-only",
+	description: "Loaded for dispatch, not auto-registered",
+	registration: false,
+	run: async () => {},
+});
+```
 
 ## `CommandHandler`
 

--- a/apps/docs/content/pages/concepts/commands.mdx
+++ b/apps/docs/content/pages/concepts/commands.mdx
@@ -111,7 +111,7 @@ Supported option types: `string`, `integer`, `number`, `boolean`, `user`, `chann
 `createCommandHandler` accepts a `client` and an array of commands. It does two things on your behalf:
 
 1. **Subscribes** to `interactionCreate`. When a chat-input interaction comes in, it looks up the command by `name` and dispatches it through validators → cooldown gates → plugins → `run`.
-2. **Registers** the command list with Discord on `clientReady`. This calls `client.application.commands.set(...)` with the names, descriptions, and options of every command you passed in.
+2. **Registers** the command list with Discord on `clientReady`. By default this syncs global application commands with the names, descriptions, and options of every loaded command.
 
 ```ts
 import { createCommandHandler } from "@djs-commands/core";
@@ -136,6 +136,34 @@ await handler.destroy();   // Removes listeners, awaits plugin teardown
 ```
 
 `destroy()` does **not** delete the registered application commands from Discord — those persist until you explicitly clear them.
+
+### Registration scopes
+
+Discord has separate global and guild application command scopes. The handler owns only the scopes you configure:
+
+```ts
+createCommandHandler({
+	client,
+	commands: [ping],
+	registration: {
+		global: "clear",
+		guilds: [{ id: "123456789012345678", mode: "sync" }],
+	},
+});
+```
+
+Use `sync` to overwrite a scope with the current command list, `clear` to overwrite it with no commands, and `ignore` to leave it untouched. `sync` and `clear` are destructive inside that scope. Commands persist in Discord until overwritten or cleared; stopping the bot does not remove them.
+
+Commands can opt out globally, target specific guilds, or skip framework auto-registration entirely while still loading for runtime dispatch:
+
+```ts
+defineCommand({
+	name: "admin",
+	description: "Guild-only admin command",
+	registration: { global: false, guilds: ["123456789012345678"] },
+	run: async () => {},
+});
+```
 
 ## Loading commands from a directory
 

--- a/apps/docs/content/pages/migration-from-v1/dropped-features.mdx
+++ b/apps/docs/content/pages/migration-from-v1/dropped-features.mdx
@@ -54,24 +54,20 @@ Or better: don't add it at all. Let your supervisor restart the bot on crash and
 
 v1 had a `testServers` option that registered new commands against a list of guild IDs first, then promoted to global on success.
 
-**Why dropped**: the deploy story for slash commands varies a lot (you might use `discord.js`'s REST helpers directly, run a separate deploy script, gate on environment, etc.). Forcing one model in the framework limited flexibility.
-
-**Replacement**: handle it yourself in the `clientReady` event:
+**Replacement**: use explicit Discord registration scopes.
 
 ```ts
-client.once("clientReady", async (c) => {
-    if (process.env.NODE_ENV === "production") {
-        await c.application.commands.set(commands);
-    } else {
-        for (const guildId of TEST_GUILDS) {
-            const guild = await c.guilds.fetch(guildId);
-            await guild.commands.set(commands);
-        }
-    }
+createCommandHandler({
+    client,
+    commandDir: "./src/commands",
+    registration: {
+        global: "clear",
+        guilds: [{ id: "123456789012345678", mode: "sync" }],
+    },
 });
 ```
 
-The framework's default `clientReady` listener registers globally. If you want test-server gating, override it with your own listener BEFORE calling `createCommandHandler` (or pass `commands: []` to skip the framework's auto-register).
+Guild sync is useful for private single-server bots and fast iteration, not only tests. `sync` overwrites the configured scope with the current command list; `clear` overwrites it with an empty list. Discord commands persist until overwritten or cleared.
 
 ## `cooldownConfig.dbRequired` (5-minute DB persistence threshold)
 

--- a/apps/docs/content/pages/migration-from-v1/handler.mdx
+++ b/apps/docs/content/pages/migration-from-v1/handler.mdx
@@ -17,7 +17,7 @@ Every option you passed to `new CommandHandler({ … })` in v1 has a mapping in 
 | `defaultPrefix` | `legacy: { enabled: true, defaultPrefix: "!" }` |
 | `botOwners` | `botOwners` (unchanged) |
 | `cooldownConfig` | per-command `cooldown: { type, duration }` (no global config) |
-| `testServers` | dropped — handle via your own deploy logic per guild |
+| `testServers` | `registration: { guilds: ["guild-id"] }` for guild sync |
 | `defaultCommand` | dropped — built-in admin commands removed; build your own |
 | `antiCrash` | dropped — use process-level `unhandledRejection` / `uncaughtException` |
 
@@ -85,3 +85,4 @@ Notes:
 - v2 doesn't wait for `ready` to wire up — you call `createCommandHandler` synchronously after constructing the `Client`.
 - v2's `commandDir` accepts a path string. We use `fileURLToPath(new URL(...))` so it works under both Bun and Node + tsx; v1's `path.join(__dirname, ...)` worked because v1 was CJS — v2 is ESM.
 - `cooldownConfig.dbRequired` (v1's "use DB if duration ≥ 5min") doesn't exist. Cooldowns default to in-memory; provide a `cacheAdapter` (e.g. `@djs-commands/adapter-redis`) for distributed cooldowns.
+- Guild registration is no longer described as only testing. Use guild sync for private single-server bots or fast iteration; use global sync for public rollout.

--- a/apps/docs/content/pages/migration-from-v1/validators.mdx
+++ b/apps/docs/content/pages/migration-from-v1/validators.mdx
@@ -13,7 +13,7 @@ v1's command-level validation flags map 1:1 to v2 properties on `defineCommand`.
 | `requiredRoles: ["role-id-1"]` | `roles: ["role-id-1"]` |
 | `ownerOnly: true` | `ownerOnly: true` |
 | `guildOnly: true` | `guildOnly: true` |
-| `testOnly: true` | dropped — handle deploy gating yourself |
+| `testOnly: true` | `registration: { global: false, guilds: ["guild-id"] }` or your own deployment policy |
 
 ```ts
 // v1

--- a/packages/core/src/dispatcher.test.ts
+++ b/packages/core/src/dispatcher.test.ts
@@ -62,6 +62,17 @@ test("registering a command with the same name overwrites the previous one", asy
 	expect(second).toHaveBeenCalledTimes(1);
 });
 
+test("unregister removes a command from dispatch", async () => {
+	const dispatcher = new Dispatcher();
+	const run = mock(async (_ctx: unknown) => {});
+	dispatcher.register({ name: "ping", description: "ping", run });
+
+	dispatcher.unregister("ping");
+	await dispatcher.dispatch(fakeInteraction("ping"));
+
+	expect(run).toHaveBeenCalledTimes(0);
+});
+
 test("dispatch extracts options from the interaction and passes them via ctx.options", async () => {
 	const dispatcher = new Dispatcher();
 	const run = mock(async (_ctx: unknown) => {});

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -44,6 +44,15 @@ export class Dispatcher {
 		}
 	}
 
+	unregister(name: string): void {
+		const command = this.commands.get(name);
+		if (!command) return;
+		this.commands.delete(name);
+		for (const [alias, aliasedCommand] of this.aliases) {
+			if (aliasedCommand === command) this.aliases.delete(alias);
+		}
+	}
+
 	async dispatch(interaction: ChatInputCommandInteraction): Promise<void> {
 		const command = this.commands.get(interaction.commandName);
 		if (!command) return;

--- a/packages/core/src/fs-loader.test.ts
+++ b/packages/core/src/fs-loader.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadCommandsFromDir, loadEventsFromDir } from "./fs-loader";
+import { loadCommandEntriesFromDir, loadCommandsFromDir, loadEventsFromDir } from "./fs-loader";
 
 let dir: string;
 
@@ -58,6 +58,15 @@ test("loadCommandsFromDir picks up files whose default export is a Command", asy
 
 	const names = commands.map((c) => c.name).sort();
 	expect(names).toEqual(["echo", "ping"]);
+});
+
+test("loadCommandEntriesFromDir includes source file paths", async () => {
+	const file = join(dir, "ping.ts");
+	await writeFile(file, PING_SOURCE);
+
+	const entries = await loadCommandEntriesFromDir(dir);
+
+	expect(entries).toEqual([{ file, command: expect.objectContaining({ name: "ping" }) }]);
 });
 
 test("loadCommandsFromDir walks subdirectories recursively", async () => {

--- a/packages/core/src/fs-loader.ts
+++ b/packages/core/src/fs-loader.ts
@@ -1,4 +1,4 @@
-import { type FSWatcher, watch } from "node:fs";
+import { existsSync, type FSWatcher, watch } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { extname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -11,6 +11,11 @@ interface DirEntry {
 	name: string;
 	isDirectory(): boolean;
 	isFile(): boolean;
+}
+
+export interface CommandFileEntry {
+	file: string;
+	command: AnyCommand;
 }
 
 async function* walk(dir: string): AsyncIterable<string> {
@@ -50,13 +55,18 @@ async function importModule(file: string, cacheBust?: number): Promise<unknown> 
 }
 
 export async function loadCommandsFromDir(dir: string): Promise<AnyCommand[]> {
+	const entries = await loadCommandEntriesFromDir(dir);
+	return entries.map((entry) => entry.command);
+}
+
+export async function loadCommandEntriesFromDir(dir: string): Promise<CommandFileEntry[]> {
 	const absolute = resolve(dir);
-	const commands: AnyCommand[] = [];
+	const entries: CommandFileEntry[] = [];
 	for await (const file of walk(absolute)) {
 		const candidate = await importModule(file);
-		if (isCommand(candidate)) commands.push(candidate);
+		if (isCommand(candidate)) entries.push({ file, command: candidate });
 	}
-	return commands;
+	return entries;
 }
 
 export async function loadEventsFromDir(dir: string): Promise<EventDefinition[]> {
@@ -87,6 +97,10 @@ export function watchCommandsDir(dir: string, options: { onCommandChange?: (file
 			if (!filename) return;
 			if (!SOURCE_EXTS.has(extname(filename))) return;
 			const file = join(absolute, filename);
+			if (!existsSync(file)) {
+				options.onCommandChange?.(file, null);
+				return;
+			}
 			importModule(file, Date.now())
 				.then((candidate) => {
 					if (isCommand(candidate)) {

--- a/packages/core/src/handler-registration.test.ts
+++ b/packages/core/src/handler-registration.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Client } from "discord.js";
+import { Events } from "discord.js";
+import { createCommandHandler } from "./handler";
+import type { PluginManifest } from "./plugin";
+import type { AnyCommand } from "./types";
+
+interface GuildSetCall {
+	guildId: string;
+	data: unknown;
+}
+
+const command = (name: string): AnyCommand => ({
+	name,
+	description: `${name} command`,
+	run: () => {},
+});
+
+const makeClient = () => {
+	const emitter = new EventEmitter();
+	const globalSetMock = mock(async (_data: unknown) => {});
+	const guildSetCalls: GuildSetCall[] = [];
+	const guildFetchMock = mock(async (guildId: string) => ({
+		commands: {
+			set: async (data: unknown) => {
+				guildSetCalls.push({ guildId, data });
+			},
+		},
+	}));
+	const client = emitter as unknown as Client;
+	const writableClient = client as unknown as {
+		application: { commands: { set: typeof globalSetMock } };
+		guilds: { fetch: typeof guildFetchMock };
+	};
+	writableClient.application = { commands: { set: globalSetMock } };
+	writableClient.guilds = { fetch: guildFetchMock };
+	return { client, globalSetMock, guildFetchMock, guildSetCalls };
+};
+
+const emitReady = async (client: Client): Promise<void> => {
+	client.emit(Events.ClientReady, client as Client<true>);
+	await new Promise((resolve) => setImmediate(resolve));
+	await new Promise((resolve) => setImmediate(resolve));
+};
+
+const namesFromData = (data: unknown): string[] => (data as { name: string }[]).map((entry) => entry.name);
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("handler registration", () => {
+	test("default global sync calls the application command manager", async () => {
+		const { client, globalSetMock, guildFetchMock } = makeClient();
+		const handler = createCommandHandler({ client, commands: [command("ping")] });
+		await handler.ready;
+
+		await emitReady(client);
+
+		expect(globalSetMock).toHaveBeenCalledTimes(1);
+		expect(namesFromData(globalSetMock.mock.calls[0]?.[0])).toEqual(["ping"]);
+		expect(guildFetchMock).toHaveBeenCalledTimes(0);
+
+		await handler.destroy();
+	});
+
+	test("guild sync calls the guild command manager without touching global", async () => {
+		const { client, globalSetMock, guildFetchMock, guildSetCalls } = makeClient();
+		const handler = createCommandHandler({ client, commands: [command("ping")], registration: { guilds: ["guild-1"] } });
+		await handler.ready;
+
+		await emitReady(client);
+
+		expect(globalSetMock).toHaveBeenCalledTimes(0);
+		expect(guildFetchMock).toHaveBeenCalledWith("guild-1");
+		expect(guildSetCalls).toHaveLength(1);
+		expect(namesFromData(guildSetCalls[0]?.data)).toEqual(["ping"]);
+
+		await handler.destroy();
+	});
+
+	test("fs-loaded commands are included after boot", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "djs-commands-"));
+		tempDirs.push(dir);
+		await writeFile(join(dir, "fs-command.mjs"), 'export default { name: "from-fs", description: "fs command", run() {} };');
+		const { client, globalSetMock } = makeClient();
+		const handler = createCommandHandler({ client, commandDir: dir, dev: false });
+		await handler.ready;
+
+		await emitReady(client);
+
+		expect(namesFromData(globalSetMock.mock.calls[0]?.[0])).toEqual(["from-fs"]);
+
+		await handler.destroy();
+	});
+
+	test("plugin commands are included after boot", async () => {
+		const { client, globalSetMock } = makeClient();
+		const plugin: PluginManifest = { name: "demo", commands: [command("from-plugin")] };
+		const handler = createCommandHandler({ client, commands: [command("base")], plugins: [plugin] });
+		await handler.ready;
+
+		await emitReady(client);
+
+		expect(namesFromData(globalSetMock.mock.calls[0]?.[0])).toEqual(["base", "from-plugin"]);
+
+		await handler.destroy();
+	});
+});

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -1,8 +1,8 @@
 import { type ApplicationCommandDataResolvable, type Client, Events, type Interaction, type Message } from "discord.js";
 import type { EventDefinition } from "./define-event";
 import { Dispatcher } from "./dispatcher";
-import { loadCommandsFromDir, loadEventsFromDir, type WatchHandle, watchCommandsDir } from "./fs-loader";
-import { buildOptionsData } from "./options";
+import { loadCommandEntriesFromDir, loadEventsFromDir, type WatchHandle, watchCommandsDir } from "./fs-loader";
+import { createRegistrationPlan, type RegistrationPlan } from "./registration";
 import { ChannelLocksModel, DisabledCommandsModel, type FrameworkStorageModel, GuildPrefixModel, getGuildPrefix } from "./storage";
 import type { AnyCommand, CommandHandler, CommandHandlerOptions, StorageFeaturesConfig } from "./types";
 
@@ -35,6 +35,9 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		dispatcher.register(command);
 	}
 
+	const commandFiles = new Map<string, string>();
+	let readyClient: Client<true> | null = null;
+
 	const onInteraction = (interaction: Interaction) => {
 		if (!interaction.isChatInputCommand()) return;
 		dispatcher.dispatch(interaction).catch((err) => {
@@ -63,14 +66,12 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 
 	const onReady = (client: Client<true>) => {
 		if (!client.application) return;
-		const data = allCommands.map((c) => ({
-			name: c.name,
-			description: c.description,
-			options: buildOptionsData(c.options),
-		})) as unknown as ApplicationCommandDataResolvable[];
-		client.application.commands.set(data).catch((err) => {
-			console.error("[djs-commands] Failed to register application commands:", err);
-		});
+		readyClient = client;
+		bootPromise
+			.then(() => syncRegistration(client, allCommands, options.registration))
+			.catch((err) => {
+				console.error("[djs-commands] Failed to register application commands:", err);
+			});
 	};
 
 	const loadedEventListeners: { event: string; handler: (...args: unknown[]) => void }[] = [];
@@ -102,9 +103,10 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 
 			// Load fs-discovered commands first so they're registered before plugin setup runs.
 			if (options.commandDir) {
-				const discovered = await loadCommandsFromDir(options.commandDir);
-				for (const command of discovered) {
-					allCommands.push(command);
+				const discovered = await loadCommandEntriesFromDir(options.commandDir);
+				for (const { file, command } of discovered) {
+					commandFiles.set(file, command.name);
+					replaceCommand(allCommands, command);
 					dispatcher.register(command);
 				}
 			}
@@ -119,12 +121,28 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 			if (dev && options.commandDir) {
 				watchHandle = watchCommandsDir(options.commandDir, {
 					onCommandChange: (file, command) => {
+						const previousName = commandFiles.get(file);
 						if (!command) {
+							if (previousName) {
+								removeCommand(allCommands, previousName);
+								dispatcher.unregister(previousName);
+								commandFiles.delete(file);
+								console.log(`[djs-commands] removed ${previousName}`);
+								if (readyClient) syncRegistration(readyClient, allCommands, options.registration).catch(logRegistrationError);
+								return;
+							}
 							console.warn(`[djs-commands] ${file} changed but no longer exports a valid command`);
 							return;
 						}
+						if (previousName && previousName !== command.name) {
+							removeCommand(allCommands, previousName);
+							dispatcher.unregister(previousName);
+						}
+						replaceCommand(allCommands, command);
+						commandFiles.set(file, command.name);
 						dispatcher.register(command);
 						console.log(`[djs-commands] hot-reloaded ${command.name}`);
+						if (readyClient) syncRegistration(readyClient, allCommands, options.registration).catch(logRegistrationError);
 					},
 				});
 			}
@@ -181,6 +199,40 @@ function assertConfiguredStorage(storage: CommandHandlerOptions["storage"], feat
 		throw new Error(`[djs-commands] storage is required for enabled storage features: ${requiredModels.join(", ")}`);
 	}
 	storage.assertModels?.(requiredModels);
+}
+
+async function applyRegistrationPlan(client: Client<true>, plan: RegistrationPlan): Promise<void> {
+	if (!client.application) return;
+	for (const operation of plan.operations) {
+		const commands = operation.commands as ApplicationCommandDataResolvable[];
+		if (operation.scope === "global") {
+			await client.application.commands.set(commands);
+		} else {
+			const guild = await client.guilds.fetch(operation.guildId);
+			await guild.commands.set(commands);
+		}
+	}
+}
+
+async function syncRegistration(client: Client<true>, commands: readonly AnyCommand[], registration: CommandHandlerOptions["registration"]): Promise<void> {
+	await applyRegistrationPlan(client, createRegistrationPlan(commands, registration));
+}
+
+function logRegistrationError(err: unknown): void {
+	console.error("[djs-commands] Failed to register application commands:", err);
+}
+
+function replaceCommand(commands: AnyCommand[], command: AnyCommand): void {
+	removeCommand(commands, command.name);
+	commands.push(command);
+}
+
+function removeCommand(commands: AnyCommand[], name: string): void {
+	let index = commands.findIndex((command) => command.name === name);
+	while (index !== -1) {
+		commands.splice(index, 1);
+		index = commands.findIndex((command) => command.name === name);
+	}
 }
 
 function registerEvent(client: Client, evt: EventDefinition, listeners: { event: string; handler: (...args: unknown[]) => void }[]): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,7 +34,8 @@ export { normalizeLegacyContext, normalizeSlashContext } from "./context";
 export type { CacheAdapter, CooldownActor, CooldownConfig, CooldownType } from "./cooldowns";
 export { defineCommand } from "./define-command";
 export { defineEvent, type EventDefinition } from "./define-event";
-export { loadCommandsFromDir, loadEventsFromDir, watchCommandsDir } from "./fs-loader";
+export type { CommandFileEntry } from "./fs-loader";
+export { loadCommandEntriesFromDir, loadCommandsFromDir, loadEventsFromDir, watchCommandsDir } from "./fs-loader";
 export { createCommandHandler } from "./handler";
 export type { LegacyParseResult } from "./legacy-parser";
 export { parseLegacyArgs } from "./legacy-parser";
@@ -54,6 +55,16 @@ export type {
 	UserOption,
 } from "./options";
 export type { PluginManifest, PluginSetupContext } from "./plugin";
+export type {
+	CommandGuildRegistrationConfig,
+	CommandRegistrationConfig,
+	HandlerRegistrationConfig,
+	RegistrationGuildScopeConfig,
+	RegistrationPlan,
+	RegistrationPlanOperation,
+	RegistrationScopeConfig,
+	RegistrationScopeMode,
+} from "./registration";
 export {
 	assertRequiredStorageFields,
 	type ChannelLockRow,

--- a/packages/core/src/registration.test.ts
+++ b/packages/core/src/registration.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { createRegistrationPlan } from "./registration";
+import type { AnyCommand } from "./types";
+
+const command = (name: string, registration?: AnyCommand["registration"]): AnyCommand => ({
+	name,
+	description: `${name} command`,
+	registration,
+	run: () => {},
+});
+
+const commandNames = (commands: readonly unknown[]) => (commands as readonly { name: string }[]).map((entry) => entry.name);
+
+describe("registration planning", () => {
+	test("defaults to global sync", () => {
+		const plan = createRegistrationPlan([command("ping")]);
+
+		expect(plan.operations).toHaveLength(1);
+		expect(plan.operations[0]).toMatchObject({ scope: "global", mode: "sync" });
+		expect(commandNames(plan.operations[0]?.commands ?? [])).toEqual(["ping"]);
+	});
+
+	test("plans global clear", () => {
+		const plan = createRegistrationPlan([command("ping")], { global: "clear" });
+
+		expect(plan.operations).toEqual([{ scope: "global", mode: "clear", commands: [] }]);
+	});
+
+	test("plans guild sync", () => {
+		const plan = createRegistrationPlan([command("ping")], { guilds: ["guild-1"] });
+
+		expect(plan.operations).toHaveLength(1);
+		expect(plan.operations[0]).toMatchObject({ scope: "guild", guildId: "guild-1", mode: "sync" });
+		expect(commandNames(plan.operations[0]?.commands ?? [])).toEqual(["ping"]);
+	});
+
+	test("plans guild clear", () => {
+		const plan = createRegistrationPlan([command("ping")], { guilds: [{ id: "guild-1", mode: "clear" }] });
+
+		expect(plan.operations).toEqual([{ scope: "guild", guildId: "guild-1", mode: "clear", commands: [] }]);
+	});
+
+	test("plans combined global and guild sync", () => {
+		const plan = createRegistrationPlan([command("ping")], { global: "sync", guilds: ["guild-1"] });
+
+		expect(plan.operations.map((operation) => operation.scope)).toEqual(["global", "guild"]);
+		expect(plan.operations[1]).toMatchObject({ scope: "guild", guildId: "guild-1", mode: "sync" });
+	});
+
+	test("does not touch ignored or omitted scopes", () => {
+		const ignored = createRegistrationPlan([command("ping")], { global: "ignore", guilds: [{ id: "guild-1", mode: "ignore" }] });
+		const omittedGlobal = createRegistrationPlan([command("ping")], { guilds: ["guild-1"] });
+
+		expect(ignored.operations).toEqual([]);
+		expect(omittedGlobal.operations.some((operation) => operation.scope === "global")).toBe(false);
+	});
+
+	test("supports guild-only command registration", () => {
+		const plan = createRegistrationPlan([command("public"), command("admin", { global: false, guilds: ["guild-1"] })], {
+			global: "sync",
+			guilds: ["guild-1", "guild-2"],
+		});
+
+		expect(commandNames(plan.operations[0]?.commands ?? [])).toEqual(["public"]);
+		expect(commandNames(plan.operations[1]?.commands ?? [])).toEqual(["public", "admin"]);
+		expect(commandNames(plan.operations[2]?.commands ?? [])).toEqual(["public"]);
+	});
+
+	test("registration false excludes command from all auto-registration scopes", () => {
+		const plan = createRegistrationPlan([command("runtime-only", false)], { global: "sync", guilds: ["guild-1"] });
+
+		expect(plan.operations.every((operation) => operation.commands.length === 0)).toBe(true);
+	});
+});

--- a/packages/core/src/registration.ts
+++ b/packages/core/src/registration.ts
@@ -1,0 +1,116 @@
+import type { ApplicationCommandDataResolvable } from "discord.js";
+import { buildOptionsData } from "./options";
+import type { AnyCommand } from "./types";
+
+export type RegistrationScopeMode = "sync" | "clear" | "ignore";
+
+export type RegistrationScopeConfig = RegistrationScopeMode | { mode: RegistrationScopeMode };
+
+export type RegistrationGuildScopeConfig = string | { id: string; mode?: RegistrationScopeMode };
+
+export type CommandGuildRegistrationConfig =
+	| boolean
+	| readonly string[]
+	| {
+			include?: readonly string[];
+			exclude?: readonly string[];
+	  };
+
+export type CommandRegistrationConfig =
+	| false
+	| {
+			global?: boolean;
+			guilds?: CommandGuildRegistrationConfig;
+	  };
+
+export type HandlerRegistrationConfig =
+	| false
+	| {
+			enabled?: boolean;
+			global?: RegistrationScopeConfig;
+			guilds?: readonly RegistrationGuildScopeConfig[];
+	  };
+
+export type RegistrationPlanOperation =
+	| {
+			scope: "global";
+			mode: "sync" | "clear";
+			commands: ApplicationCommandDataResolvable[];
+	  }
+	| {
+			scope: "guild";
+			guildId: string;
+			mode: "sync" | "clear";
+			commands: ApplicationCommandDataResolvable[];
+	  };
+
+export interface RegistrationPlan {
+	operations: RegistrationPlanOperation[];
+}
+
+export function createRegistrationPlan(commands: readonly AnyCommand[], registration?: HandlerRegistrationConfig): RegistrationPlan {
+	const scopes = resolveManagedScopes(registration);
+	return {
+		operations: scopes.map((scope) => {
+			if (scope.mode === "clear") {
+				return scope.scope === "global" ? { scope: "global", mode: "clear", commands: [] } : { scope: "guild", guildId: scope.guildId, mode: "clear", commands: [] };
+			}
+			const data = commands.filter((command) => commandIncludedInScope(command.registration, scope)).map(commandToApplicationData);
+			return scope.scope === "global" ? { scope: "global", mode: "sync", commands: data } : { scope: "guild", guildId: scope.guildId, mode: "sync", commands: data };
+		}),
+	};
+}
+
+type ManagedScope = { scope: "global"; mode: "sync" | "clear" } | { scope: "guild"; guildId: string; mode: "sync" | "clear" };
+
+type SyncScope = { scope: "global" } | { scope: "guild"; guildId: string };
+
+function resolveManagedScopes(registration?: HandlerRegistrationConfig): ManagedScope[] {
+	if (registration === false || registration?.enabled === false) return [];
+	if (registration === undefined) return [{ scope: "global", mode: "sync" }];
+
+	const scopes: ManagedScope[] = [];
+	if (registration.global !== undefined) {
+		const mode = resolveScopeMode(registration.global);
+		if (mode !== "ignore") scopes.push({ scope: "global", mode });
+	}
+
+	for (const guild of registration.guilds ?? []) {
+		const id = typeof guild === "string" ? guild : guild.id;
+		const mode = typeof guild === "string" ? "sync" : (guild.mode ?? "sync");
+		if (mode !== "ignore") scopes.push({ scope: "guild", guildId: id, mode });
+	}
+
+	return scopes;
+}
+
+function resolveScopeMode(config: RegistrationScopeConfig): RegistrationScopeMode {
+	return typeof config === "string" ? config : config.mode;
+}
+
+function commandsMatchGuildConfig(config: CommandGuildRegistrationConfig | undefined, guildId: string): boolean {
+	if (config === undefined) return true;
+	if (typeof config === "boolean") return config;
+	if (isGuildList(config)) return config.includes(guildId);
+	if (config.exclude?.includes(guildId)) return false;
+	if (config.include) return config.include.includes(guildId);
+	return true;
+}
+
+function isGuildList(config: CommandGuildRegistrationConfig): config is readonly string[] {
+	return Array.isArray(config);
+}
+
+function commandIncludedInScope(registration: CommandRegistrationConfig | undefined, scope: SyncScope): boolean {
+	if (registration === false) return false;
+	if (scope.scope === "global") return registration?.global ?? true;
+	return commandsMatchGuildConfig(registration?.guilds, scope.guildId);
+}
+
+function commandToApplicationData(command: AnyCommand): ApplicationCommandDataResolvable {
+	return {
+		name: command.name,
+		description: command.description,
+		options: buildOptionsData(command.options),
+	} as unknown as ApplicationCommandDataResolvable;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,7 @@ import type { ChatInputCommandInteraction, Client, Guild, GuildMember, Message, 
 import type { CacheAdapter, CooldownConfig } from "./cooldowns";
 import type { CommandOptions, ResolveOptions } from "./options";
 import type { PluginManifest } from "./plugin";
+import type { CommandRegistrationConfig, HandlerRegistrationConfig } from "./registration";
 import type { Storage } from "./storage";
 import type { CanRunCommand, Validator } from "./validators";
 
@@ -50,6 +51,8 @@ export interface Command<S extends CommandOptions = Record<string, never>> {
 	validators?: readonly Validator[];
 	cooldown?: CooldownConfig;
 	legacy?: CommandLegacyConfig;
+	/** Controls whether this command is included in handler-managed Discord registration scopes. */
+	registration?: CommandRegistrationConfig;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous command list erases the schema generic
@@ -84,6 +87,8 @@ export interface CommandHandlerOptions {
 	validators?: readonly Validator[];
 	canRunCommand?: CanRunCommand;
 	plugins?: PluginManifest[];
+	/** Discord application command registration plan. Defaults to syncing global commands. Pass false to disable. */
+	registration?: HandlerRegistrationConfig;
 	cacheAdapter?: CacheAdapter;
 	legacy?: HandlerLegacyConfig;
 	/** Persistent storage adapter for enabled framework features. */

--- a/packages/create-djs-commands/src/templates.ts
+++ b/packages/create-djs-commands/src/templates.ts
@@ -140,7 +140,8 @@ const client = new Client({ intents: [${intents.join(", ")}] });
 
 const handler = createCommandHandler({
 \tclient,
-\tcommandDir: ${dirImport},${storageOption}${legacyOption}${storageFeaturesOption}
+\tcommandDir: ${dirImport},
+\tregistration: { global: "sync" },${storageOption}${legacyOption}${storageFeaturesOption}
 });
 
 handler.ready.catch((err) => {


### PR DESCRIPTION
## Summary
- add explicit global/guild registration planning with sync, clear, ignore, and registration disable
- apply scoped registration after boot so fs-loaded and plugin commands are included
- add docs, migration guidance, and generated project registration example

## Test plan
- bun run check
- bun run typecheck
- bun run test

Closes #141