### PR TITLE
fix(core): avoid deprecated ephemeral reply option

### DIFF
--- a/.changeset/ephemeral-flags.md
+++ b/.changeset/ephemeral-flags.md
@@ -1,0 +1,5 @@
+---
+"@djs-commands/core": patch
+---
+
+Replace deprecated `ephemeral` response examples with `MessageFlags.Ephemeral` and stop advertising the deprecated option on the command reply helper type.

--- a/apps/docs/content/pages/api-reference/core/define-command.mdx
+++ b/apps/docs/content/pages/api-reference/core/define-command.mdx
@@ -76,7 +76,7 @@ interface BaseRunContext<S> {
 	channel: TextBasedChannel | null;
 	channelId: string | null;
 	options: ResolveOptions<S>;
-	reply: (content: string | { content?: string; ephemeral?: boolean }) => Promise<unknown>;
+	reply: (content: CommandReplyInput) => Promise<unknown>; // use flags: MessageFlags.Ephemeral for ephemeral slash replies
 }
 ```
 
@@ -105,9 +105,11 @@ type LegacyRunContext<S> = BaseRunContext<S> & {
 The legacy-prefix branch — `message` is the raw discord.js message.
 
 ```ts
+import { MessageFlags } from "discord.js";
+
 run: async (ctx) => {
 	if (ctx.type === "slash") {
-		await ctx.interaction.deferReply({ ephemeral: true });
+		await ctx.interaction.deferReply({ flags: MessageFlags.Ephemeral });
 	}
 	await ctx.reply("hi");
 }

--- a/apps/docs/content/pages/concepts/commands.mdx
+++ b/apps/docs/content/pages/concepts/commands.mdx
@@ -60,7 +60,7 @@ interface BaseRunContext {
 	channel: TextBasedChannel | null;
 	channelId: string | null;
 	options: ResolveOptions<S>; // typed from your `options` schema
-	reply: (content: string | { content?: string; ephemeral?: boolean }) => Promise<unknown>;
+	reply: (content: CommandReplyInput) => Promise<unknown>; // use flags: MessageFlags.Ephemeral for ephemeral slash replies
 }
 
 type SlashRunContext = BaseRunContext & { type: "slash"; interaction: ChatInputCommandInteraction };
@@ -70,9 +70,11 @@ type LegacyRunContext = BaseRunContext & { type: "legacy"; message: Message };
 When you need source-specific behavior, narrow on `ctx.type`:
 
 ```ts
+import { MessageFlags } from "discord.js";
+
 run: async (ctx) => {
 	if (ctx.type === "slash") {
-		await ctx.interaction.deferReply({ ephemeral: true });
+		await ctx.interaction.deferReply({ flags: MessageFlags.Ephemeral });
 	}
 	await ctx.reply("hi");
 }

--- a/apps/docs/content/pages/migration-from-v1/validators.mdx
+++ b/apps/docs/content/pages/migration-from-v1/validators.mdx
@@ -64,12 +64,14 @@ The framework runs both when `storageFeatures.channelLocks` is enabled: a comman
 
 ```ts
 // v1 — registered through `customValidations`
+import { MessageFlags } from "discord.js";
+
 new CommandHandler({
     client,
     customValidations: [
         ({ command, interaction }) => {
             if (command.beta && !isBetaUser(interaction.user.id)) {
-                interaction.reply({ content: "Beta only", ephemeral: true });
+                interaction.reply({ content: "Beta only", flags: MessageFlags.Ephemeral });
                 return false;
             }
             return true;

--- a/apps/docs/content/pages/recipes/index.mdx
+++ b/apps/docs/content/pages/recipes/index.mdx
@@ -84,12 +84,14 @@ defineCommand({
 });
 
 // Wire submission handling on the discord.js client itself:
+import { MessageFlags } from "discord.js";
+
 client.on("interactionCreate", async (i) => {
 	if (!i.isModalSubmit() || i.customId !== "feedback-modal") return;
 	const subject = i.fields.getTextInputValue("subject");
 	const body = i.fields.getTextInputValue("body");
 	// store, log, post to a channel...
-	await i.reply({ content: "Thanks!", ephemeral: true });
+	await i.reply({ content: "Thanks!", flags: MessageFlags.Ephemeral });
 });
 ```
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,7 @@ export type {
 	CommandHandler,
 	CommandHandlerOptions,
 	CommandLegacyConfig,
+	CommandReplyInput,
 	CommandRun,
 	CommandRunContext,
 	HandlerLegacyConfig,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,15 @@
-import type { ChatInputCommandInteraction, Client, Guild, GuildMember, Message, PermissionsString, TextBasedChannel, User } from "discord.js";
+import type {
+	ChatInputCommandInteraction,
+	Client,
+	Guild,
+	GuildMember,
+	InteractionReplyOptions,
+	Message,
+	MessageReplyOptions,
+	PermissionsString,
+	TextBasedChannel,
+	User,
+} from "discord.js";
 import type { CacheAdapter, CooldownConfig } from "./cooldowns";
 import type { CommandOptions, ResolveOptions } from "./options";
 import type { PluginManifest } from "./plugin";
@@ -7,6 +18,8 @@ import type { Storage } from "./storage";
 import type { CanRunCommand, Validator } from "./validators";
 
 /** Shared fields available to both slash and legacy command runs. */
+export type CommandReplyInput = string | Omit<InteractionReplyOptions, "ephemeral"> | MessageReplyOptions;
+
 interface BaseRunContext<S extends CommandOptions = Record<string, never>> {
 	/** Discord.js client that received the command. */
 	client: Client;
@@ -22,8 +35,8 @@ interface BaseRunContext<S extends CommandOptions = Record<string, never>> {
 	channelId: string | null;
 	/** Typed option values resolved from slash options or legacy positional args. */
 	options: ResolveOptions<S>;
-	/** Convenience reply helper for slash interactions and legacy messages. */
-	reply: (content: string | { content?: string; ephemeral?: boolean; [key: string]: unknown }) => Promise<unknown>;
+	/** Convenience reply helper for slash interactions and legacy messages. Use `flags: MessageFlags.Ephemeral` for ephemeral slash replies. */
+	reply: (content: CommandReplyInput) => Promise<unknown>;
 }
 
 /** Command context for slash-command invocations. Narrow with `ctx.type === "slash"`. */


### PR DESCRIPTION
## Summary

- Remove deprecated `ephemeral` guidance from public docs snippets.
- Export `CommandReplyInput` and remove the deprecated `ephemeral` option from the command reply helper type.
- Point examples at `flags: MessageFlags.Ephemeral`.
- Add a patch changeset for the core package.

## Test Plan

- `bun run check`
- `bun run typecheck` from `packages/core`
- commit hook: `biome check` and `turbo typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference, concepts guides, and recipe examples to demonstrate the new pattern for configuring ephemeral message replies.

* **New Features**
  * Exported command reply input type for use in custom command implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->