### PR TITLE
feat(core): add startup summary

### DIFF
--- a/.changeset/startup-log.md
+++ b/.changeset/startup-log.md
@@ -1,0 +1,6 @@
+---
+"@djs-commands/core": minor
+"create-djs-commands": patch
+---
+
+Add a styled DJS Commands startup summary after bot boot and registration, with scaffolded bots relying on the built-in boot output.

--- a/apps/docs/content/pages/api-reference/core/command-handler.mdx
+++ b/apps/docs/content/pages/api-reference/core/command-handler.mdx
@@ -48,6 +48,7 @@ interface CommandHandlerOptions {
 	legacy?: HandlerLegacyConfig;
 	storage?: Storage;
 	storageFeatures?: StorageFeaturesConfig;
+	startupLog?: StartupLogConfig;
 }
 ```
 
@@ -67,6 +68,7 @@ interface CommandHandlerOptions {
 | `legacy` | Master switch + default prefix for legacy invocation. |
 | `storage` | Persistence adapter for enabled framework storage features. |
 | `storageFeatures` | Opt into storage-backed framework features. `guildPrefixes` defaults to `legacy.enabled`; `disabledCommands` and `channelLocks` default to `false`. |
+| `startupLog` | Controls the DJS Commands boot summary printed after the client is ready and registration completes. Defaults to enabled. |
 
 ## `HandlerRegistrationConfig`
 
@@ -162,3 +164,41 @@ interface StorageFeaturesConfig {
 ```
 
 Only enabled features query storage. If an enabled feature needs an unmapped framework model, `handler.ready` rejects.
+
+## `StartupLogConfig`
+
+```ts
+type StartupLogConfig =
+	| boolean
+	| "box"
+	| "line"
+	| {
+			enabled?: boolean;
+			style?: "box" | "line";
+	  };
+```
+
+By default, the handler prints a DJS Commands startup summary after `handler.ready`, Discord `clientReady`, and command registration complete. TTY terminals get a boxed summary; CI and redirected logs get a compact single line.
+
+```txt
+╭─ DJS Commands ─────────────────────────╮
+│ Version       3.0.1                    │
+│ Bot           MyBot#1234               │
+│ Commands      18 loaded                │
+│ Registration  guild sync: 1            │
+│ Legacy        enabled, prefix "!"      │
+│ Storage       configured               │
+│ Cache         memory                   │
+│ Dev           hot reload enabled       │
+╰────────────────────────────────────────╯
+```
+
+Disable it for fully custom logging:
+
+```ts
+createCommandHandler({
+	client,
+	commandDir: "./src/commands",
+	startupLog: false,
+});
+```

--- a/apps/docs/content/pages/concepts/commands.mdx
+++ b/apps/docs/content/pages/concepts/commands.mdx
@@ -139,6 +139,8 @@ await handler.destroy();   // Removes listeners, awaits plugin teardown
 
 `destroy()` does **not** delete the registered application commands from Discord — those persist until you explicitly clear them.
 
+After `handler.ready`, Discord `clientReady`, and command registration complete, DJS Commands prints a startup summary with the package version, bot tag, loaded command count, registration scopes, legacy mode, storage, cache, and dev mode. Pass `startupLog: false` to silence it, or `startupLog: "line"` for compact log output.
+
 ### Registration scopes
 
 Discord has separate global and guild application command scopes. The handler owns only the scopes you configure:

--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
     },
     "packages/adapter-drizzle": {
       "name": "@djs-commands/adapter-drizzle",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "devDependencies": {
         "@djs-commands/core": "workspace:*",
         "@djs-commands/tsconfig": "workspace:*",
@@ -106,7 +106,7 @@
     },
     "packages/adapter-mongoose": {
       "name": "@djs-commands/adapter-mongoose",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "devDependencies": {
         "@djs-commands/core": "workspace:*",
         "@djs-commands/tsconfig": "workspace:*",
@@ -122,7 +122,7 @@
     },
     "packages/adapter-prisma": {
       "name": "@djs-commands/adapter-prisma",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "devDependencies": {
         "@djs-commands/core": "workspace:*",
         "@djs-commands/tsconfig": "workspace:*",
@@ -139,7 +139,7 @@
     },
     "packages/adapter-redis": {
       "name": "@djs-commands/adapter-redis",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "devDependencies": {
         "@djs-commands/core": "workspace:*",
         "@djs-commands/tsconfig": "workspace:*",
@@ -156,7 +156,10 @@
     },
     "packages/core": {
       "name": "@djs-commands/core",
-      "version": "2.0.1",
+      "version": "3.0.0",
+      "dependencies": {
+        "picocolors": "^1.1.1",
+      },
       "devDependencies": {
         "@djs-commands/tsconfig": "workspace:*",
         "@types/bun": "catalog:",
@@ -171,7 +174,7 @@
     },
     "packages/create-djs-commands": {
       "name": "create-djs-commands",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "bin": {
         "create-djs-commands": "dist/cli.js",
       },
@@ -188,7 +191,7 @@
     },
     "packages/jsx": {
       "name": "@djs-commands/jsx",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "devDependencies": {
         "@djs-commands/tsconfig": "workspace:*",
         "@types/bun": "catalog:",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,6 +46,7 @@ Prefer scaffolding? Run `npx create-djs-commands my-bot` and you're online in un
 - **Storage** — user-owned schema for `guild_prefix`, `disabled_commands`, and `channel_locks` framework models. [Docs →](https://djscommands.deoxy.dev/concepts/storage)
 - **Components V2** — function-form builders (`button`, `container`, `section`, `modal`, …); pair with [`@djs-commands/jsx`](https://www.npmjs.com/package/@djs-commands/jsx) for JSX. [Docs →](https://djscommands.deoxy.dev/components-v2)
 - **fs-autoloader** — `commandDir` autoloads files; hot reloads in dev.
+- **Startup summary** — prints a DJS Commands boot banner after registration; set `startupLog: false` for custom logging.
 
 ## Companion packages
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,9 @@
 	"peerDependencies": {
 		"discord.js": "^14.26.0"
 	},
+	"dependencies": {
+		"picocolors": "^1.1.1"
+	},
 	"devDependencies": {
 		"@djs-commands/tsconfig": "workspace:*",
 		"@types/bun": "catalog:",

--- a/packages/core/src/handler-registration.test.ts
+++ b/packages/core/src/handler-registration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -35,9 +35,11 @@ const makeClient = () => {
 	const writableClient = client as unknown as {
 		application: { commands: { set: typeof globalSetMock } };
 		guilds: { fetch: typeof guildFetchMock };
+		user: { tag: string };
 	};
 	writableClient.application = { commands: { set: globalSetMock } };
 	writableClient.guilds = { fetch: guildFetchMock };
+	writableClient.user = { tag: "TestBot#0001" };
 	return { client, globalSetMock, guildFetchMock, guildSetCalls };
 };
 
@@ -50,8 +52,14 @@ const emitReady = async (client: Client): Promise<void> => {
 const namesFromData = (data: unknown): string[] => (data as { name: string }[]).map((entry) => entry.name);
 
 const tempDirs: string[] = [];
+let consoleLogSpy: ReturnType<typeof spyOn> | undefined;
+
+beforeEach(() => {
+	consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+});
 
 afterEach(async () => {
+	consoleLogSpy?.mockRestore();
 	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -109,6 +117,28 @@ describe("handler registration", () => {
 		await emitReady(client);
 
 		expect(namesFromData(globalSetMock.mock.calls[0]?.[0])).toEqual(["base", "from-plugin"]);
+
+		await handler.destroy();
+	});
+
+	test("prints a startup summary after registration", async () => {
+		const { client } = makeClient();
+		const handler = createCommandHandler({
+			client,
+			commands: [command("ping"), command("role")],
+			registration: { guilds: ["guild-1"] },
+			startupLog: "line",
+		});
+		await handler.ready;
+
+		await emitReady(client);
+
+		expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+		const output = String(consoleLogSpy?.mock.calls[0]?.[0]);
+		expect(output).toContain("[djs-commands] ready");
+		expect(output).toContain("bot TestBot#0001");
+		expect(output).toContain("commands 2 loaded");
+		expect(output).toContain("registration guild sync: 1");
 
 		await handler.destroy();
 	});

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -3,6 +3,7 @@ import type { EventDefinition } from "./define-event";
 import { Dispatcher } from "./dispatcher";
 import { loadCommandEntriesFromDir, loadEventsFromDir, type WatchHandle, watchCommandsDir } from "./fs-loader";
 import { createRegistrationPlan, type RegistrationPlan } from "./registration";
+import { formatStartupLog, getCoreVersion } from "./startup-log";
 import { ChannelLocksModel, DisabledCommandsModel, type FrameworkStorageModel, GuildPrefixModel, getGuildPrefix } from "./storage";
 import type { AnyCommand, CommandHandler, CommandHandlerOptions, StorageFeaturesConfig } from "./types";
 
@@ -86,7 +87,19 @@ export function createCommandHandler(options: CommandHandlerOptions): CommandHan
 		if (!client.application) return;
 		readyClient = client;
 		bootPromise
-			.then(() => syncRegistration(client, allCommands, options.registration))
+			.then(async () => {
+				const plan = await syncRegistration(client, allCommands, options.registration);
+				logStartup(client, {
+					cacheConfigured: Boolean(options.cacheAdapter),
+					commandCount: allCommands.length,
+					dev,
+					legacy: { enabled: legacyEnabled, prefix: legacyPrefix },
+					registration: options.registration,
+					registrationPlan: plan,
+					startupLog: options.startupLog,
+					storage: { configured: Boolean(options.storage), features: storageFeatures },
+				});
+			})
 			.catch((err) => {
 				console.error("[djs-commands] Failed to register application commands:", err);
 			});
@@ -232,8 +245,40 @@ async function applyRegistrationPlan(client: Client<true>, plan: RegistrationPla
 	}
 }
 
-async function syncRegistration(client: Client<true>, commands: readonly AnyCommand[], registration: CommandHandlerOptions["registration"]): Promise<void> {
-	await applyRegistrationPlan(client, createRegistrationPlan(commands, registration));
+async function syncRegistration(client: Client<true>, commands: readonly AnyCommand[], registration: CommandHandlerOptions["registration"]): Promise<RegistrationPlan> {
+	const plan = createRegistrationPlan(commands, registration);
+	await applyRegistrationPlan(client, plan);
+	return plan;
+}
+
+function logStartup(
+	client: Client<true>,
+	input: {
+		cacheConfigured: boolean;
+		commandCount: number;
+		dev: boolean;
+		legacy: { enabled: boolean; prefix: string };
+		registration: CommandHandlerOptions["registration"];
+		registrationPlan: RegistrationPlan;
+		startupLog: CommandHandlerOptions["startupLog"];
+		storage: { configured: boolean; features: Required<StorageFeaturesConfig> };
+	}
+): void {
+	const message = formatStartupLog(
+		{
+			bot: client.user?.tag ?? client.user?.id,
+			cacheConfigured: input.cacheConfigured,
+			commandCount: input.commandCount,
+			dev: input.dev,
+			legacy: input.legacy,
+			registration: input.registration,
+			registrationPlan: input.registrationPlan,
+			storage: input.storage,
+			version: getCoreVersion(),
+		},
+		input.startupLog
+	);
+	if (message) console.log(message);
 }
 
 function logRegistrationError(err: unknown): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,8 @@ export type {
 	HandlerLegacyConfig,
 	LegacyRunContext,
 	SlashRunContext,
+	StartupLogConfig,
+	StartupLogStyle,
 	StorageFeaturesConfig,
 } from "./types";
 export type { CanRunCommand, ValidationResult, Validator, ValidatorContext, ValidatorSource } from "./validators";

--- a/packages/core/src/startup-log.test.ts
+++ b/packages/core/src/startup-log.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { formatStartupLog } from "./startup-log";
+
+const baseInput = {
+	bot: "TestBot#0001",
+	cacheConfigured: false,
+	commandCount: 3,
+	dev: true,
+	legacy: { enabled: true, prefix: "!" },
+	registration: { guilds: ["guild-1"] },
+	registrationPlan: {
+		operations: [
+			{
+				commands: [
+					{ description: "Ping", name: "ping" },
+					{ description: "Role", name: "role" },
+					{ description: "Snipe", name: "snipe" },
+				],
+				guildId: "guild-1",
+				mode: "sync",
+				scope: "guild",
+			},
+		],
+	},
+	storage: {
+		configured: true,
+		features: { channelLocks: false, disabledCommands: false, guildPrefixes: true },
+	},
+	version: "3.0.1",
+} satisfies Parameters<typeof formatStartupLog>[0];
+
+describe("startup log formatting", () => {
+	test("formats a compact line for non-TTY output", () => {
+		const output = formatStartupLog(baseInput, true, { isTTY: false });
+
+		expect(output).toContain("[djs-commands] ready");
+		expect(output).toContain("version 3.0.1");
+		expect(output).toContain("bot TestBot#0001");
+		expect(output).toContain("commands 3 loaded");
+		expect(output).toContain("registration guild sync: 1");
+		expect(output).toContain('legacy enabled, prefix "!"');
+		expect(output).toContain("storage configured (guild prefixes)");
+	});
+
+	test("formats a boxed summary when requested", () => {
+		const output = formatStartupLog(baseInput, "box", { isTTY: false });
+
+		expect(output).toContain("╭─ DJS Commands");
+		expect(output).toContain("│ Version");
+		expect(output).toContain("3.0.1");
+		expect(output).toContain("╰");
+	});
+
+	test("returns null when disabled", () => {
+		expect(formatStartupLog(baseInput, false, { isTTY: false })).toBeNull();
+		expect(formatStartupLog(baseInput, { enabled: false }, { isTTY: false })).toBeNull();
+	});
+
+	test("summarizes disabled registration", () => {
+		const output = formatStartupLog({ ...baseInput, registration: false, registrationPlan: { operations: [] } }, "line", { isTTY: false });
+
+		expect(output).toContain("registration disabled");
+	});
+});

--- a/packages/core/src/startup-log.ts
+++ b/packages/core/src/startup-log.ts
@@ -1,0 +1,138 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import pico from "picocolors";
+import type { HandlerRegistrationConfig, RegistrationPlan } from "./registration";
+import type { StartupLogConfig, StorageFeaturesConfig } from "./types";
+
+interface StartupLogInput {
+	version?: string;
+	bot?: string;
+	commandCount: number;
+	registration: HandlerRegistrationConfig | undefined;
+	registrationPlan: RegistrationPlan;
+	legacy: {
+		enabled: boolean;
+		prefix: string;
+	};
+	storage: {
+		configured: boolean;
+		features: Required<StorageFeaturesConfig>;
+	};
+	cacheConfigured: boolean;
+	dev: boolean;
+}
+
+interface FormatOptions {
+	isTTY?: boolean;
+}
+
+interface ResolvedStartupLogConfig {
+	style: "box" | "line";
+	useColor: boolean;
+}
+
+const UNKNOWN_VERSION = "unknown";
+
+/** Reads the installed `@djs-commands/core` package version for startup diagnostics. */
+export function getCoreVersion(): string {
+	try {
+		const packageJsonPath = join(dirname(fileURLToPath(import.meta.url)), "../package.json");
+		const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { version?: unknown };
+		return typeof pkg.version === "string" ? pkg.version : UNKNOWN_VERSION;
+	} catch {
+		return UNKNOWN_VERSION;
+	}
+}
+
+/** Formats the startup banner printed by `createCommandHandler` after boot and registration complete. */
+export function formatStartupLog(input: StartupLogInput, config: StartupLogConfig | undefined, options: FormatOptions = {}): string | null {
+	const resolved = resolveStartupLogConfig(config, options);
+	if (!resolved) return null;
+
+	const rows: [string, string][] = [
+		["Version", input.version ?? UNKNOWN_VERSION],
+		["Bot", input.bot ?? "unknown"],
+		["Commands", `${input.commandCount} loaded`],
+		["Registration", formatRegistration(input.registration, input.registrationPlan)],
+		["Legacy", input.legacy.enabled ? `enabled, prefix "${input.legacy.prefix}"` : "disabled"],
+		["Storage", formatStorage(input.storage)],
+		["Cache", input.cacheConfigured ? "configured" : "memory"],
+		["Dev", input.dev ? "hot reload enabled" : "production mode"],
+	];
+
+	return resolved.style === "box" ? formatBox(rows, resolved.useColor) : formatLine(rows, resolved.useColor);
+}
+
+function resolveStartupLogConfig(config: StartupLogConfig | undefined, options: FormatOptions): ResolvedStartupLogConfig | null {
+	if (config === false) return null;
+	if (typeof config === "object" && config.enabled === false) return null;
+
+	const isTTY = options.isTTY ?? process.stdout.isTTY === true;
+	const style = typeof config === "string" ? config : typeof config === "object" ? config.style : undefined;
+
+	return {
+		style: style ?? (isTTY ? "box" : "line"),
+		useColor: isTTY,
+	};
+}
+
+function formatBox(rows: readonly [string, string][], useColor: boolean): string {
+	const title = "DJS Commands";
+	const labelWidth = Math.max(...rows.map(([label]) => label.length));
+	const valueWidth = Math.max(...rows.map(([, value]) => value.length));
+	const contentWidth = Math.max(title.length + 2, labelWidth + 2 + valueWidth);
+	const top = `╭─ ${title} ${"─".repeat(Math.max(0, contentWidth - title.length - 1))}╮`;
+	const bottom = `╰${"─".repeat(contentWidth + 2)}╯`;
+	const lines = rows.map(([label, value]) => {
+		const formattedLabel = useColor ? pico.bold(label.padEnd(labelWidth)) : label.padEnd(labelWidth);
+		return `│ ${formattedLabel}  ${value.padEnd(valueWidth)} │`;
+	});
+
+	if (!useColor) return [top, ...lines, bottom].join("\n");
+	return [pico.cyan(top), ...lines, pico.cyan(bottom)].join("\n");
+}
+
+function formatLine(rows: readonly [string, string][], useColor: boolean): string {
+	const prefix = useColor ? pico.cyan("[djs-commands] ready") : "[djs-commands] ready";
+	const fields = rows.map(([label, value]) => `${label.toLowerCase()} ${value}`);
+	return [prefix, ...fields].join(" | ");
+}
+
+function formatRegistration(registration: HandlerRegistrationConfig | undefined, plan: RegistrationPlan): string {
+	if (registration === false || registration?.enabled === false) return "disabled";
+	if (plan.operations.length === 0) return "ignored";
+
+	const parts: string[] = [];
+	const global = plan.operations.find((operation) => operation.scope === "global");
+	if (global) {
+		parts.push(`global ${global.mode}: ${global.commands.length}`);
+	}
+
+	const guildCounts = plan.operations
+		.filter((operation) => operation.scope === "guild")
+		.reduce(
+			(acc, operation) => {
+				acc[operation.mode] += 1;
+				return acc;
+			},
+			{ clear: 0, sync: 0 }
+		);
+
+	if (guildCounts.sync > 0) parts.push(`guild sync: ${guildCounts.sync}`);
+	if (guildCounts.clear > 0) parts.push(`guild clear: ${guildCounts.clear}`);
+
+	return parts.join(", ");
+}
+
+function formatStorage(storage: StartupLogInput["storage"]): string {
+	if (!storage.configured) return "not configured";
+
+	const features: string[] = [];
+	if (storage.features.guildPrefixes) features.push("guild prefixes");
+	if (storage.features.disabledCommands) features.push("disabled commands");
+	if (storage.features.channelLocks) features.push("channel locks");
+
+	if (features.length === 0) return "configured";
+	return `configured (${features.join(", ")})`;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,6 +121,20 @@ export interface StorageFeaturesConfig {
 	channelLocks?: boolean;
 }
 
+/** Startup console output style. `box` is best for local terminals; `line` is compact for logs and CI. */
+export type StartupLogStyle = "box" | "line";
+
+/** Startup console output configuration. Pass `false` to silence the DJS Commands boot banner. */
+export type StartupLogConfig =
+	| boolean
+	| StartupLogStyle
+	| {
+			/** Disable startup output without removing the option object. */
+			enabled?: boolean;
+			/** Force a specific output shape. Defaults to `box` in TTY terminals and `line` elsewhere. */
+			style?: StartupLogStyle;
+	  };
+
 /** Options passed to `createCommandHandler` to wire a discord.js client. */
 export interface CommandHandlerOptions {
 	/** Discord.js client instance. */
@@ -151,6 +165,8 @@ export interface CommandHandlerOptions {
 	storage?: Storage;
 	/** Opt into storage-backed framework features. */
 	storageFeatures?: StorageFeaturesConfig;
+	/** Prints a DJS Commands boot summary after the client is ready and command registration completes. Defaults to enabled. */
+	startupLog?: StartupLogConfig;
 }
 
 /** Handle returned by `createCommandHandler`. */

--- a/packages/create-djs-commands/src/scaffold.test.ts
+++ b/packages/create-djs-commands/src/scaffold.test.ts
@@ -132,6 +132,7 @@ test("legacy mode is reflected in src/index.ts and src/commands/ping.ts", async 
 	expect(index).toContain("legacy: { enabled: true");
 	expect(index).toContain("storageFeatures: { guildPrefixes: false }");
 	expect(index).toContain("GatewayIntentBits.MessageContent");
+	expect(index).not.toContain("clientReady");
 
 	const ping = await readFile(join(result.targetDir, "src/commands/ping.ts"), "utf8");
 	expect(ping).toContain("legacy:");

--- a/packages/create-djs-commands/src/templates.ts
+++ b/packages/create-djs-commands/src/templates.ts
@@ -149,10 +149,6 @@ handler.ready.catch((err) => {
 \tprocess.exit(1);
 });
 
-client.once("clientReady", (c) => {
-\tconsole.log(\`Logged in as \${c.user.tag}\`);
-});
-
 await client.login(token);
 `;
 }


### PR DESCRIPTION
## Summary

- Add a DJS Commands startup summary after `handler.ready`, Discord `clientReady`, and command registration complete.
- Support `startupLog: false`, `startupLog: "box"`, `startupLog: "line"`, and object config.
- Use `picocolors` with a small built-in box/line renderer.
- Include version, bot, command count, registration summary, legacy mode, storage, cache, and dev mode.
- Remove the redundant generated `Logged in as ...` scaffold log.
- Document the new option and add a minor changeset.

## Test Plan

- `bun run check`
- `bun run docs:check`
- `bun run typecheck`
- `bun run knip`
- `bun test packages/core/src/startup-log.test.ts packages/core/src/handler-registration.test.ts packages/create-djs-commands/src/scaffold.test.ts`
