### PR TITLE
docs: update current release wording to v3

### DIFF
--- a/.changeset/v3-docs-wording.md
+++ b/.changeset/v3-docs-wording.md
@@ -1,0 +1,5 @@
+---
+"create-djs-commands": patch
+---
+
+Update scaffolded package versions and public docs wording for the v3 release line.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://djscommands.deoxy.dev">Docs</a> ·
   <a href="https://djscommands.deoxy.dev/getting-started">Quick start</a> ·
-  <a href="https://djscommands.deoxy.dev/migration-from-v1">v1 → v2 migration</a> ·
+  <a href="https://djscommands.deoxy.dev/migration-from-v1">v1 → v3 migration</a> ·
   <a href="https://www.npmjs.com/org/djs-commands">NPM</a>
 </p>
 
@@ -21,7 +21,7 @@
 
 ## Coming from v1 (`@d3oxy/djs-commands`)?
 
-The v1 package is preserved at the [`v1-final-commit` tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and stays on npm under `@d3oxy/djs-commands@1.4.x`. To upgrade to v2, follow the [Migration from v1](https://djscommands.deoxy.dev/migration-from-v1) guide — every v1 API has a v2 equivalent (with side-by-side examples).
+The v1 package is preserved at the [`v1-final-commit` tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and stays on npm under `@d3oxy/djs-commands@1.4.x`. To upgrade to v3, follow the [Migration from v1](https://djscommands.deoxy.dev/migration-from-v1) guide — every v1 API has a v3 equivalent (with side-by-side examples).
 
 ## Quick start
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-This repo ships v2.x of `@djs-commands/*` packages via [Changesets](https://github.com/changesets/changesets) + GitHub Actions, authenticating to npm via [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) (OIDC). No long-lived `NPM_TOKEN` secret is required.
+This repo ships v3.x of `@djs-commands/*` packages via [Changesets](https://github.com/changesets/changesets) + GitHub Actions, authenticating to npm via [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) (OIDC). No long-lived `NPM_TOKEN` secret is required.
 
 ## Day-to-day flow
 
@@ -73,13 +73,13 @@ You'll need to be logged in via `npm login` and have publish access. Note that p
 
 ## v1 sunset
 
-After v2.0.0 publishes successfully, the maintainer also handles the v1 deprecation (these are one-way actions, not automated):
+After the current major publishes successfully, the maintainer also handles the v1 deprecation (these are one-way actions, not automated):
 
 ```bash
 # Final v1 maintenance release (replaces README with deprecation notice)
 git checkout v1-final-commit
 git switch -c v1-maintenance
-# … edit packages/v1's README.md to point at v2 …
+# … edit packages/v1's README.md to point at v3 …
 npm version patch       # bumps to 1.4.11 or similar
 npm publish --access public
 
@@ -87,7 +87,7 @@ npm publish --access public
 npm deprecate '@d3oxy/djs-commands@<2' '@d3oxy/djs-commands is unmaintained. Migrate to @djs-commands/core — see https://djscommands.deoxy.dev/migration-from-v1'
 
 # Update the GitHub repo description to mention the new package name
-# Open and pin a GitHub issue announcing v2
+# Open and pin a GitHub issue announcing the current major
 ```
 
 These steps are spelled out in [slice #67](https://github.com/D3OXY/djs-commands/issues/67).

--- a/apps/docs/content/pages/concepts/index.mdx
+++ b/apps/docs/content/pages/concepts/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Concepts
-description: The mental model behind DJS Commands v2.
+description: The mental model behind DJS Commands v3.
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";

--- a/apps/docs/content/pages/getting-started/index.mdx
+++ b/apps/docs/content/pages/getting-started/index.mdx
@@ -20,7 +20,7 @@ bun run dev
 The CLI scaffolds the directory layout, `tsconfig.json`, `.env.example`, and a working `/ping` command. Pick one of the templates (minimal, components-v2 showcase, or moderation with Drizzle) and you're online in under a minute.
 
 <Callout type="info">
-DJS Commands v2 targets Discord.js v14.26+ and Node.js 22+. Bun 1.2+ is supported and is the development runtime used by the maintainers.
+DJS Commands v3 targets Discord.js v14.26+ and Node.js 22+. Bun 1.2+ is supported and is the development runtime used by the maintainers.
 </Callout>
 
 <Cards>

--- a/apps/docs/content/pages/getting-started/installation.mdx
+++ b/apps/docs/content/pages/getting-started/installation.mdx
@@ -81,7 +81,7 @@ yarn add @djs-commands/core
 </Tabs>
 
 <Callout type="warn">
-v2 is published to the new `@djs-commands` npm organization. The legacy v1 package (`@d3oxy/djs-commands`) is **not** API-compatible — see the [v1 → v2 migration notes](/getting-started/your-first-command#what-changed-from-v1) once you're ready.
+v3 is published to the `@djs-commands` npm organization. The legacy v1 package (`@d3oxy/djs-commands`) is **not** API-compatible — see the [v1 → v3 migration notes](/migration-from-v1) once you're ready.
 </Callout>
 
 </Step>

--- a/apps/docs/content/pages/index.mdx
+++ b/apps/docs/content/pages/index.mdx
@@ -34,7 +34,7 @@ import { ArrowRight, ArrowUpRight, Boxes, Database, Eye, FileCode, Layers, Plug,
 				<span className="absolute inline-flex size-full rounded-full bg-[#67E8F9] opacity-60 animate-ping" />
 				<span className="relative inline-flex size-1.5 rounded-full bg-[#67E8F9]" />
 			</span>
-			v2.0 · live on NPM
+			v3.0 · live on NPM
 		</div>
 
 		<h1 className="text-[2.5rem] sm:text-6xl lg:text-7xl xl:text-[5.5rem] font-black tracking-[-0.04em] leading-[0.95] mb-7 text-fd-foreground">
@@ -244,12 +244,12 @@ export default defineCommand({
 		<div className="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-white/[0.04] to-transparent p-8 sm:p-10">
 			<div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-6 items-center">
 				<div>
-					<p className="text-[11px] uppercase tracking-[0.25em] text-fd-muted-foreground/60 mb-3 font-mono">— v1 → v2</p>
+					<p className="text-[11px] uppercase tracking-[0.25em] text-fd-muted-foreground/60 mb-3 font-mono">— v1 → v3</p>
 					<h3 className="text-2xl sm:text-3xl font-black tracking-[-0.02em] mb-3">
 						Coming from <code className="font-mono text-[0.85em] text-[#7C3AED]">@d3oxy/djs-commands</code>?
 					</h3>
 					<p className="text-base text-fd-muted-foreground leading-relaxed max-w-xl">
-						Every v1 API has a v2 equivalent. The migration guide walks through every option that moved or was dropped — with side-by-side examples.
+						Every v1 API has a v3 equivalent. The migration guide walks through every option that moved or was dropped — with side-by-side examples.
 					</p>
 				</div>
 				<a

--- a/apps/docs/content/pages/migration-from-v1/commands.mdx
+++ b/apps/docs/content/pages/migration-from-v1/commands.mdx
@@ -5,7 +5,7 @@ description: CommandType.SLASH/LEGACY/BOTH and callback(usage) become defineComm
 
 # Command files
 
-v1 used `CommandType.SLASH | LEGACY | BOTH` and a `callback(usage)` shape. v2 unifies everything under `defineCommand`. The same `defineCommand` serves slash invocations, prefix invocations, or both.
+v1 used `CommandType.SLASH | LEGACY | BOTH` and a `callback(usage)` shape. v3 unifies everything under `defineCommand`. The same `defineCommand` serves slash invocations, prefix invocations, or both.
 
 ## Slash command
 
@@ -23,7 +23,7 @@ module.exports = {
 ```
 
 ```ts
-// v2 — commands/ping.ts
+// v3 — commands/ping.ts
 import { defineCommand } from "@djs-commands/core";
 
 export default defineCommand({
@@ -40,7 +40,7 @@ The big shifts:
 - `module.exports = { … }` → `export default defineCommand({ … })`. The wrapper is just an identity function for type inference.
 - `callback(usage)` → `run(ctx)`. The `ctx` is normalized — `ctx.reply(...)` works for both slash and legacy invocations.
 - Slash is the default; you don't need a `type` flag.
-- Filename → command name in v1 was implicit; v2 is explicit (`name: "ping"`).
+- Filename → command name in v1 was implicit; v3 is explicit (`name: "ping"`).
 
 ## Slash + legacy from one definition
 
@@ -59,7 +59,7 @@ module.exports = {
 ```
 
 ```ts
-// v2 — commands/ping.ts
+// v3 — commands/ping.ts
 export default defineCommand({
     name: "ping",
     description: "Replies with pong",
@@ -83,7 +83,7 @@ run: async (ctx) => {
 
 ## Typed options
 
-v1 didn't infer types for command arguments. v2 does — `options.user` is typed as `User`, `options.message` is typed as `string`, choices narrow to literal unions.
+v1 didn't infer types for command arguments. v3 does — `options.user` is typed as `User`, `options.message` is typed as `string`, choices narrow to literal unions.
 
 ```ts
 // v1 — manually pulled args from `usage.args` (string[])
@@ -99,7 +99,7 @@ module.exports = {
 ```
 
 ```ts
-// v2 — schema is the source of truth, run handler args inferred
+// v3 — schema is the source of truth, run handler args inferred
 export default defineCommand({
     name: "echo",
     description: "Echo a message",
@@ -117,7 +117,7 @@ In legacy mode, arguments are auto-parsed from the message text using the same s
 
 ## Cooldowns
 
-v1 had a global `cooldownConfig` plus per-command cooldown declarations. v2 is per-command only:
+v1 had a global `cooldownConfig` plus per-command cooldown declarations. v3 is per-command only:
 
 ```ts
 // v1
@@ -130,7 +130,7 @@ module.exports = {
 ```
 
 ```ts
-// v2
+// v3
 export default defineCommand({
     name: "ping",
     description: "…",

--- a/apps/docs/content/pages/migration-from-v1/dropped-features.mdx
+++ b/apps/docs/content/pages/migration-from-v1/dropped-features.mdx
@@ -5,7 +5,7 @@ description: What didn't make the cut and why
 
 # Dropped features
 
-These features existed in v1 and intentionally don't ship in v2. Each section explains the rationale and the recommended replacement.
+These features existed in v1 and intentionally don't ship in v3. Each section explains the rationale and the recommended replacement.
 
 ## Custom commands (user-defined runtime slash commands)
 
@@ -13,7 +13,7 @@ v1 had a `custom-command-schema` and built-in `/customcommand` admin command tha
 
 **Why dropped**: it's a whole feature inside a feature. It complicates persistence (every adapter would have to support it), it's a moderate fraction of v1's surface area, and most users either built their own version with richer behavior or never used it at all.
 
-**Replacement**: build it yourself on top of v2 if you need it. Define an admin command (`/define`) that writes to your own table and dynamically registers handlers via your application logic. Your data shape, your UI.
+**Replacement**: build it yourself on top of v3 if you need it. Define an admin command (`/define`) that writes to your own table and dynamically registers handlers via your application logic. Your data shape, your UI.
 
 ## Built-in default admin commands
 
@@ -73,6 +73,6 @@ Guild sync is useful for private single-server bots and fast iteration, not only
 
 v1 had a magic 300-second threshold above which cooldowns were persisted to MongoDB and below which they were in-memory.
 
-**Why dropped**: it was a heuristic that pleased no one. v2 makes it explicit: in-memory by default; provide `cacheAdapter` (e.g. `@djs-commands/adapter-redis`) if you want distributed cooldowns regardless of duration.
+**Why dropped**: it was a heuristic that pleased no one. v3 makes it explicit: in-memory by default; provide `cacheAdapter` (e.g. `@djs-commands/adapter-redis`) if you want distributed cooldowns regardless of duration.
 
 **Replacement**: `cacheAdapter: redisCacheAdapter(redis)` from `@djs-commands/adapter-redis`.

--- a/apps/docs/content/pages/migration-from-v1/events-and-plugins.mdx
+++ b/apps/docs/content/pages/migration-from-v1/events-and-plugins.mdx
@@ -18,7 +18,7 @@ module.exports = (client) => {
 ```
 
 ```ts
-// v2 — events/ready.ts
+// v3 — events/ready.ts
 import { defineEvent } from "@djs-commands/core";
 
 export default defineEvent({
@@ -54,7 +54,7 @@ module.exports = (commandHandler, client) => {
 ```
 
 ```ts
-// v2 — plugins/leveling.ts
+// v3 — plugins/leveling.ts
 import { defineCommand, type PluginManifest } from "@djs-commands/core";
 
 interface LevelingOptions {
@@ -92,4 +92,4 @@ Why this is better:
 
 ## Hot reload
 
-v2's fs-autoloader watches `commandDir` and re-imports files on change in dev mode (`NODE_ENV !== "production"`). v1 required a full restart on every command change. No code changes needed to opt in — it just works.
+v3's fs-autoloader watches `commandDir` and re-imports files on change in dev mode (`NODE_ENV !== "production"`). v1 required a full restart on every command change. No code changes needed to opt in — it just works.

--- a/apps/docs/content/pages/migration-from-v1/handler.mdx
+++ b/apps/docs/content/pages/migration-from-v1/handler.mdx
@@ -1,13 +1,13 @@
 ---
 title: Handler options
-description: Mapping every v1 CommandHandler option to v2
+description: Mapping every v1 CommandHandler option to v3
 ---
 
 # Handler options
 
-Every option you passed to `new CommandHandler({ … })` in v1 has a mapping in v2.
+Every option you passed to `new CommandHandler({ … })` in v1 has a mapping in v3.
 
-| v1 option | v2 equivalent |
+| v1 option | v3 equivalent |
 |---|---|
 | `client` | `client` (unchanged) |
 | `mongoUri` | Own a Mongoose connection/model and pass mapped `storage` from `@djs-commands/adapter-mongoose` |
@@ -53,7 +53,7 @@ client.login(process.env.TOKEN);
 ```
 
 ```ts
-// v2
+// v3
 import { createCommandHandler } from "@djs-commands/core";
 import { Client, GatewayIntentBits } from "discord.js";
 import { fileURLToPath } from "node:url";
@@ -74,7 +74,7 @@ createCommandHandler({
     eventDir: fileURLToPath(new URL("./events", import.meta.url)),
     legacy: { enabled: true, defaultPrefix: "!" },
     botOwners: ["123…"],
-    // cooldowns are per-command in v2 — no global config
+    // cooldowns are per-command in v3 — no global config
 });
 
 await client.login(process.env.TOKEN!);
@@ -82,7 +82,7 @@ await client.login(process.env.TOKEN!);
 
 Notes:
 
-- v2 doesn't wait for `ready` to wire up — you call `createCommandHandler` synchronously after constructing the `Client`.
-- v2's `commandDir` accepts a path string. We use `fileURLToPath(new URL(...))` so it works under both Bun and Node + tsx; v1's `path.join(__dirname, ...)` worked because v1 was CJS — v2 is ESM.
+- v3 doesn't wait for `ready` to wire up — you call `createCommandHandler` synchronously after constructing the `Client`.
+- v3's `commandDir` accepts a path string. We use `fileURLToPath(new URL(...))` so it works under both Bun and Node + tsx; v1's `path.join(__dirname, ...)` worked because v1 was CJS — v3 is ESM.
 - `cooldownConfig.dbRequired` (v1's "use DB if duration ≥ 5min") doesn't exist. Cooldowns default to in-memory; provide a `cacheAdapter` (e.g. `@djs-commands/adapter-redis`) for distributed cooldowns.
 - Guild registration is no longer described as only testing. Use guild sync for private single-server bots or fast iteration; use global sync for public rollout.

--- a/apps/docs/content/pages/migration-from-v1/index.mdx
+++ b/apps/docs/content/pages/migration-from-v1/index.mdx
@@ -5,7 +5,7 @@ description: A guide for upgrading bots from @d3oxy/djs-commands to @djs-command
 
 # Migrating from v1
 
-If you're coming from `@d3oxy/djs-commands` (v1), this guide walks you through every API that moved, renamed, or was dropped in v2.
+If you're coming from `@d3oxy/djs-commands` (v1), this guide walks you through every API that moved, renamed, or was dropped in v3.
 
 ## TL;DR
 
@@ -13,7 +13,7 @@ If you're coming from `@d3oxy/djs-commands` (v1), this guide walks you through e
 # 1. Remove the old package
 bun remove @d3oxy/djs-commands
 
-# 2. Install v2 packages
+# 2. Install v3 packages
 bun add @djs-commands/core discord.js
 # Optional based on your stack:
 bun add @djs-commands/adapter-mongoose mongoose  # if you used mongoUri in v1
@@ -39,7 +39,7 @@ new CommandHandler({
 ```
 
 ```ts
-// v2
+// v3
 import { createCommandHandler } from "@djs-commands/core";
 import { fileURLToPath } from "node:url";
 import { storage } from "./storage";
@@ -56,7 +56,7 @@ createCommandHandler({
 
 ## What's in this section
 
-- [Handler options](/migration-from-v1/handler) — every `CommandHandler` option mapped to v2
+- [Handler options](/migration-from-v1/handler) — every `CommandHandler` option mapped to v3
 - [Command files](/migration-from-v1/commands) — `CommandType`, `callback(usage)` → unified `defineCommand`
 - [Validators](/migration-from-v1/validators) — `requiredPermissions` / `requiredRoles` / `ownerOnly` / `guildOnly` / `channelOnly`
 - [Persistence](/migration-from-v1/persistence) — Mongoose schemas → Storage adapters
@@ -65,4 +65,4 @@ createCommandHandler({
 
 ## Why the rewrite
 
-v1 was unmaintained since late 2023. Discord shipped Components V2, polls, voice messages, user-installable apps, and ~18 months of API surface that v1 couldn't reach. v2 is built on `discord.js@^14.26`, ships first-class Components V2 via `@djs-commands/jsx`, drops the Mongoose lock-in, and is structured for the upcoming discord.js v15. v1 stays on npm at `@d3oxy/djs-commands@1.4.x` for bots that aren't ready to upgrade — it just won't get new features.
+v1 was unmaintained since late 2023. Discord shipped Components V2, polls, voice messages, user-installable apps, and ~18 months of API surface that v1 couldn't reach. v3 is built on `discord.js@^14.26`, ships first-class Components V2 via `@djs-commands/jsx`, drops the Mongoose lock-in, and is structured for the upcoming discord.js v15. v1 stays on npm at `@d3oxy/djs-commands@1.4.x` for bots that aren't ready to upgrade — it just won't get new features.

--- a/apps/docs/content/pages/migration-from-v1/persistence.mdx
+++ b/apps/docs/content/pages/migration-from-v1/persistence.mdx
@@ -5,7 +5,7 @@ description: Mongoose schemas → Storage adapters
 
 # Persistence
 
-v1 baked Mongoose into the framework with 7 hardcoded schemas. v2 splits storage out behind a generic `Storage` contract — pick `@djs-commands/adapter-drizzle`, `@djs-commands/adapter-prisma`, or `@djs-commands/adapter-mongoose` (the v1 continuity path).
+v1 baked Mongoose into the framework with 7 hardcoded schemas. v3 splits storage out behind a generic `Storage` contract — pick `@djs-commands/adapter-drizzle`, `@djs-commands/adapter-prisma`, or `@djs-commands/adapter-mongoose` (the v1 continuity path).
 
 ## Mongoose continuity
 
@@ -29,7 +29,7 @@ Define your own Mongoose schemas/models, then map framework logical fields in `m
 
 ## Schema mapping
 
-| v1 collection | v2 model | What changed |
+| v1 collection | v3 model | What changed |
 |---|---|---|
 | `cooldowns` | (in-memory + optional `CacheAdapter`) | Cooldowns no longer hit the DB by default. Use `@djs-commands/adapter-redis` for sharded bots. |
 | `guild-prefix-schema` | `GuildPrefixModel` | Resolved when `storageFeatures.guildPrefixes` is enabled. It defaults from `legacy.enabled`, but can be configured. |
@@ -41,7 +41,7 @@ Define your own Mongoose schemas/models, then map framework logical fields in `m
 
 ## Programmatic prefix / disabled / locks
 
-v1 commands like `/prefix`, `/togglecommand`, `/channelonly` were built into the framework. v2 ships them as helpers so you can build admin commands of your own:
+v1 commands like `/prefix`, `/togglecommand`, `/channelonly` were built into the framework. v3 ships them as helpers so you can build admin commands of your own:
 
 ```ts
 import {

--- a/apps/docs/content/pages/migration-from-v1/validators.mdx
+++ b/apps/docs/content/pages/migration-from-v1/validators.mdx
@@ -5,9 +5,9 @@ description: requiredPermissions / requiredRoles / ownerOnly / guildOnly / chann
 
 # Validators
 
-v1's command-level validation flags map 1:1 to v2 properties on `defineCommand`.
+v1's command-level validation flags map 1:1 to v3 properties on `defineCommand`.
 
-| v1 | v2 |
+| v1 | v3 |
 |---|---|
 | `requiredPermissions: ["BanMembers"]` | `permissions: ["BanMembers"]` |
 | `requiredRoles: ["role-id-1"]` | `roles: ["role-id-1"]` |
@@ -27,7 +27,7 @@ module.exports = {
 ```
 
 ```ts
-// v2
+// v3
 export default defineCommand({
     name: "ban",
     description: "Ban a user",
@@ -40,7 +40,7 @@ export default defineCommand({
 
 ## Channel locks: static vs dynamic
 
-v1 had a `channels` array on the command (static) and a separate `channel-commands-schema` for runtime channel locks. In v2:
+v1 had a `channels` array on the command (static) and a separate `channel-commands-schema` for runtime channel locks. In v3:
 
 - **Static**: `channels: ["channel-id"]` on `defineCommand` (declared once, in code)
 - **Dynamic**: `ChannelLocks` storage model (per-guild ops control)
@@ -81,7 +81,7 @@ new CommandHandler({
 ```
 
 ```ts
-// v2 — global `validators` or per-command
+// v3 — global `validators` or per-command
 import type { Validator } from "@djs-commands/core";
 
 const betaOnly: Validator = ({ command, user }) => {
@@ -100,7 +100,7 @@ Custom validators return `{ ok: true } | { ok: false, reason: string }`. The fra
 
 ## Dynamic per-invocation gates
 
-v1 didn't have a hook for runtime gating (you'd build one through `customValidations`). v2 has `canRunCommand`:
+v1 didn't have a hook for runtime gating (you'd build one through `customValidations`). v3 has `canRunCommand`:
 
 ```ts
 createCommandHandler({

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -115,7 +115,7 @@ function DocsLayoutWrapper({ children, tree }: DocsLayoutWrapperProps) {
 					<div className="flex items-center gap-2.5">
 						<img src="/logo.png" alt="" aria-hidden="true" className="size-6 rounded-md" />
 						<span className="font-semibold text-[0.95rem] tracking-tight">DJS Commands</span>
-						<span className="font-medium text-fd-muted-foreground text-xs opacity-60">v2 docs</span>
+						<span className="font-medium text-fd-muted-foreground text-xs opacity-60">v3 docs</span>
 					</div>
 				),
 			}}

--- a/examples/components-v2-showcase/src/index.tsx
+++ b/examples/components-v2-showcase/src/index.tsx
@@ -19,7 +19,7 @@ const welcome = defineCommand({
 			flags: MessageFlags.IsComponentsV2,
 			components: render(
 				<Container accentColor={0x5865f2}>
-					<TextDisplay># Welcome to djs-commands v2</TextDisplay>
+					<TextDisplay># Welcome to djs-commands v3</TextDisplay>
 					<Section accessory={<Button style="primary" customId="welcome:open-feedback" label="Send Feedback" />}>
 						Components V2 lets you compose rich messages from layout primitives. Click the button to open a feedback modal.
 					</Section>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -60,7 +60,7 @@ Prefer scaffolding? Run `npx create-djs-commands my-bot` and you're online in un
 
 ## Migrating from v1?
 
-`@d3oxy/djs-commands@1.4.x` is preserved at the [`v1-final-commit` git tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and is no longer maintained. Every v1 API has a v2 equivalent — see the [v1 → v2 migration guide](https://djscommands.deoxy.dev/migration-from-v1).
+`@d3oxy/djs-commands@1.4.x` is preserved at the [`v1-final-commit` git tag](https://github.com/D3OXY/djs-commands/tree/v1-final-commit) and is no longer maintained. Every v1 API has a v3 equivalent — see the [v1 → v3 migration guide](https://djscommands.deoxy.dev/migration-from-v1).
 
 ## License
 

--- a/packages/create-djs-commands/src/templates.ts
+++ b/packages/create-djs-commands/src/templates.ts
@@ -6,11 +6,11 @@ interface FileContent {
 }
 
 const DEPS = {
-	core: "^2.0.0",
-	jsx: "^2.0.0",
-	adapterDrizzle: "^2.0.0",
-	adapterPrisma: "^2.0.0",
-	adapterMongoose: "^2.0.0",
+	core: "^3.0.0",
+	jsx: "^3.0.0",
+	adapterDrizzle: "^3.0.0",
+	adapterPrisma: "^3.0.0",
+	adapterMongoose: "^3.0.0",
 	discordJs: "^14.26.0",
 	drizzleOrm: "^0.36.4",
 	pg: "^8.13.1",


### PR DESCRIPTION
## Summary

- Update current docs and README wording from v2 to v3.
- Update the docs navbar/version badge and v1 migration copy.
- Update `create-djs-commands` scaffolded `@djs-commands/*` package ranges to `^3.0.0`.
- Keep historical changelog/release-bootstrap v2 references and Discord Components V2 wording intact.

## Test Plan

- `bun run check`
- `bun run typecheck`
- `bun test packages/create-djs-commands/src/scaffold.test.ts`
